### PR TITLE
OSAC-19 fix for large messages between Python and robot

### DIFF
--- a/Activities/Shared/UiPath.Shared.Service/Client/Proxy.cs
+++ b/Activities/Shared/UiPath.Shared.Service/Client/Proxy.cs
@@ -21,7 +21,7 @@ namespace UiPath.Shared.Service.Client
 
         internal Proxy(string endpoint, Binding binding = null)
         {
-            Initialize(endpoint, binding ?? new NetNamedPipeBinding(NetNamedPipeSecurityMode.None));
+            Initialize(endpoint, binding ?? new NetNamedPipeBinding(NetNamedPipeSecurityMode.None) { MaxReceivedMessageSize = 2147483647 });
         }
 
         protected virtual void Initialize(string endpoint, Binding binding)


### PR DESCRIPTION
Set MaxReceivedMessageSize to 2147483647 characters