### PR TITLE
OSAC 104 - fix missing PackageReference

### DIFF
--- a/Activities/Credentials/UiPath.Credentials.Packages/UiPath.Credentials.Packages.csproj
+++ b/Activities/Credentials/UiPath.Credentials.Packages/UiPath.Credentials.Packages.csproj
@@ -33,11 +33,15 @@
 
     </ItemGroup>
   </Target>
-
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="CredentialManagement" Version="1.0.2" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">
     <PackageReference Include="System.Activities.Core.Presentation" />
+    <PackageReference Include="CredentialManagement" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="CredentialManagement" Version="1.0.2" />
     <ProjectReference Include="..\..\Credentials\UiPath.Credentials.Activities\UiPath.Credentials.Activities.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>


### PR DESCRIPTION
Small fix for a runtime error at Credentials Activity package (missing Nuget dependency).