### PR TITLE
[WIP] Database: Fix/database query activities failing parameters conversion from DBNull (71685)

### DIFF
--- a/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
@@ -105,7 +105,14 @@ namespace UiPath.Database.Activities
                     var currentParam = Parameters[param.Key];
                     if (currentParam.Direction == ArgumentDirection.Out || currentParam.Direction == ArgumentDirection.InOut)
                     {
-                        currentParam.Set(asyncCodeActivityContext, param.Value.Value);
+                        if (param.Value.Value != DBNull.Value)
+                        {
+                            currentParam.Set(asyncCodeActivityContext, param.Value.Value);
+                        }
+                        else
+                        {
+                            currentParam.Set(asyncCodeActivityContext, null);
+                        }
                     }
                 }
             };

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -110,7 +110,14 @@ namespace UiPath.Database.Activities
                     var currentParam = Parameters[param.Key];
                     if (currentParam.Direction == ArgumentDirection.Out || currentParam.Direction == ArgumentDirection.InOut)
                     {
-                        currentParam.Set(asyncCodeActivityContext, param.Value.Value);
+                        if (param.Value.Value != DBNull.Value)
+                        {
+                            currentParam.Set(asyncCodeActivityContext, param.Value.Value);
+                        }
+                        else
+                        {
+                            currentParam.Set(asyncCodeActivityContext, null);
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Fixed ExecuteQuery and ExecuteNonQuery throwing an exception when trying to convert the parameter of type DBNull returned by the query:
`A value of type 'System.DBNull' cannot be set to the location with name 'Argument1' because it is a location of type 'System.String'`

https://uipath.atlassian.net/browse/STUD-71685