### PR TITLE
Database: Fix insert/bulk insert activities

### DIFF
--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -119,14 +119,26 @@ namespace UiPath.Database
         {
             // the select command text should be different depending on the provider
             // in this iteration we will try both formats for an insert operation, but a proper matching must be implemented
+            Exception firstException, secondException;
             try
             {
                 return InsertDataTableInternal(tableName, dataTable, true);
             }
-            catch(Exception)
+            catch(Exception e)
+            {
+                firstException = e;
+            }
+            try
             {
                 return InsertDataTableInternal(tableName, dataTable, false);
             }
+            catch (Exception e)
+            {
+                secondException = e;
+            }
+
+            // if both methods fail, return both fail messages 
+            throw new AggregateException(firstException, secondException);
         }
 
         private int InsertDataTableInternal(string tableName, DataTable dataTable, bool removeBrackets)


### PR DESCRIPTION
## Description
`Insert datatable` activity is failing when using `System.Data.Odbc` as provider on any version `>1.4.0` with syntax error.  This happens because a wrong `Select` format is used, and the auto-generating the insert query doesn't throw. 

As a quick fix, we can try the second format when the first one fails (either on build query or on execute query) . Ideally, we would have a matching service between providers and select query formats.

## Jira
https://uipath.atlassian.net/browse/STUD-66421
