### PR TITLE
OSAC-410, OSAC-411, OSAC-407, OSAC-409 - Update descriptions of Hash …

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
@@ -193,7 +193,8 @@ namespace UiPath.Cryptography.Activities.Tests
             EncryptText symmetricAlgorithm = new EncryptText
             {
                 Algorithm = enumValue,
-                Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode))
+                Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                KeyInputModeSwitch = KeyInputMode.SecureKey
             };
             Dictionary<string, object> arguments = new Dictionary<string, object>();
             arguments.Add(nameof(EncryptText.Input), toProcess);
@@ -224,7 +225,8 @@ namespace UiPath.Cryptography.Activities.Tests
             DecryptText symmetricAlgorithm = new DecryptText
             {
                 Algorithm = enumValue,
-                Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode))
+                Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                KeyInputModeSwitch = KeyInputMode.SecureKey
             };
 
             Dictionary<string, object> arguments = new Dictionary<string, object>();

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptFile.cs
@@ -26,6 +26,8 @@ namespace UiPath.Cryptography.Activities
         [LocalizedDescription(nameof(Resources.Activity_DecryptFile_Property_Algorithm_Description))]
         public SymmetricAlgorithms Algorithm { get; set; }
 
+        [RequiredArgument]
+        [OverloadGroup(nameof(InputFilePath))]
         [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_DecryptFile_Property_InputFilePath_Name))]
         [LocalizedDescription(nameof(Resources.Activity_DecryptFile_Property_InputFilePath_Description))]
@@ -76,6 +78,8 @@ namespace UiPath.Cryptography.Activities
         public InArgument<bool> ContinueOnError { get; set; }
 
         [Browsable(false)]
+        [RequiredArgument]
+        [OverloadGroup(nameof(InputFile))]
         [DefaultValue(null)]
         [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_DecryptFile_Property_InputFile_Name))]
@@ -104,6 +108,17 @@ namespace UiPath.Cryptography.Activities
                 var error = new ValidationError(Resources.FipsComplianceWarning, true, nameof(Algorithm));
                 metadata.AddValidationError(error);
             }
+
+            if (Key == null && KeyInputModeSwitch == KeyInputMode.Key)
+            {
+                var error = new ValidationError(Resources.KeyNullError, false, nameof(Key));
+                metadata.AddValidationError(error);
+            }
+            if (KeySecureString == null && KeyInputModeSwitch == KeyInputMode.SecureKey)
+            {
+                var error = new ValidationError(Resources.KeySecureStringNullError, false, nameof(KeySecureString));
+                metadata.AddValidationError(error);
+            }
         }
 
         protected override void Execute(CodeActivityContext context)
@@ -118,22 +133,14 @@ namespace UiPath.Cryptography.Activities
                 var keySecureString = KeySecureString.Get(context);
                 var keyEncoding = KeyEncoding.Get(context);
 
-                if (string.IsNullOrWhiteSpace(inputFilePath) && inputFile == null)
-                    throw new ArgumentNullException(Resources.InputFilePathDisplayName);
-
-                if (string.IsNullOrWhiteSpace(outputFilePath) && inputFile == null)
-                    throw new ArgumentNullException(Resources.OutputFilePathDisplayName);
-
-                //either input file path or input file as resource should be used
-                if (!string.IsNullOrWhiteSpace(inputFilePath) && inputFile != null)
-                    throw new ArgumentException(string.Format(Resources.Exception_UseOnlyFilePathOrInputResource,
-                        Resources.Activity_EncryptFile_Property_InputFile_Name, Resources.Activity_EncryptFile_Property_InputFilePath_Name));
-
-                if (string.IsNullOrWhiteSpace(key) && keySecureString == null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNull);
-
-                if (key != null && keySecureString != null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNotNull);
+                if (string.IsNullOrWhiteSpace(key) && KeyInputModeSwitch == KeyInputMode.Key)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_Key_Name);
+                }
+                if ((keySecureString == null || keySecureString?.Length == 0) && KeyInputModeSwitch == KeyInputMode.SecureKey)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_KeySecureString_Name);
+                }
 
                 if (keyEncoding == null)
                     throw new ArgumentNullException(Resources.Encoding);

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
@@ -82,6 +82,17 @@ namespace UiPath.Cryptography.Activities
                 default:
                     break;
             }
+
+            if (Key == null && KeyInputModeSwitch == KeyInputMode.Key)
+            {
+                var error = new ValidationError(Resources.KeyNullError, false, nameof(Key));
+                metadata.AddValidationError(error);
+            }
+            if (KeySecureString == null && KeyInputModeSwitch == KeyInputMode.SecureKey)
+            {
+                var error = new ValidationError(Resources.KeySecureStringNullError, false, nameof(KeySecureString));
+                metadata.AddValidationError(error);
+            }
         }
 
         protected override string Execute(CodeActivityContext context)
@@ -98,11 +109,14 @@ namespace UiPath.Cryptography.Activities
                 if (string.IsNullOrWhiteSpace(input))
                     throw new ArgumentNullException(Resources.InputStringDisplayName);
 
-                if (string.IsNullOrWhiteSpace(key) && keySecureString == null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNull);
-
-                if (key != null && keySecureString != null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNotNull);
+                if (string.IsNullOrWhiteSpace(key) && KeyInputModeSwitch == KeyInputMode.Key)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_Key_Name);
+                }
+                if ((keySecureString == null || keySecureString?.Length == 0) && KeyInputModeSwitch == KeyInputMode.SecureKey)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_KeySecureString_Name);
+                }
 
                 if (keyEncoding == null)
                     throw new ArgumentNullException(Resources.Encoding);

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -81,6 +81,17 @@ namespace UiPath.Cryptography.Activities
                 default:
                     break;
             }
+
+            if (Key == null && KeyInputModeSwitch == KeyInputMode.Key)
+            {
+                var error = new ValidationError(Resources.KeyNullError, false, nameof(Key));
+                metadata.AddValidationError(error);
+            }
+            if (KeySecureString == null && KeyInputModeSwitch == KeyInputMode.SecureKey)
+            {
+                var error = new ValidationError(Resources.KeySecureStringNullError, false, nameof(KeySecureString));
+                metadata.AddValidationError(error);
+            }
         }
 
         protected override string Execute(CodeActivityContext context)
@@ -97,11 +108,14 @@ namespace UiPath.Cryptography.Activities
                 if (string.IsNullOrWhiteSpace(input))
                     throw new ArgumentNullException(Resources.InputStringDisplayName);
 
-                if (string.IsNullOrWhiteSpace(key) && keySecureString == null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNull);
-
-                if (key != null && keySecureString != null)
-                    throw new ArgumentNullException(Resources.KeyAndSecureStringNotNull);
+                if (string.IsNullOrWhiteSpace(key) && KeyInputModeSwitch == KeyInputMode.Key)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_Key_Name);
+                }
+                if ((keySecureString == null || keySecureString?.Length == 0) && KeyInputModeSwitch == KeyInputMode.SecureKey)
+                {
+                    throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_KeySecureString_Name);
+                }
 
                 if (keyEncoding == null)
                     throw new ArgumentNullException(Resources.Encoding);

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/HashFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/HashFile.cs
@@ -84,4 +84,12 @@ namespace UiPath.Cryptography.Activities
         }
     }
 #endif
+#if NET
+    [Browsable(false)]
+    [LocalizedDisplayName(nameof(Resources.Activity_HashFile_Name))]
+    [LocalizedDescription(nameof(Resources.Activity_HashFile_Description))]
+    public partial class HashFile : KeyedHashFile
+    {
+    }
+#endif
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/HashText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/HashText.cs
@@ -99,4 +99,12 @@ namespace UiPath.Cryptography.Activities
         }
     }
 #endif
+#if NET
+    [Browsable(false)]
+    [LocalizedDisplayName(nameof(Resources.Activity_HashText_Name))]
+    [LocalizedDescription(nameof(Resources.Activity_HashText_Description))]
+    public partial class HashText : KeyedHashText
+    {
+    }
+#endif
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/KeyedHashFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/KeyedHashFile.cs
@@ -25,6 +25,8 @@ namespace UiPath.Cryptography.Activities
         [LocalizedDescription(nameof(Resources.Activity_KeyedHashFile_Property_Algorithm_Description))]
         public KeyedHashAlgorithms Algorithm { get; set; }
 
+        [RequiredArgument]
+        [OverloadGroup(nameof(FilePath))]
         [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_KeyedHashFile_Property_FilePath_Name))]
         [LocalizedDescription(nameof(Resources.Activity_KeyedHashFile_Property_FilePath_Description))]
@@ -64,6 +66,8 @@ namespace UiPath.Cryptography.Activities
         public InArgument<bool> ContinueOnError { get; set; }
 
         [Browsable(false)]
+        [RequiredArgument]
+        [OverloadGroup(nameof(InputFile))]
         [DefaultValue(null)]
         [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_KeyedHashFile_Property_InputFile_Name))]
@@ -94,7 +98,6 @@ namespace UiPath.Cryptography.Activities
                 }
                 if (KeySecureString == null && KeyInputModeSwitch == KeyInputMode.SecureKey)
                 {
-                    // the validation error is added for having the both fields validated  
                     var error = new ValidationError(Resources.KeySecureStringNullError, false, nameof(KeySecureString));
                     metadata.AddValidationError(error);
                 }
@@ -120,9 +123,6 @@ namespace UiPath.Cryptography.Activities
                 var keyEncoding = Encoding.Get(context);
                 var inputFile = InputFile.Get(context);
 
-                if (string.IsNullOrWhiteSpace(filePath) && inputFile == null)
-                    throw new ArgumentNullException(Resources.FilePathDisplayName);
-
                 if (Algorithm.ToString().StartsWith(nameof(HMAC)))
                 {
                     if (string.IsNullOrWhiteSpace(key) && KeyInputModeSwitch == KeyInputMode.Key)
@@ -134,11 +134,6 @@ namespace UiPath.Cryptography.Activities
                         throw new ArgumentNullException(Resources.Activity_KeyedHashText_Property_KeySecureString_Name);
                     }
                 }
-
-                //either input file path or input file as resource should be used
-                if (!string.IsNullOrWhiteSpace(filePath) && inputFile != null)
-                    throw new ArgumentException(string.Format(Resources.Exception_UseOnlyFilePathOrInputResource,
-                        Resources.Activity_KeyedHashFile_Property_InputFile_Name, Resources.Activity_KeyedHashFile_Property_FilePath_Name));
 
                 if (keyEncoding == null)
                     throw new ArgumentNullException(Resources.Encoding);

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/KeyedHashText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/KeyedHashText.cs
@@ -86,7 +86,6 @@ namespace UiPath.Cryptography.Activities
                 }
                 if (KeySecureString == null && KeyInputModeSwitch == KeyInputMode.SecureKey)
                 {
-                    // the validation error is added for having the both fields validated  
                     var error = new ValidationError(Resources.KeySecureStringNullError, false, nameof(KeySecureString));
                     metadata.AddValidationError(error);
                 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptFileViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptFileViewModel.cs
@@ -66,6 +66,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         public DesignInArgument<IResource> InputFile { get; set; } = new DesignInArgument<IResource>();
 
         /// <summary>
+        /// The path to the file that you want to decrypt.
+        /// </summary>
+        public DesignInArgument<string> InputFilePath { get; set; } = new DesignInArgument<string>();
+
+        /// <summary>
         /// The file that you want to decrypt.
         /// </summary>
         public DesignOutArgument<ILocalResource> DecryptedFile { get; set; } = new DesignOutArgument<ILocalResource>();
@@ -81,8 +86,10 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             var propertyOrderIndex = 1;
 
             InputFile.IsPrincipal = true;
-            InputFile.IsRequired = true;
             InputFile.OrderIndex = propertyOrderIndex++;
+
+            InputFilePath.IsPrincipal = true;
+            InputFilePath.OrderIndex = propertyOrderIndex++;
 
             Algorithm.IsPrincipal = true;
             Algorithm.OrderIndex = propertyOrderIndex++;
@@ -142,12 +149,16 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             switch (KeyInputModeSwitch.Value)
             {
                 case KeyInputMode.Key:
+                    Key.IsRequired = true;
                     Key.IsVisible = true;
                     KeySecureString.IsVisible = false;
+                    KeySecureString.IsRequired = false;
                     break;
                 case KeyInputMode.SecureKey:
+                    Key.IsRequired = false;
                     Key.IsVisible = false;
                     KeySecureString.IsVisible = true;
+                    KeySecureString.IsRequired = true;
                     break;
                 default:
                     throw new NotImplementedException();

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptTextViewModel.cs
@@ -123,12 +123,16 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             switch (KeyInputModeSwitch.Value)
             {
                 case KeyInputMode.Key:
+                    Key.IsRequired = true;
                     Key.IsVisible = true;
                     KeySecureString.IsVisible = false;
+                    KeySecureString.IsRequired = false;
                     break;
                 case KeyInputMode.SecureKey:
+                    Key.IsRequired = false;
                     Key.IsVisible = false;
                     KeySecureString.IsVisible = true;
+                    KeySecureString.IsRequired = true;
                     break;
                 default:
                     throw new NotImplementedException();

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptFileViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptFileViewModel.cs
@@ -66,6 +66,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         public DesignInArgument<IResource> InputFile { get; set; } = new DesignInArgument<IResource>();
 
         /// <summary>
+        /// The path to the file that you want to encrypt.
+        /// </summary>
+        public DesignInArgument<string> InputFilePath { get; set; } = new DesignInArgument<string>();
+
+        /// <summary>
         /// The file that you want to encrypt.
         /// </summary>
         public DesignOutArgument<ILocalResource> EncryptedFile { get; set; } = new DesignOutArgument<ILocalResource>();
@@ -81,8 +86,10 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             var propertyOrderIndex = 1;
 
             InputFile.IsPrincipal = true;
-            InputFile.IsRequired = true;
             InputFile.OrderIndex = propertyOrderIndex++;
+
+            InputFilePath.IsPrincipal = true;
+            InputFilePath.OrderIndex = propertyOrderIndex++;
 
             Algorithm.IsPrincipal = true;
             Algorithm.OrderIndex = propertyOrderIndex++;
@@ -146,17 +153,17 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             switch (KeyInputModeSwitch.Value)
             {
                 case KeyInputMode.Key:
+                    Key.IsRequired = true;
                     Key.IsVisible = true;
                     KeySecureString.IsVisible = false;
-
+                    KeySecureString.IsRequired = false;
                     break;
-
                 case KeyInputMode.SecureKey:
+                    Key.IsRequired = false;
                     Key.IsVisible = false;
                     KeySecureString.IsVisible = true;
-
+                    KeySecureString.IsRequired = true;
                     break;
-
                 default:
                     throw new NotImplementedException();
             }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
@@ -123,12 +123,16 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             switch (KeyInputModeSwitch.Value)
             {
                 case KeyInputMode.Key:
+                    Key.IsRequired = true;
                     Key.IsVisible = true;
                     KeySecureString.IsVisible = false;
+                    KeySecureString.IsRequired = false;
                     break;
                 case KeyInputMode.SecureKey:
+                    Key.IsRequired = false;
                     Key.IsVisible = false;
                     KeySecureString.IsVisible = true;
+                    KeySecureString.IsRequired = true;
                     break;
                 default:
                     throw new NotImplementedException();

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/KeyedHashFileViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/KeyedHashFileViewModel.cs
@@ -19,6 +19,15 @@ namespace UiPath.Cryptography.Activities
     public partial class KeyedHashFile
     {
     }
+
+    /// <summary>
+    /// Hashes a file with a key using a specified algorithm and encoding format 
+    /// and returns the hexadecimal string representation of the resulting hash.
+    /// </summary>
+    [ViewModelClass(typeof(KeyedHashFileViewModel))]
+    public partial class HashFile
+    {
+    }
 }
 
 namespace UiPath.Cryptography.Activities.NetCore.ViewModels
@@ -34,10 +43,14 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         /// <summary>
-        /// The file that you want to encrypt.
+        /// The file that you want to hash.
         /// </summary>
         public DesignInArgument<IResource> InputFile { get; set; } = new DesignInArgument<IResource>();
 
+        /// <summary>
+        /// The path to the file you want to hash.
+        /// </summary>
+        public DesignInArgument<string> FilePath { get; set; } = new DesignInArgument<string>();
 
         /// <summary>
         /// A drop-down which enables you to select the keyed hashing algorithm you want to use.
@@ -80,8 +93,10 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             Algorithm.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
 
             InputFile.IsPrincipal = true;
-            InputFile.IsRequired = true;
             InputFile.OrderIndex = propertyOrderIndex++;
+
+            FilePath.IsPrincipal = true;
+            FilePath.OrderIndex = propertyOrderIndex++;
 
             Key.IsPrincipal = true;
             Key.IsVisible = true;
@@ -102,9 +117,9 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ContinueOnError.Value = false;
 
             MenuActionsBuilder<KeyInputMode>.WithValueProperty(KeyInputModeSwitch)
-    .AddMenuProperty(Key, KeyInputMode.Key)
-    .AddMenuProperty(KeySecureString, KeyInputMode.SecureKey)
-    .BuildAndInsertMenuActions();
+                .AddMenuProperty(Key, KeyInputMode.Key)
+                .AddMenuProperty(KeySecureString, KeyInputMode.SecureKey)
+                .BuildAndInsertMenuActions();
         }
         /// <inheritdoc/>
         protected override void InitializeRules()

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/KeyedHashTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/KeyedHashTextViewModel.cs
@@ -18,6 +18,15 @@ namespace UiPath.Cryptography.Activities
     public partial class KeyedHashText
     {
     }
+
+    /// <summary>
+    /// Hashes a string with a key using a specified algorithm and returns 
+    /// the hexadecimal string representation of the resulting hash.
+    /// </summary>
+    [ViewModelClass(typeof(KeyedHashTextViewModel))]
+    public partial class HashText
+    {
+    }
 }
 
 namespace UiPath.Cryptography.Activities.NetCore.ViewModels
@@ -100,9 +109,9 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ContinueOnError.Value = false;
 
             MenuActionsBuilder<KeyInputMode>.WithValueProperty(KeyInputModeSwitch)
-   .AddMenuProperty(Key, KeyInputMode.Key)
-   .AddMenuProperty(KeySecureString, KeyInputMode.SecureKey)
-   .BuildAndInsertMenuActions();
+               .AddMenuProperty(Key, KeyInputMode.Key)
+               .AddMenuProperty(KeySecureString, KeyInputMode.SecureKey)
+               .BuildAndInsertMenuActions();
         }
         /// <inheritdoc/>
         protected override void InitializeRules()

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
@@ -853,7 +853,7 @@ namespace UiPath.Cryptography.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applies the selected hashing algorithm on the contents of the provided file and returns the hexadecimal string representation of the resulting hash..
+        ///   Looks up a localized string similar to This activity is now deprecated. SHA1, SHA256, SHA384, and SHA512 were moved to a single activity Hash File..
         /// </summary>
         public static string Activity_HashFile_Description {
             get {
@@ -943,7 +943,7 @@ namespace UiPath.Cryptography.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hashes a string using a specified algorithm and returns the hexadecimal string representation of the resulting hash..
+        ///   Looks up a localized string similar to This activity is now deprecated. SHA1, SHA256, SHA384, and SHA512 were moved to a single activity Hash Text..
         /// </summary>
         public static string Activity_HashText_Description {
             get {
@@ -1051,7 +1051,7 @@ namespace UiPath.Cryptography.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hashes a file with a key using a specified algorithm and encoding format and returns the hexadecimal string representation of the resulting hash..
+        ///   Looks up a localized string similar to Hashes a file with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key..
         /// </summary>
         public static string Activity_KeyedHashFile_Description {
             get {
@@ -1249,7 +1249,7 @@ namespace UiPath.Cryptography.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash..
+        ///   Looks up a localized string similar to Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key..
         /// </summary>
         public static string Activity_KeyedHashText_Description {
             get {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -446,7 +446,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_KeyedHashFile_Description" xml:space="preserve">
-    <value>Hashes a file with a key using a specified algorithm and encoding format and returns the hexadecimal string representation of the resulting hash.</value>
+    <value>Hashes a file with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key.</value>
     <comment>Activity description</comment>
   </data>
   <data name="Activity_KeyedHashFile_Name" xml:space="preserve">
@@ -510,7 +510,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_KeyedHashText_Description" xml:space="preserve">
-    <value>Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash.</value>
+    <value>Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key.</value>
     <comment>Activity description</comment>
   </data>
   <data name="Activity_KeyedHashText_Name" xml:space="preserve">
@@ -574,7 +574,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_HashFile_Description" xml:space="preserve">
-    <value>Applies the selected hashing algorithm on the contents of the provided file and returns the hexadecimal string representation of the resulting hash.</value>
+    <value>This activity is now deprecated. SHA1, SHA256, SHA384, and SHA512 were moved to a single activity Hash File.</value>
     <comment>Activity description</comment>
   </data>
   <data name="Activity_HashFile_Name" xml:space="preserve">
@@ -614,7 +614,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_HashText_Description" xml:space="preserve">
-    <value>Hashes a string using a specified algorithm and returns the hexadecimal string representation of the resulting hash.</value>
+    <value>This activity is now deprecated. SHA1, SHA256, SHA384, and SHA512 were moved to a single activity Hash Text.</value>
     <comment>Activity description</comment>
   </data>
   <data name="Activity_HashText_Name" xml:space="preserve">

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
@@ -30,7 +30,6 @@
           "Name": "InputFile",
           "DisplayNameKey": "Activity_DecryptFile_Property_InputFile_Name",
           "TooltipKey": "Activity_DecryptFile_Property_InputFile_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -44,7 +43,6 @@
           "Name": "InputFilePath",
           "DisplayNameKey": "Activity_DecryptFile_Property_InputFilePath_Name",
           "TooltipKey": "Activity_DecryptFile_Property_InputFilePath_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -82,7 +80,6 @@
           "Name": "OutputFilePath",
           "DisplayNameKey": "Activity_DecryptFile_Property_OutputFilePath_Name",
           "TooltipKey": "Activity_DecryptFile_Property_OutputFilePath_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -275,7 +272,6 @@
           "Name": "InputFilePath",
           "DisplayNameKey": "Activity_EncryptFile_Property_InputFilePath_Name",
           "TooltipKey": "Activity_EncryptFile_Property_InputFilePath_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -289,7 +285,6 @@
           "Name": "InputFile",
           "DisplayNameKey": "Activity_EncryptFile_Property_InputFile_Name",
           "TooltipKey": "Activity_EncryptFile_Property_InputFile_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -329,7 +324,6 @@
           "Name": "OutputFilePath",
           "DisplayNameKey": "Activity_EncryptFile_Property_OutputFilePath_Name",
           "TooltipKey": "Activity_EncryptFile_Property_OutputFilePath_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -522,7 +516,6 @@
           "Name": "InputFile",
           "DisplayNameKey": "Activity_KeyedHashFile_Property_InputFile_Name",
           "TooltipKey": "Activity_KeyedHashFile_Property_InputFile_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -536,7 +529,6 @@
           "Name": "FilePath",
           "DisplayNameKey": "Activity_KeyedHashFile_Property_FilePath_Name",
           "TooltipKey": "Activity_KeyedHashFile_Property_FilePath_Description",
-          "IsRequired": true,
           "IsPrincipal": true,
           "IsVisible": true,
           "Category": {
@@ -586,6 +578,111 @@
           "Name": "Result",
           "DisplayNameKey": "Activity_KeyedHashFile_Property_Result_Name",
           "TooltipKey": "Activity_KeyedHashFile_Property_Result_Description",
+          "IsRequired": false,
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Output"
+          },
+          "Widget": null,
+          "IconKey": null
+        }
+      ],
+      "DefaultFactory": null,
+      "ViewModelType": null
+    },
+    {
+      "AssemblyQualifiedName": null,
+      "FullName": "UiPath.Cryptography.Activities.HashFile",
+      "ShortName": "HashFile",
+      "DisplayNameKey": "Activity_HashFile_Name",
+      "DescriptionKey": "Activity_HashFile_Description",
+      "IconKey": "Hash_file_with_key.svg",
+      "CategoryKey": null,
+      "ActivityColor": null,
+      "ActivityNameBackgroundColor": null,
+      "Properties": [
+        {
+          "Name": "Algorithm",
+          "DisplayNameKey": "Activity_HashFile_Property_Algorithm_Name",
+          "TooltipKey": "Activity_HashFile_Property_Algorithm_Description",
+          "IsRequired": true,
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "InputFile",
+          "DisplayNameKey": "Activity_KeyedHashFile_Property_InputFile_Name",
+          "TooltipKey": "Activity_KeyedHashFile_Property_InputFile_Description",
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "FilePath",
+          "DisplayNameKey": "Activity_HashFile_Property_FilePath_Name",
+          "TooltipKey": "Activity_KeyedHashFile_Property_FilePath_Description",
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "Key",
+          "DisplayNameKey": "Activity_KeyedHashFile_Property_Key_Name",
+          "TooltipKey": "Activity_KeyedHashFile_Property_Key_Description",
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "KeySecureString",
+          "DisplayNameKey": "Activity_KeyedHashFile_Property_KeySecureString_Name",
+          "TooltipKey": "Activity_KeyedHashFile_Property_KeySecureString_Description",
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_HashFile_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_HashFile_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Options_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "Result",
+          "DisplayNameKey": "Activity_HashFile_Property_Result_Name",
+          "TooltipKey": "Activity_HashFile_Property_Result_Description",
           "IsRequired": false,
           "IsPrincipal": true,
           "IsVisible": true,
@@ -679,6 +776,99 @@
           "Name": "Result",
           "DisplayNameKey": "Activity_KeyedHashText_Property_Result_Name",
           "TooltipKey": "Activity_KeyedHashText_Property_Result_Description",
+          "IsRequired": false,
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Output"
+          },
+          "Widget": null,
+          "IconKey": null
+        }
+      ],
+      "DefaultFactory": null,
+      "ViewModelType": null
+    },
+    {
+      "AssemblyQualifiedName": null,
+      "FullName": "UiPath.Cryptography.Activities.HashText",
+      "ShortName": "HashText",
+      "DisplayNameKey": "Activity_HashText_Name",
+      "DescriptionKey": "Activity_HashText_Description",
+      "IconKey": "Hash_text_with_key.svg",
+      "CategoryKey": null,
+      "ActivityColor": null,
+      "ActivityNameBackgroundColor": null,
+      "Properties": [
+        {
+          "Name": "Algorithm",
+          "DisplayNameKey": "Activity_HashText_Property_Algorithm_Name",
+          "TooltipKey": "Activity_HashText_Property_Algorithm_Description",
+          "IsRequired": true,
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "Input",
+          "DisplayNameKey": "Activity_HashText_Property_Input_Name",
+          "TooltipKey": "Activity_HashText_Property_Input_Description",
+          "IsRequired": true,
+          "IsPrincipal": true,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "Key",
+          "DisplayNameKey": "Activity_KeyedHashText_Property_Key_Name",
+          "TooltipKey": "Activity_HashText_Property_Key_Description",
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "KeySecureString",
+          "DisplayNameKey": "Activity_KeyedHashText_Property_KeySecureString_Name",
+          "TooltipKey": "Activity_HashText_Property_KeySecureString_Description",
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Principal_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_HashText_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_HashText_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "Name": null,
+            "DisplayNameKey": "Category_Options_Name"
+          },
+          "Widget": null,
+          "IconKey": null
+        },
+        {
+          "Name": "Result",
+          "DisplayNameKey": "Activity_HashText_Property_Result_Name",
+          "TooltipKey": "Activity_HashText_Property_Result_Description",
           "IsRequired": false,
           "IsPrincipal": true,
           "IsVisible": true,


### PR DESCRIPTION
…File and Hash File With Key activities, Add a fallback for .NET 5 projects for the deleted Hash Key activity, [SW] [Cryptography] - Error thrown at runtime when activities have both Key and Secure Key fields completed, Windows projects: Hash File, Encrypt File and Decrypt File should have IResource input as an extra property on top of the existing File Path property