### PR TITLE
OSAC 8 - fix for column names having spaces

### DIFF
--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -174,7 +174,7 @@ namespace UiPath.Database
             var columns = new StringBuilder();
             foreach (DataColumn column in table.Columns)
             {
-                columns.Append(column.ColumnName + ",");
+                columns.Append("[" + column.ColumnName + "],");
             }
             columns = columns.Remove(columns.Length - 1, 1);
 


### PR DESCRIPTION
Description
Database Insert Error with Table Name contains Space
How to test
- Connect to an existing SQL Server data source
- Excel Application Scope to read data from the excel and store the output to a data table
- Use Insert activity to add the data table directly to the database.
Jira
[OSAC-8](https://uipath.atlassian.net/browse/OSAC-8)
Label:
24S