### PR TITLE
Update driver warning to include more information

### DIFF
--- a/Activities/Database/UiPath.Database/Properties/UiPath.Database.resx
+++ b/Activities/Database/UiPath.Database/Properties/UiPath.Database.resx
@@ -124,7 +124,7 @@
     <value>Unmapped column {0} was not found in destination database table {1}</value>
   </data>
   <data name="BulkInsert_DriverDoesNotSupportBulkInsert" xml:space="preserve">
-    <value>The provided driver version does not support Bulk Insert operations. Please check the driver.</value>
+    <value>The configured provider does not support Bulk Insert operations. Providers that support Bulk Insert operations are: Microsoft.Data.SqlClient and Oracle.ManagedDataAccess.Client.OracleConnection.</value>
   </data>
   <data name="BulkInsert_NumberOfColumnsMustMatch" xml:space="preserve">
     <value>The provided number of columns in the DataTable must match the number of columns in the DB table.</value>


### PR DESCRIPTION
Feedback from customers indicated that the previous warning message when a driver did not support Bulk Insert operations was not helpful in troubleshooting as it did not list supported versions or types. The https://docs.uipath.com/activities/docs/bulk-insert page also did not list the compatible driver versions.