### PR TITLE
OSAC-298 - [SW][Database] Secure Connection String should be moved in the upper part of the connect activity card

### DIFF
--- a/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/DatabaseConnectViewModel.cs
+++ b/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/DatabaseConnectViewModel.cs
@@ -61,11 +61,13 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
             ProviderName.OrderIndex = propertyOrderIndex++;
             ProviderName.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
+            ConnectionSecureString.IsPrincipal = true;
+            ConnectionSecureString.OrderIndex = propertyOrderIndex++;
+            ConnectionSecureString.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
+
             DatabaseConnection.OrderIndex = propertyOrderIndex++;
             DatabaseConnection.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
-            ConnectionSecureString.OrderIndex = propertyOrderIndex++;
-            ConnectionSecureString.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
         }
 
         protected override async ValueTask InitializeModelAsync()


### PR DESCRIPTION
Description
[SW][Database] Secure Connection String should be moved in the upper part of the connect activity card
How to test
Open Activity package in Studio Web
Jira
OSAC-298
Label:
24S