### PR TITLE
Database: Fix SNI.dll loading [STUD-70051]

### DIFF
--- a/Activities/Database/ConnectionDialog/UiPath.Data.ConnectionUI.Dialog/Workaround/DbWorkarounds.cs
+++ b/Activities/Database/ConnectionDialog/UiPath.Data.ConnectionUI.Dialog/Workaround/DbWorkarounds.cs
@@ -29,13 +29,39 @@ namespace UiPath.Data.ConnectionUI.Dialog.Workaround
             if(!isWindows)
                 return;
 
-            IntPtr Handle = LoadLibrary(Path.GetFullPath((typeof(DbWorkarounds).Assembly.CodeBase.Replace("file:///", "")) + RelativePath));
+            var asmLocation = GetAssemblyLocation();
+            var path = Path.GetFullPath(asmLocation + RelativePath);
 
+            IntPtr Handle = LoadLibrary(path);
             if (Handle == IntPtr.Zero)
             {
                 int errorCode = Marshal.GetLastWin32Error();
-                throw new Exception(string.Format("Failed to load library (ErrorCode: {0})", errorCode));
+                string errorMessage = string.Format("Failed to load library {0} (ErrorCode: {1})", path, errorCode);
+                throw new Exception(errorMessage);
             }
         }
+
+#if NETCOREAPP
+        private static string GetAssemblyLocation()
+        {
+            return typeof(DbWorkarounds).Assembly.Location;
+        }
+#else
+        private static string GetAssemblyLocation()
+        {
+            //on legacy still use the Assembly.CodeBase
+            //on legacy Assembly.Location returns the shadow copy location and not the original location (so we won't find the sni dll relative to this path)
+            var codeBase = typeof(DbWorkarounds).Assembly.CodeBase;
+            bool isUNCPath = codeBase.StartsWith("file:////");
+            var adjustdCodeBase = codeBase.Replace("file:///", "");
+            //workaround: if UNC path, we should make sure that it stats with "//" (double) and not "/" (single)
+            //since single "/" means relative path
+            if (isUNCPath && !adjustdCodeBase.StartsWith("//"))
+                adjustdCodeBase = "/" + adjustdCodeBase;
+
+            return adjustdCodeBase;
+        }
+#endif
+
     }
 }


### PR DESCRIPTION
Use Assembly.Location instead of Assembly.CodeBase (since CodeBase is deprecated) 
For UNC path we were parsing incorrectly the file:/// prefix

https://uipath.atlassian.net/browse/STUD-70051