### PR TITLE
OSAC 91 and OSAC 135 - Pretty Label for Python versions

### DIFF
--- a/Activities/Python/UiPath.Python.Activities/PythonScope.cs
+++ b/Activities/Python/UiPath.Python.Activities/PythonScope.cs
@@ -19,6 +19,7 @@ namespace UiPath.Python.Activities
         [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.VersionNameDisplayName))]
         [LocalizedDescription(nameof(Resources.VersionDescription))]
+        [TypeConverter(typeof(EnumTypeConverter))]
         [DefaultValue(Version.Auto)]
         public Version Version { get; set; }
 

--- a/Activities/Python/UiPath.Python.Activities/PythonScope.cs
+++ b/Activities/Python/UiPath.Python.Activities/PythonScope.cs
@@ -136,7 +136,7 @@ namespace UiPath.Python.Activities
                     Version autodetected = Version.Auto;
                     EngineProvider.Autodetect(path, out autodetected);
                     if (autodetected != Version.Auto && autodetected != Version)
-                        throw new InvalidOperationException(string.Format(Resources.InvalidVersionException, Version.ToString(), autodetected.ToString()));
+                        throw new InvalidOperationException(string.Format(Resources.InvalidVersionException, Version.ToFriendlyString(), autodetected.ToFriendlyString()));
                 }
                 throw new InvalidOperationException(Resources.PythonInitializeException, e);
             }

--- a/Activities/Python/UiPath.Python/Version.cs
+++ b/Activities/Python/UiPath.Python/Version.cs
@@ -69,7 +69,7 @@ namespace UiPath.Python
     /// <summary>
     /// Helper class for Python version operations
     /// </summary>
-    internal static class VersionExtensions
+    public static class VersionExtensions
     {
         internal static string GetAssemblyName(this Version version)
         {
@@ -117,6 +117,14 @@ namespace UiPath.Python
                     return version;
             }
             return Version.Auto;
+        }
+
+        public static string ToFriendlyString(this Version version)
+        {
+            FieldInfo fi = version.GetType().GetField(version.ToString());
+            DescriptionAttribute[] attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+
+            return (attributes.Length > 0) ? attributes[0].Description : version.ToString();
         }
     }
 

--- a/Activities/Python/UiPath.Python/Version.cs
+++ b/Activities/Python/UiPath.Python/Version.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -24,6 +26,7 @@ namespace UiPath.Python
         }
     }
 
+    [TypeConverter(typeof(EnumTypeConverter))]
     public enum Version
     {
         //Unknown = -1,
@@ -31,27 +34,35 @@ namespace UiPath.Python
         Auto,
 
         [Version(2, 7, "Python.Runtime.27.dll")]
+        [Description("Python 2.7")]
         Python_27,
 
         [Version(3, 3, "Python.Runtime.33.dll")]
+        [Description("Python 3.3")]
         Python_33,
 
         [Version(3, 4, "Python.Runtime.34.dll")]
+        [Description("Python 3.4")]
         Python_34,
 
         [Version(3, 5, "Python.Runtime.35.dll")]
+        [Description("Python 3.5")]
         Python_35,
 
         [Version(3, 6, "Python.Runtime.36.dll")]
+        [Description("Python 3.6")]
         Python_36,
 
         [Version(3, 7, "Python.Runtime.37.dll")]
+        [Description("Python 3.7")]
         Python_37,
 
         [Version(3, 8, "Python.Runtime.38.dll")]
+        [Description("Python 3.8")]
         Python_38,
 
         [Version(3, 9, "Python.Runtime.39.dll")]
+        [Description("Python 3.9")]
         Python_39,
     }
 
@@ -81,10 +92,10 @@ namespace UiPath.Python
                     throw new ArgumentException(string.Format(Resources.UnsupportedVersionException, nrVer[0].Value, string.Join(", ", Enum.GetNames(typeof(Version)).Where(x => x != Version.Auto.ToString()))));
                 return version;
             }
-            else 
+            else
                 return Version.Auto;
-
         }
+
         internal static Version Get(this System.Version version)
         {
             return GetPythonVersion(version.Major, version.Minor);
@@ -106,6 +117,56 @@ namespace UiPath.Python
                     return version;
             }
             return Version.Auto;
+        }
+    }
+
+    public class EnumTypeConverter : EnumConverter
+    {
+        private Type enumType;
+
+        public EnumTypeConverter() : base(typeof(Version))
+        {
+            enumType = typeof(Version);
+        }
+
+        public EnumTypeConverter(Type type) : base(type)
+        {
+            enumType = type;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destType)
+        {
+            return destType == typeof(string);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture,
+                                         object value, Type destType)
+        {
+            FieldInfo fi = enumType.GetField(Enum.GetName(enumType, value));
+            DescriptionAttribute dna = (DescriptionAttribute)Attribute.GetCustomAttribute(fi,
+                                        typeof(DescriptionAttribute));
+            if (dna != null)
+                return dna.Description;
+            else
+                return value.ToString();
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type srcType)
+        {
+            return srcType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture,
+                                           object value)
+        {
+            foreach (FieldInfo fi in enumType.GetFields())
+            {
+                DescriptionAttribute dna = (DescriptionAttribute)Attribute.GetCustomAttribute(fi,
+                                            typeof(DescriptionAttribute));
+                if ((dna != null) && ((string)value == dna.Description))
+                    return Enum.Parse(enumType, fi.Name);
+            }
+            return Enum.Parse(enumType, (string)value);
         }
     }
 }


### PR DESCRIPTION
Description
Pretty labels for Python versions in Python Scope
Replace Python version label in error messages
How to test
Open Studio and use Python scope version drop down.
Jira
[OSAC-91](https://uipath.atlassian.net/browse/OSAC-91)
[OSAC-135](https://uipath.atlassian.net/browse/OSAC-135)
Label:
24S