### PR TITLE
Change AssemblyVersion SemVer values

### DIFF
--- a/Activities/Cryptography/CryptographyAssemblyInfo.cs
+++ b/Activities/Cryptography/CryptographyAssemblyInfo.cs
@@ -1,3 +1,7 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.1.*")]
+#if DEBUG
+[assembly: AssemblyVersion("1.2.*")]
+#else
+[assembly: AssemblyVersion("1.2.0")]
+#endif

--- a/Activities/Database/DatabaseAssemblyVersion.cs
+++ b/Activities/Database/DatabaseAssemblyVersion.cs
@@ -1,3 +1,7 @@
 ﻿using System.Reflection;
 
+#if DEBUG
 [assembly: AssemblyVersion("1.5.*")]
+#else
+[assembly: AssemblyVersion("1.5.0")]
+#endif

--- a/Activities/FTP/FTPAssemblyInfo.cs
+++ b/Activities/FTP/FTPAssemblyInfo.cs
@@ -14,5 +14,8 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://schemas.uipath.com/workflow/activities/ftp", "UiPath.FTP.Activities")]
 [assembly: XmlnsDefinition("http://schemas.uipath.com/workflow/activities/ftp", "UiPath.FTP.Activities.Design")]
 
+#if DEBUG
 [assembly: AssemblyVersion("2.2.*")]
-
+#else
+[assembly: AssemblyVersion("2.2.0")]
+#endif

--- a/Activities/GlobalAssemblyInfo.cs
+++ b/Activities/GlobalAssemblyInfo.cs
@@ -7,8 +7,7 @@ using System.Windows.Markup;
 
 [assembly: AssemblyCompany("UiPath")]
 [assembly: AssemblyProduct("UiPath")]
-[assembly: AssemblyCopyright("Copyright © UiPath")]
+[assembly: AssemblyCopyright("Copyright Â© UiPath")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: XmlnsPrefix("http://schemas.uipath.com/workflow/activities", "ui")]
-

--- a/Activities/GoogleSpreadsheet/GoogleSpreadsheetVersion.cs
+++ b/Activities/GoogleSpreadsheet/GoogleSpreadsheetVersion.cs
@@ -6,4 +6,9 @@ using System.Windows.Markup;
 [assembly: AssemblyCopyright("Copyright © 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("1.1.2.*")]
+
+#if DEBUG
+[assembly: AssemblyVersion("1.2.*")]
+#else
+[assembly: AssemblyVersion("1.2.0")]
+#endif

--- a/Activities/Java/JavaPackageVersion.cs
+++ b/Activities/Java/JavaPackageVersion.cs
@@ -4,5 +4,9 @@
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
+#if DEBUG
 [assembly: AssemblyVersion("1.3.*")]
+#else
+[assembly: AssemblyVersion("1.3.0")]
+#endif
 

--- a/Activities/Python/PythonPackageVersion.cs
+++ b/Activities/Python/PythonPackageVersion.cs
@@ -4,5 +4,8 @@
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
+#if DEBUG
 [assembly: AssemblyVersion("1.4.*")]
-
+#else
+[assembly: AssemblyVersion("1.4.0")]
+#endif


### PR DESCRIPTION
These changes are necessary in order to move forward to using the templated Activities pipelines. As the current assembly versions are ended in the `*` character, the build per se is adding the `.build` & `.revision` components instead of the needed `.patch` component. All these changes were made based on the `vars.yaml` file - where the explicit version is specified. 

e.g.
![image](https://user-images.githubusercontent.com/52775984/107223474-e8aac180-6a1e-11eb-8129-ddd44b27659a.png)
![image](https://user-images.githubusercontent.com/52775984/107223530-f52f1a00-6a1e-11eb-8c3d-a08a95d280f2.png)
↑ The result of the change for the Python project that's using the templated pipelines.