### PR TITLE
OSAC 99 - Python change communication from WCF to System.IO.Pipes - Timeout argument not used

### DIFF
--- a/Activities/Activities.Python.sln
+++ b/Activities/Activities.Python.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.Python.Tests", "Pyth
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.Python.Packaging", "Python\UiPath.Python.Packaging\UiPath.Python.Packaging.csproj", "{949AC18E-A23D-4E0A-8217-E771F4AAE867}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared.Service", "Shared\UiPath.Shared.Service\UiPath.Shared.Service.shproj", "{A6A27646-4889-4F95-A0DF-DD78D287388F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Python\UiPath.Python.Host.Shared\UiPath.Python.Host.Shared.projitems*{0fbf5f7e-2ae4-4f4a-84cb-26b3a9e3119c}*SharedItemsImports = 5
@@ -26,6 +28,7 @@ Global
 		Python\UiPath.Python.Host.Shared\UiPath.Python.Host.Shared.projitems*{25ff4279-6ee6-441e-9d40-a40db81cb57c}*SharedItemsImports = 13
 		Shared\UiPath.Shared.Service\UiPath.Shared.Service.projitems*{a1783eab-5baf-49f1-8372-b467b57063cc}*SharedItemsImports = 5
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{a1783eab-5baf-49f1-8372-b467b57063cc}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Service\UiPath.Shared.Service.projitems*{a6a27646-4889-4f95-a0df-dd78d287388f}*SharedItemsImports = 13
 		Python\UiPath.Python.Host.Shared\UiPath.Python.Host.Shared.projitems*{bcba78df-1513-44d3-83b3-37655a7f3887}*SharedItemsImports = 5
 		Shared\UiPath.Shared.Service\UiPath.Shared.Service.projitems*{bcba78df-1513-44d3-83b3-37655a7f3887}*SharedItemsImports = 5
 		Shared\UiPath.Shared.Activities.Design\UiPath.Shared.Activities.Design.projitems*{e116c90e-c6a0-4292-b1ff-e0746ffe95d5}*SharedItemsImports = 5
@@ -64,34 +67,6 @@ Global
 		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A1783EAB-5BAF-49F1-8372-B467B57063CC}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{A1783EAB-5BAF-49F1-8372-B467B57063CC}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{A1783EAB-5BAF-49F1-8372-B467B57063CC}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{A1783EAB-5BAF-49F1-8372-B467B57063CC}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{E270608B-BA9E-4972-A18E-34B93E6552B4}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{E270608B-BA9E-4972-A18E-34B93E6552B4}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{E270608B-BA9E-4972-A18E-34B93E6552B4}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{E270608B-BA9E-4972-A18E-34B93E6552B4}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{E116C90E-C6A0-4292-B1FF-E0746FFE95D5}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{E116C90E-C6A0-4292-B1FF-E0746FFE95D5}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{E116C90E-C6A0-4292-B1FF-E0746FFE95D5}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{E116C90E-C6A0-4292-B1FF-E0746FFE95D5}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{0FBF5F7E-2AE4-4F4A-84CB-26B3A9E3119C}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{0FBF5F7E-2AE4-4F4A-84CB-26B3A9E3119C}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{0FBF5F7E-2AE4-4F4A-84CB-26B3A9E3119C}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{0FBF5F7E-2AE4-4F4A-84CB-26B3A9E3119C}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{BCBA78DF-1513-44D3-83B3-37655A7F3887}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{BCBA78DF-1513-44D3-83B3-37655A7F3887}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{BCBA78DF-1513-44D3-83B3-37655A7F3887}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{BCBA78DF-1513-44D3-83B3-37655A7F3887}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{9E913818-9270-4570-A8F4-80812EBFA09E}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{9E913818-9270-4570-A8F4-80812EBFA09E}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{9E913818-9270-4570-A8F4-80812EBFA09E}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{9E913818-9270-4570-A8F4-80812EBFA09E}.Release|AnyCPU.Build.0 = Release|AnyCPU
-		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Debug|AnyCPU.Build.0 = Debug|Any CPU
-		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Release|AnyCPU.ActiveCfg = Release|Any CPU
-		{949AC18E-A23D-4E0A-8217-E771F4AAE867}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Activities/Python/UiPath.Python.Activities/PythonScope.cs
+++ b/Activities/Python/UiPath.Python.Activities/PythonScope.cs
@@ -113,6 +113,10 @@ namespace UiPath.Python.Activities
             }
 
             var operationTimeout = OperationTimeout.Get(context);
+            if (operationTimeout == 0)
+            {
+                operationTimeout = 3600; //default to 1h for no values provided.
+            }
 
             try
             {
@@ -137,6 +141,7 @@ namespace UiPath.Python.Activities
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+
             return ctx =>
             {
                 ctx.ScheduleAction(Body, _pythonEngine, OnCompleted, OnFaulted);

--- a/Activities/Python/UiPath.Python/Properties/UiPath.Python.Designer.cs
+++ b/Activities/Python/UiPath.Python/Properties/UiPath.Python.Designer.cs
@@ -115,6 +115,15 @@ namespace UiPath.Python.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Python timeout elapsed.
+        /// </summary>
+        public static string TimeoutException {
+            get {
+                return ResourceManager.GetString("TimeoutException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python version {0} is not supported. Supported versions are: {1}.
         /// </summary>
         public static string UnsupportedVersionException {

--- a/Activities/Python/UiPath.Python/Properties/UiPath.Python.resx
+++ b/Activities/Python/UiPath.Python/Properties/UiPath.Python.resx
@@ -135,6 +135,9 @@
   <data name="SerializationException" xml:space="preserve">
     <value>Python serialization exception</value>
   </data>
+  <data name="TimeoutException" xml:space="preserve">
+    <value>Python timeout elapsed</value>
+  </data>
   <data name="UnsupportedVersionException" xml:space="preserve">
     <value>Python version {0} is not supported. Supported versions are: {1}</value>
   </data>

--- a/Activities/Python/UiPath.Python/Service/PythonProxy.cs
+++ b/Activities/Python/UiPath.Python/Service/PythonProxy.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Text;
 using System.Threading;
+using UiPath.Python.Properties;
 using UiPath.Shared.Service;
 
 namespace UiPath.Python.Service
@@ -34,90 +35,168 @@ namespace UiPath.Python.Service
 
         public Argument Convert(Guid obj, string t)
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.Convert,
-                Instance = obj,
-                Type = t
-            };
+                try
+                {
+                    var request = new PythonRequest()
+                    {
+                        RequestType = RequestType.Convert,
+                        Instance = obj,
+                        Type = t
+                    };
 
-            PythonResponse response = RequestAsync(request, Token);
-            Token.ThrowIfCancellationRequested();
-            response.ThrowExceptionIfNeeded();
-            return response.Argument;
+                    PythonResponse response = RequestAsync(request, cts.Token);
+                    cts.Token.ThrowIfCancellationRequested();
+                    response.ThrowExceptionIfNeeded();
+                    return response.Argument;
+                }
+                catch (Exception e)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(UiPath_Python.TimeoutException);
+                    }
+                    Trace.TraceError($"Python exception: {e}");
+                    throw;
+                }
+            }
         }
 
         public void Execute(string code)
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.Execute,
-                Code = code
-            };
+                try
+                {
+                    var request = new PythonRequest()
+                    {
+                        RequestType = RequestType.Execute,
+                        Code = code
+                    };
 
-            PythonResponse response = RequestAsync(request, Token);
-            Token.ThrowIfCancellationRequested();
-            response.ThrowExceptionIfNeeded();
+                    PythonResponse response = RequestAsync(request, cts.Token);
+                    cts.Token.ThrowIfCancellationRequested();
+                    response.ThrowExceptionIfNeeded();
+                }
+                catch (Exception e)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(UiPath_Python.TimeoutException);
+                    }
+                    Trace.TraceError($"Python exception: {e}");
+                    throw;
+                }
+            }
         }
 
         public void Initialize(string path, Version version, string workingFolder)
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.Initialize,
-                ScriptPath = path,
-                PythonVersion = version.ToString(),
-                WorkingFolder = workingFolder
-            };
+                try
+                {
+                    var request = new PythonRequest()
+                    {
+                        RequestType = RequestType.Initialize,
+                        ScriptPath = path,
+                        PythonVersion = version.ToString(),
+                        WorkingFolder = workingFolder
+                    };
 
-            PythonResponse response = RequestAsync(request, Token);
-            Token.ThrowIfCancellationRequested();
-            response.ThrowExceptionIfNeeded();
+                    PythonResponse response = RequestAsync(request, Token);
+                    Token.ThrowIfCancellationRequested();
+                    response.ThrowExceptionIfNeeded();
+                }
+                catch (Exception e)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(UiPath_Python.TimeoutException);
+                    }
+                    Trace.TraceError($"Python exception: {e}");
+                    throw;
+                }
+            }
         }
 
         public Guid InvokeMethod(Guid instance, string method, IEnumerable<Argument> args)
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.InvokeMethod,
-                Instance = instance,
-                Method = method,
-                Arguments = args
-            };
+                try
+                {
+                    var request = new PythonRequest()
+                    {
+                        RequestType = RequestType.InvokeMethod,
+                        Instance = instance,
+                        Method = method,
+                        Arguments = args
+                    };
 
-            PythonResponse response = RequestAsync(request, Token);
-            Token.ThrowIfCancellationRequested();
-            response.ThrowExceptionIfNeeded();
-            return response.Guid;
+                    PythonResponse response = RequestAsync(request, cts.Token);
+                    cts.Token.ThrowIfCancellationRequested();
+                    response.ThrowExceptionIfNeeded();
+                    return response.Guid;
+                }
+                catch (Exception e)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(UiPath_Python.TimeoutException);
+                    }
+                    Trace.TraceError($"Python exception: {e}");
+                    throw;
+                }
+            }
         }
 
         public Guid LoadScript(string code)
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.LoadScript,
-                Code = code
-            };
+                try
+                {
+                    var request = new PythonRequest()
+                    {
+                        RequestType = RequestType.LoadScript,
+                        Code = code
+                    };
 
-            PythonResponse response = RequestAsync(request, Token);
+                    PythonResponse response = RequestAsync(request, cts.Token);
 
-            Token.ThrowIfCancellationRequested();
+                    cts.Token.ThrowIfCancellationRequested();
 
-            Trace.TraceInformation("LoadScript Guid:: " + response.Guid);
+                    Trace.TraceInformation("LoadScript Guid:: " + response.Guid);
 
-            return response.Guid;
+                    return response.Guid;
+                }
+                catch (Exception e)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(UiPath_Python.TimeoutException);
+                    }
+                    Trace.TraceError($"Python exception: {e}");
+                    throw;
+                }
+            }
         }
 
         public void Shutdown()
         {
-            var request = new PythonRequest()
+            using (var cts = new CancellationTokenSource((int)Timeout * 1000))
             {
-                RequestType = RequestType.Shutdown
-            };
+                var request = new PythonRequest()
+                {
+                    RequestType = RequestType.Shutdown
+                };
 
-            PythonResponse response = RequestAsync(request, Token);
+                PythonResponse response = RequestAsync(request, cts.Token);
 
-            Token.ThrowIfCancellationRequested();
+                cts.Token.ThrowIfCancellationRequested();
+            }
         }
 
         #endregion Service methods


### PR DESCRIPTION
Description
Python change communication from WCF to System.IO.Pipes - Timeout argument not used
How to test
Configure TimeoutMS argument at PythonScope
Jira
[OSAC-99](https://uipath.atlassian.net/browse/OSAC-99)
Label:
24S