### PR TITLE
FTP: Upgrade package references (24.11) [STUD-71020]

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" ToolsVersion="Current">
   <Import Project="..\FTP.build.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0-windows</TargetFrameworks>
     <OutputPath>$(ProjectDir)..\..\Output\Activities\FTP\</OutputPath>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
     <PackageReference Include="UiPath.Workflow" />
     <PackageReference Include="System.Activities.Core.Presentation" />
   </ItemGroup>

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/UiPath.FTP.Activities.Packaging.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/UiPath.FTP.Activities.Packaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\FTP.build.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0-windows;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0-windows;net6.0</TargetFrameworks>
     <OutputPath>..\..\Output\Activities\FTP\</OutputPath>
     <!--leave empty for ci to replace with prelease tag-->
 	<VersionSuffix></VersionSuffix>
@@ -31,8 +31,8 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="37.1.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="FluentFTP" Version="50.1.0" />
+    <PackageReference Include="SSH.NET" Version="2024.0.0" />
   </ItemGroup>
 
 	<Target Name="AddDlls">
@@ -72,7 +72,7 @@
 			<BuildOutputInPackage Include="$(OutputPath)zh-TW\UiPath.FTP.Activities.resources.dll" TargetPath="zh-TW\UiPath.FTP.Activities.resources.dll" />
 
 		</ItemGroup>
-		<ItemGroup Condition=" '$(TargetFramework)' != 'net5.0' ">
+		<ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
 			<BuildOutputInPackage Include="$(OutputPath)UiPath.FTP.Activities.Design.dll" />
 		</ItemGroup>
 	</Target>
@@ -84,12 +84,12 @@
 		<Delete Files="@(PackageFilesToDelete)" ContinueOnError="WarnAndContinue" />
 	</Target>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
     <ProjectReference Include="..\..\FTP\UiPath.FTP.Activities.Design\UiPath.FTP.Activities.Design.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\..\FTP\UiPath.FTP.Activities\UiPath.FTP.Activities.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>

--- a/Activities/FTP/UiPath.FTP.Activities/DownloadFiles.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/DownloadFiles.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UiPath.FTP.Activities.Properties;
 using UiPath.Shared.Activities;
+using UiPath.FTP;
 
 namespace UiPath.FTP.Activities
 {

--- a/Activities/FTP/UiPath.FTP.Activities/UiPath.FTP.Activities.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities/UiPath.FTP.Activities.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\FTP.build.props" />
   <PropertyGroup>
     <PackageId>.noconflict</PackageId>
-    <TargetFrameworks>net461;net5.0;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net6.0-windows</TargetFrameworks>
     <OutputPath>..\..\Output\Activities\FTP\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -13,11 +13,11 @@
     <Reference Include="System.Activities" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="UiPath.Workflow" />
     <PackageReference Include="System.Activities.ViewModels" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
     <PackageReference Include="System.Activities.Core.Presentation" />
     <PackageReference Include="UiPath.Workflow" />
     <PackageReference Include="System.Activities.ViewModels" />
@@ -56,6 +56,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Condition="'$(TargetFramework)' != 'net5.0'" Remove="NetCore/**" />
+    <Compile Condition="'$(TargetFramework)' != 'net6.0'" Remove="NetCore/**" />
   </ItemGroup>
 </Project>

--- a/Activities/FTP/UiPath.FTP/Extensions.cs
+++ b/Activities/FTP/UiPath.FTP/Extensions.cs
@@ -24,7 +24,7 @@ namespace UiPath.FTP
             return ftpObjectInfo;
         }
 
-        public static FtpObjectInfo ToFtpObjectInfo(this SftpFile sftpFile)
+        public static FtpObjectInfo ToFtpObjectInfo(this ISftpFile sftpFile)
         {
             FtpObjectInfo ftpObjectInfo = new FtpObjectInfo();
 
@@ -41,22 +41,22 @@ namespace UiPath.FTP
             return ftpObjectInfo;
         }
 
-        public static FtpObjectType ToFtpObjectType(this FtpFileSystemObjectType ftpFileSystemObjectType)
+        public static UiPath.FTP.FtpObjectType ToFtpObjectType(this FluentFTP.FtpObjectType ftpFileSystemObjectType)
         {
             switch (ftpFileSystemObjectType)
             {
-                case FtpFileSystemObjectType.File:
-                    return FtpObjectType.File;
-                case FtpFileSystemObjectType.Directory:
-                    return FtpObjectType.Directory;
-                case FtpFileSystemObjectType.Link:
-                    return FtpObjectType.Link;
+                case FluentFTP.FtpObjectType.File:
+                    return UiPath.FTP.FtpObjectType.File;
+                case FluentFTP.FtpObjectType.Directory:
+                    return UiPath.FTP.FtpObjectType.Directory;
+                case FluentFTP.FtpObjectType.Link:
+                    return UiPath.FTP.FtpObjectType.Link;
                 default:
                     throw new NotSupportedException(Resources.UnsupportedObjectTypeException);
             }
         }
 
-        public static FtpObjectType GetFtpObjectType(this SftpFile sftpFile)
+        public static UiPath.FTP.FtpObjectType GetFtpObjectType(this ISftpFile sftpFile)
         {
             if (sftpFile == null)
             {
@@ -65,15 +65,15 @@ namespace UiPath.FTP
 
             if (sftpFile.IsRegularFile)
             {
-                return FtpObjectType.File;
+                return UiPath.FTP.FtpObjectType.File;
             }
             if (sftpFile.IsDirectory)
             {
-                return FtpObjectType.Directory;
+                return UiPath.FTP.FtpObjectType.Directory;
             }
             if (sftpFile.IsSymbolicLink)
             {
-                return FtpObjectType.Link;
+                return UiPath.FTP.FtpObjectType.Link;
             }
 
             throw new NotSupportedException(Resources.UnsupportedObjectTypeException);

--- a/Activities/FTP/UiPath.FTP/FtpSession.cs
+++ b/Activities/FTP/UiPath.FTP/FtpSession.cs
@@ -1,5 +1,5 @@
 ﻿using FluentFTP;
-using FluentFTP.Proxy;
+using FluentFTP.Proxy.SyncProxy;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,6 +18,7 @@ namespace UiPath.FTP
     public class FtpSession : IFtpSession
     {
         private readonly FtpClient _ftpClient;
+
         private const int DefaultProxyPort = 3128;
 
         public FtpSession(FtpConfiguration ftpConfiguration, FtpsMode ftpsMode)
@@ -27,13 +28,13 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(ftpConfiguration));
             }
 
-            var proxy = new ProxyInfo();
+            var proxy = new FtpProxyProfile();
             if(ftpConfiguration.ProxyType != FtpProxyType.None)
             {
-                proxy.Host = ftpConfiguration.ProxyServer;
-                proxy.Port = (ftpConfiguration.ProxyPort == null) ? DefaultProxyPort : ftpConfiguration.ProxyPort.Value;
+                proxy.ProxyHost = ftpConfiguration.ProxyServer;
+                proxy.ProxyPort = (ftpConfiguration.ProxyPort == null) ? DefaultProxyPort : ftpConfiguration.ProxyPort.Value;
                 if (!string.IsNullOrEmpty(ftpConfiguration.ProxyUsername))
-                    proxy.Credentials = new NetworkCredential(ftpConfiguration.ProxyUsername, ftpConfiguration.ProxyPassword);
+                    proxy.ProxyCredentials = new NetworkCredential(ftpConfiguration.ProxyUsername, ftpConfiguration.ProxyPassword);
             }
 
             switch (ftpConfiguration.ProxyType)
@@ -70,13 +71,13 @@ namespace UiPath.FTP
             switch (ftpsMode)
             {
                 case FtpsMode.Explicit:
-                    _ftpClient.EncryptionMode = FtpEncryptionMode.Explicit;
+                    _ftpClient.Config.EncryptionMode = FtpEncryptionMode.Explicit;
                     break;
                 case FtpsMode.Implicit:
-                    _ftpClient.EncryptionMode = FtpEncryptionMode.Implicit;
+                    _ftpClient.Config.EncryptionMode = FtpEncryptionMode.Implicit;
                     break;
                 case FtpsMode.None:
-                    _ftpClient.EncryptionMode = FtpEncryptionMode.None;
+                    _ftpClient.Config.EncryptionMode = FtpEncryptionMode.None;
                     break;
                 default:
                     throw new InvalidOperationException(Resources.UnknownFTPSModeException);
@@ -84,8 +85,8 @@ namespace UiPath.FTP
 
             if (ftpsMode != FtpsMode.None)
             {
-                _ftpClient.SslProtocols = (SslProtocols)ftpConfiguration.SslProtocols;
-                _ftpClient.ValidateCertificate += (control, e) => _ftpClient_ValidateCertificate(control, e, ftpConfiguration.AcceptAllCertificates);
+                _ftpClient.Config.SslProtocols = (SslProtocols)ftpConfiguration.SslProtocols; //viorel -> to review
+                _ftpClient.ValidateCertificate += (control, e) => _ftpClient_ValidateCertificate(control as FtpClient, e, ftpConfiguration.AcceptAllCertificates);
 
                 if (string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath) == false)
                 {
@@ -99,7 +100,7 @@ namespace UiPath.FTP
                         clientCertificate = new X509Certificate2(ftpConfiguration.ClientCertificatePath, ftpConfiguration.ClientCertificatePassword);
                     }
 
-                    _ftpClient.ClientCertificates.Add(clientCertificate);
+                    _ftpClient.Config.ClientCertificates.Add(clientCertificate);
                 }
             }
         }
@@ -168,14 +169,14 @@ namespace UiPath.FTP
             FtpListItem[] items = _ftpClient.GetListing(currentDirectory.FullName);
             string nextLocalPath = Path.Combine(localPath, currentDirectory.Name);
 
-            foreach (FtpListItem file in items.Where(i => i.Type == FtpFileSystemObjectType.File))
+            foreach (FtpListItem file in items.Where(i => i.Type == FluentFTP.FtpObjectType.File))
             {
                 listing.Add(new Tuple<string, string>(Path.Combine(nextLocalPath, file.Name), file.FullName));
             }
 
             if (recursive)
             {
-                foreach (FtpListItem directory in items.Where(i => i.Type == FtpFileSystemObjectType.Directory))
+                foreach (FtpListItem directory in items.Where(i => i.Type == FluentFTP.FtpObjectType.Directory))
                 {
                     listing.AddRange(GetRemoteListing(directory.FullName, nextLocalPath, recursive));
                 }
@@ -205,7 +206,7 @@ namespace UiPath.FTP
 
             if (recursive)
             {
-                foreach (FtpListItem directory in items.Where(i => i.Type == FtpFileSystemObjectType.Directory))
+                foreach (FtpListItem directory in items.Where(i => i.Type == FluentFTP.FtpObjectType.Directory))
                 {
                     listing.AddRange(GetRemoteListing(directory.FullName, recursive));
                 }
@@ -229,29 +230,29 @@ namespace UiPath.FTP
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            string initialWorkingDirectory = await _ftpClient.GetWorkingDirectoryAsync();
-            await _ftpClient.SetWorkingDirectoryAsync(remotePath);
-            string currentWorkingDirectory = await _ftpClient.GetWorkingDirectoryAsync();
+            string initialWorkingDirectory = _ftpClient.GetWorkingDirectory();
+            _ftpClient.SetWorkingDirectory(remotePath);
+            string currentWorkingDirectory = _ftpClient.GetWorkingDirectory();
 
             List<Tuple<string, string>> listing = new List<Tuple<string, string>>();
-            FtpListItem currentDirectory = await _ftpClient.GetObjectInfoAsync(currentWorkingDirectory);
-            FtpListItem[] items = await _ftpClient.GetListingAsync(currentDirectory.FullName);
+            FtpListItem currentDirectory = await Task.Run(() => _ftpClient.GetObjectInfo(currentWorkingDirectory), cancellationToken);
+            FtpListItem[] items = await Task.Run(() => _ftpClient.GetListing(currentDirectory.FullName), cancellationToken);
             string nextLocalPath = Path.Combine(localPath, currentDirectory.Name);
 
-            foreach (FtpListItem file in items.Where(i => i.Type == FtpFileSystemObjectType.File))
+            foreach (FtpListItem file in items.Where(i => i.Type == FluentFTP.FtpObjectType.File))
             {
                 listing.Add(new Tuple<string, string>(Path.Combine(nextLocalPath, file.Name), file.FullName));
             }
 
             if (recursive)
             {
-                foreach (FtpListItem directory in items.Where(i => i.Type == FtpFileSystemObjectType.Directory))
+                foreach (FtpListItem directory in items.Where(i => i.Type == FluentFTP.FtpObjectType.Directory))
                 {
                     listing.AddRange(await GetRemoteListingAsync(directory.FullName, nextLocalPath, recursive, cancellationToken));
                 }
             }
 
-            await _ftpClient.SetWorkingDirectoryAsync(initialWorkingDirectory);
+            await Task.Run(() => _ftpClient.SetWorkingDirectory(initialWorkingDirectory), cancellationToken);
 
             return listing;
         }
@@ -269,13 +270,13 @@ namespace UiPath.FTP
             FtpListItem currentDirectory = _ftpClient.GetObjectInfo(_ftpClient.GetWorkingDirectory());
 
             List<FtpObjectInfo> listing = new List<FtpObjectInfo>();
-            FtpListItem[] items = await _ftpClient.GetListingAsync(currentDirectory?.FullName ?? remotePath);
+            FtpListItem[] items = await Task.Run(() => _ftpClient.GetListing(currentDirectory?.FullName ?? remotePath), cancellationToken);
 
             listing.AddRange(items.Select(fli => fli.ToFtpObjectInfo()));
 
             if (recursive)
             {
-                foreach (FtpListItem directory in items.Where(i => i.Type == FtpFileSystemObjectType.Directory))
+                foreach (FtpListItem directory in items.Where(i => i.Type == FluentFTP.FtpObjectType.Directory))
                 {
                     listing.AddRange(await GetRemoteListingAsync(directory.FullName, recursive, cancellationToken));
                 }
@@ -310,7 +311,7 @@ namespace UiPath.FTP
             Trace.TraceInformation("Attempting to asynchronously open an FTP connection.");
 
             // TODO: Should we check for cancellation here?
-            return _ftpClient.ConnectAsync();
+            return Task.Run(() => _ftpClient.Connect(), cancellationToken);
         }
 
         void IFtpSession.Close()
@@ -325,7 +326,7 @@ namespace UiPath.FTP
             Trace.TraceInformation("Attempting to asynchronously close an FTP connection.");
 
             // TODO: Should we check for cancellation here?
-            return _ftpClient.DisconnectAsync();
+            return Task.Run(() => _ftpClient.Disconnect(), cancellationToken);
         }
 
         void IFtpSession.CreateDirectory(string path)
@@ -346,7 +347,7 @@ namespace UiPath.FTP
             }
 
             // TODO: Should we check for cancellation here?
-            return _ftpClient.CreateDirectoryAsync(path);
+            return Task.Run(() => _ftpClient.CreateDirectory(path), cancellationToken);
         }
 
         void IFtpSession.Delete(string path)
@@ -358,10 +359,10 @@ namespace UiPath.FTP
 
             switch (((IFtpSession)this).GetObjectType(path))
             {
-                case FtpObjectType.Directory:
+                case UiPath.FTP.FtpObjectType.Directory:
                     _ftpClient.DeleteDirectory(path);
                     break;
-                case FtpObjectType.File:
+                case UiPath.FTP.FtpObjectType.File:
                     _ftpClient.DeleteFile(path);
                     break;
                 default:
@@ -378,11 +379,11 @@ namespace UiPath.FTP
 
             switch (await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken))
             {
-                case FtpObjectType.Directory:
-                    await _ftpClient.DeleteDirectoryAsync(path);
+                case UiPath.FTP.FtpObjectType.Directory:
+                    await Task.Run(() => _ftpClient.DeleteDirectory(path), cancellationToken);
                     break;
-                case FtpObjectType.File:
-                    await _ftpClient.DeleteFileAsync(path);
+                case UiPath.FTP.FtpObjectType.File:
+                    await Task.Run(() => _ftpClient.DeleteFile(path), cancellationToken);
                     break;
                 default:
                     throw new NotImplementedException(Resources.UnsupportedObjectTypeException);
@@ -407,7 +408,7 @@ namespace UiPath.FTP
             }
 
             // TODO: Should we check for cancellation here?
-            return _ftpClient.DirectoryExistsAsync(path);
+            return Task.Run(() => _ftpClient.DirectoryExists(path), cancellationToken);
         }
 
         void IFtpSession.Download(string remotePath, string localPath, bool overwrite, bool recursive)
@@ -421,8 +422,8 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(localPath));
             }
 
-            FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
-            if (objectType == FtpObjectType.Directory)
+            UiPath.FTP.FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
+            if (objectType == UiPath.FTP.FtpObjectType.Directory)
             {
                 IEnumerable<Tuple<string, string>> listing = GetRemoteListing(remotePath, localPath, recursive);
 
@@ -433,14 +434,14 @@ namespace UiPath.FTP
             }
             else
             {
-                if (objectType == FtpObjectType.File)
+                if (objectType == UiPath.FTP.FtpObjectType.File)
                 {
                     if (File.Exists(localPath) && !overwrite)
                     {
                         throw new IOException(Resources.FileExistsException);
                     }
 
-                    _ftpClient.DownloadFileAsync(localPath, remotePath, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip); 
+                    _ftpClient.DownloadFile(localPath, remotePath, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip); 
                 }
                 else
                 {
@@ -460,8 +461,8 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(localPath));
             }
 
-            FtpObjectType objectType = await ((IFtpSession)this).GetObjectTypeAsync(remotePath, cancellationToken);
-            if (objectType == FtpObjectType.Directory)
+            UiPath.FTP.FtpObjectType objectType = await ((IFtpSession)this).GetObjectTypeAsync(remotePath, cancellationToken);
+            if (objectType == UiPath.FTP.FtpObjectType.Directory)
             {
                 IEnumerable<Tuple<string, string>> listing = await GetRemoteListingAsync(remotePath, localPath, recursive, cancellationToken);
 
@@ -469,19 +470,19 @@ namespace UiPath.FTP
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    await _ftpClient.DownloadFileAsync(pair.Item1, pair.Item2, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, cancellationToken);
+                    await Task.Run(() => _ftpClient.DownloadFile(pair.Item1, pair.Item2, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null), cancellationToken);
                 }
             }
             else
             {
-                if (objectType == FtpObjectType.File)
+                if (objectType == UiPath.FTP.FtpObjectType.File)
                 {
                     if (File.Exists(localPath) && !overwrite)
                     {
                         throw new IOException(Resources.FileExistsException);
                     }
 
-                    await _ftpClient.DownloadFileAsync(localPath, remotePath, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, cancellationToken);
+                    await Task.Run(() => _ftpClient.DownloadFile(localPath, remotePath, overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null), cancellationToken);
                 }
                 else
                 {
@@ -508,29 +509,29 @@ namespace UiPath.FTP
             }
 
             // TODO: Should we check for cancellation here?
-            return _ftpClient.FileExistsAsync(path);
+            return Task.Run(() => _ftpClient.FileExists(path), cancellationToken);
         }
 
-        FtpObjectType IFtpSession.GetObjectType(string path)
+        UiPath.FTP.FtpObjectType IFtpSession.GetObjectType(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 throw new ArgumentNullException(nameof(path));
             }
 
-            FtpObjectType objectType = FtpObjectType.File;
+            UiPath.FTP.FtpObjectType objectType = UiPath.FTP.FtpObjectType.File;
             FtpListItem objectInfo = _ftpClient.GetObjectInfo(path);
             if (objectInfo == null)
             {
                 if (_ftpClient.FileExists(path))
                 {
-                    objectType = FtpObjectType.File;
+                    objectType = UiPath.FTP.FtpObjectType.File;
                 }
                 else
                 {
                     if (_ftpClient.DirectoryExists(path))
                     {
-                        objectType = FtpObjectType.Directory;
+                        objectType = UiPath.FTP.FtpObjectType.Directory;
                     }
                     else
                     {
@@ -546,26 +547,26 @@ namespace UiPath.FTP
             return objectType;
         }
 
-        async Task<FtpObjectType> IFtpSession.GetObjectTypeAsync(string path, CancellationToken cancellationToken)
+        async Task<UiPath.FTP.FtpObjectType> IFtpSession.GetObjectTypeAsync(string path, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 throw new ArgumentNullException(nameof(path));
             }
 
-            FtpObjectType objectType = FtpObjectType.File;
-            FtpListItem objectInfo = await _ftpClient.GetObjectInfoAsync(path);
+            UiPath.FTP.FtpObjectType objectType = UiPath.FTP.FtpObjectType.File;
+            FtpListItem objectInfo = await Task.Run(() => _ftpClient.GetObjectInfo(path));
             if (objectInfo == null)
             {
-                if (await _ftpClient.FileExistsAsync(path))
+                if (await Task.Run(() => _ftpClient.FileExists(path), cancellationToken))
                 {
-                    objectType = FtpObjectType.File;
+                    objectType = UiPath.FTP.FtpObjectType.File;
                 }
                 else
                 {
-                    if (await _ftpClient.DirectoryExistsAsync(path))
+                    if (await Task.Run(() => _ftpClient.DirectoryExists(path), cancellationToken))
                     {
-                        objectType = FtpObjectType.Directory;
+                        objectType = UiPath.FTP.FtpObjectType.Directory;
                     }
                     else
                     {
@@ -617,7 +618,7 @@ namespace UiPath.FTP
             {
                 throw new IOException(string.Format(Resources.PathNotFoundException, RemotePath));
             }
-            if (ftpItem.Type == FtpFileSystemObjectType.Directory)
+            if (ftpItem.Type == FluentFTP.FtpObjectType.Directory)
             {
                 if (_ftpClient.DirectoryExists(newPath) && !overwrite)
                 {
@@ -625,7 +626,7 @@ namespace UiPath.FTP
                 }
                 _ftpClient.MoveDirectory(RemotePath, newPath, overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip);
             }
-            else if (ftpItem.Type == FtpFileSystemObjectType.File)
+            else if (ftpItem.Type == FluentFTP.FtpObjectType.File)
             {
                 if (_ftpClient.FileExists(newPath) && !overwrite)
                 {
@@ -696,19 +697,19 @@ namespace UiPath.FTP
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    await _ftpClient.UploadFileAsync(pair.Item1, pair.Item2, overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, true, FtpVerify.None, null, cancellationToken);
+                    await Task.Run(() => _ftpClient.UploadFile(pair.Item1, pair.Item2, overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, true, FtpVerify.None, null), cancellationToken);
                 }
             }
             else
             {
                 if (File.Exists(localPath))
                 {
-                    if ((await _ftpClient.FileExistsAsync(remotePath)) && !overwrite)
+                    if (await Task.Run(() => _ftpClient.FileExists(remotePath), cancellationToken) && !overwrite)
                     {
                         throw new IOException(Resources.FileExistsException);
                     }
 
-                    await _ftpClient.UploadFileAsync(localPath, remotePath, overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, true, FtpVerify.None, null, cancellationToken); 
+                    await Task.Run(() => _ftpClient.UploadFile(localPath, remotePath, overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, true, FtpVerify.None, null), cancellationToken); 
                 }
                 else
                 {

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -115,18 +115,18 @@ namespace UiPath.FTP
             _sftpClient.ChangeDirectory(remotePath);
             
             List<Tuple<string, string>> listing = new List<Tuple<string, string>>();
-            SftpFile currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
-            IEnumerable<SftpFile> items = _sftpClient.ListDirectory(currentDirectory.FullName);
+            ISftpFile currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
+            IEnumerable<ISftpFile> items = _sftpClient.ListDirectory(currentDirectory.FullName);
             string nextLocalPath = Path.Combine(localPath, currentDirectory.Name);
 
-            foreach (SftpFile file in items.Where(i => i.IsRegularFile))
+            foreach (var file in items.Where(i => i.IsRegularFile))
             {
                 listing.Add(new Tuple<string, string>(Path.Combine(nextLocalPath, file.Name), file.FullName));
             }
 
             if (recursive)
             {
-                foreach (SftpFile directory in items.Where(i => i.IsDirectory && i.Name != "." && i.Name != ".."))
+                foreach (var directory in items.Where(i => i.IsDirectory && i.Name != "." && i.Name != ".."))
                 {
                     listing.AddRange(GetRemoteListing(directory.FullName, nextLocalPath, recursive));
                 }
@@ -147,16 +147,16 @@ namespace UiPath.FTP
             string initialWorkingDirectory = _sftpClient.WorkingDirectory;
             _sftpClient.ChangeDirectory(remotePath);
 
-            SftpFile currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
+            var currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
 
             List<FtpObjectInfo> listing = new List<FtpObjectInfo>();
-            IEnumerable<SftpFile> items = _sftpClient.ListDirectory(currentDirectory.FullName).Where(sf => sf.Name != "." && sf.Name != "..");
+            var items = _sftpClient.ListDirectory(currentDirectory.FullName).Where(sf => sf.Name != "." && sf.Name != "..");
 
             listing.AddRange(items.Select(sf => sf.ToFtpObjectInfo()));
 
             if (recursive)
             {
-                foreach (SftpFile directory in items.Where(i => i.IsDirectory))
+                foreach (var directory in items.Where(i => i.IsDirectory))
                 {
                     listing.AddRange(GetRemoteListing(directory.FullName, recursive));
                 }
@@ -184,18 +184,18 @@ namespace UiPath.FTP
             _sftpClient.ChangeDirectory(remotePath);
 
             List<Tuple<string, string>> listing = new List<Tuple<string, string>>();
-            SftpFile currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
-            IEnumerable<SftpFile> items = await Task.Factory.FromAsync(_sftpClient.BeginListDirectory(currentDirectory.FullName, null, null), _sftpClient.EndListDirectory);
+            var currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
+            var items = await Task.Factory.FromAsync(_sftpClient.BeginListDirectory(currentDirectory.FullName, null, null), _sftpClient.EndListDirectory);
             string nextLocalPath = Path.Combine(localPath, currentDirectory.Name);
 
-            foreach (SftpFile file in items.Where(i => i.IsRegularFile))
+            foreach (var file in items.Where(i => i.IsRegularFile))
             {
                 listing.Add(new Tuple<string, string>(Path.Combine(nextLocalPath, file.Name), file.FullName));
             }
 
             if (recursive)
             {
-                foreach (SftpFile directory in items.Where(i => i.IsDirectory && i.Name != "." && i.Name != ".."))
+                foreach (var directory in items.Where(i => i.IsDirectory && i.Name != "." && i.Name != ".."))
                 {
                     listing.AddRange(await GetRemoteListingAsync(directory.FullName, nextLocalPath, recursive, cancellationToken));
                 }
@@ -216,17 +216,17 @@ namespace UiPath.FTP
             string initialWorkingDirectory = _sftpClient.WorkingDirectory;
             _sftpClient.ChangeDirectory(remotePath);
 
-            SftpFile currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
+            var currentDirectory = _sftpClient.Get(_sftpClient.WorkingDirectory);
 
             List<FtpObjectInfo> listing = new List<FtpObjectInfo>();
-            IEnumerable<SftpFile> items = await Task.Factory.FromAsync(_sftpClient.BeginListDirectory(currentDirectory.FullName, null, null), _sftpClient.EndListDirectory);
+            var items = await Task.Factory.FromAsync(_sftpClient.BeginListDirectory(currentDirectory.FullName, null, null), _sftpClient.EndListDirectory);
             items = items.Where(sf => sf.Name != "." && sf.Name != "..");
 
             listing.AddRange(items.Select(sf => sf.ToFtpObjectInfo()));
 
             if (recursive)
             {
-                foreach (SftpFile directory in items.Where(i => i.IsDirectory))
+                foreach (var directory in items.Where(i => i.IsDirectory))
                 {
                     listing.AddRange(await GetRemoteListingAsync(directory.FullName, recursive, cancellationToken));
                 }
@@ -372,7 +372,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == FtpObjectType.Directory;
+            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.Directory;
         }
 
         async Task<bool> IFtpSession.DirectoryExistsAsync(string path, CancellationToken cancellationToken)
@@ -384,7 +384,7 @@ namespace UiPath.FTP
 
             if (_sftpClient.Exists(path))
             {
-                return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == FtpObjectType.Directory;
+                return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == UiPath.FTP.FtpObjectType.Directory;
             }
             else
             {
@@ -403,8 +403,8 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(localPath));
             }
 
-            FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
-            if (objectType == FtpObjectType.Directory)
+            UiPath.FTP.FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
+            if (objectType == UiPath.FTP.FtpObjectType.Directory)
             {
                 IEnumerable<Tuple<string, string>> listing = GetRemoteListing(remotePath, localPath, recursive);
 
@@ -424,7 +424,7 @@ namespace UiPath.FTP
             }
             else
             {
-                if (objectType == FtpObjectType.File)
+                if (objectType == UiPath.FTP.FtpObjectType.File)
                 {
                     if (File.Exists(localPath) && !overwrite)
                     {
@@ -454,8 +454,8 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(localPath));
             }
 
-            FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
-            if (objectType == FtpObjectType.Directory)
+            UiPath.FTP.FtpObjectType objectType = ((IFtpSession)this).GetObjectType(remotePath);
+            if (objectType == UiPath.FTP.FtpObjectType.Directory)
             {
                 IEnumerable<Tuple<string, string>> listing = await GetRemoteListingAsync(remotePath, localPath, recursive, cancellationToken);
 
@@ -482,7 +482,7 @@ namespace UiPath.FTP
             }
             else
             {
-                if (objectType == FtpObjectType.File)
+                if (objectType == UiPath.FTP.FtpObjectType.File)
                 {
                     if (File.Exists(localPath))
                     {
@@ -515,7 +515,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == FtpObjectType.File;
+            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.File;
         }
 
         async Task<bool> IFtpSession.FileExistsAsync(string path, CancellationToken cancellationToken)
@@ -527,7 +527,7 @@ namespace UiPath.FTP
 
             if (_sftpClient.Exists(path))
             {
-                return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == FtpObjectType.File;
+                return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == UiPath.FTP.FtpObjectType.File;
             }
             else
             {
@@ -535,7 +535,7 @@ namespace UiPath.FTP
             }
         }
 
-        FtpObjectType IFtpSession.GetObjectType(string path)
+        UiPath.FTP.FtpObjectType IFtpSession.GetObjectType(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -550,7 +550,7 @@ namespace UiPath.FTP
             return _sftpClient.Get(path).GetFtpObjectType();
         }
 
-        Task<FtpObjectType> IFtpSession.GetObjectTypeAsync(string path, CancellationToken cancellationToken)
+        Task<UiPath.FTP.FtpObjectType> IFtpSession.GetObjectTypeAsync(string path, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(path))
             {

--- a/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
+++ b/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <Import Project="..\FTP.build.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net6.0-windows</TargetFrameworks>
     <OutputPath>..\..\Output\Activities\FTP\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -13,16 +13,16 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Services" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="UiPath.Workflow" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
     <PackageReference Include="System.Activities.Core.Presentation" />
     <PackageReference Include="UiPath.Workflow" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="37.1.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="FluentFTP" Version="50.1.0" />
+    <PackageReference Include="SSH.NET" Version="2024.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Activities/FTP/UiPath.FTP/packages.config
+++ b/Activities/FTP/UiPath.FTP/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FluentFTP" version="19.1.2" targetFramework="net452" />
-  <package id="SSH.NET" version="2016.1.0" targetFramework="net452" />
-</packages>

--- a/Activities/FTP/azure-pipelines.yml
+++ b/Activities/FTP/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
       projectName: 'FTP'
       solutionPath: '$(SolutionsPath)/Activities.FTP.sln'
       sonarKeyPrefix: 'CommunityActivities'
-      sdkBuild: true
+      sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
 


### PR DESCRIPTION
Upgrade SSH.NET to 2024.0.0
Upgrade FluentFTP to 50.1.0
Small refactoring due to FtpClient being split into synd and async classes, see https://github.com/robinrodricks/FluentFTP/wiki/v40-Migration-Guide 
For now use the sync version of FtpClient (we can check if we need to switch to AsyncFtpClient) 
Update target framework to net6.0 and net6.0-windows
Removed packages-config since is no longer used (because we are using package references  https://learn.microsoft.com/en-us/nuget/reference/packages-config)
Update yml file to build with net6 on the CI