### PR TITLE
FTP: EnumerateObjects filter (25.8) [STUD-76148]

### DIFF
--- a/Activities/Activities.FTP.sln
+++ b/Activities/Activities.FTP.sln
@@ -15,13 +15,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.FTP.Tests", "FTP\UiP
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3CA460CE-5F36-43C5-AFA0-7B6CCCB94AF6}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets
-		FTP\FTP.build.props = FTP\FTP.build.props
 	EndProjectSection
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared.Activities", "Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.shproj", "{4E20C041-2F59-408E-ADB3-0BCFAB48DE61}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared", "Shared\UiPath.Shared\UiPath.Shared.shproj", "{2E040804-8ED9-4FB8-BB8A-4A38479E2A9E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FTP", "FTP", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		FTP\Directory.build.props = FTP\Directory.build.props
+		FTP\Directory.build.targets = FTP\Directory.build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +58,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {3CA460CE-5F36-43C5-AFA0-7B6CCCB94AF6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5AC55779-EA32-41AD-BAAD-1808F8A412CB}

--- a/Activities/Community.Activities.sln
+++ b/Activities/Community.Activities.sln
@@ -19,7 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.Credentials.Activiti
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FTP", "FTP", "{099CA148-FA0A-44E4-8C8A-CAF7B106897E}"
 	ProjectSection(SolutionItems) = preProject
-		FTP\FTP.build.props = FTP\FTP.build.props
+		FTP\Directory.build.props = FTP\Directory.build.props
+		FTP\Directory.build.targets = FTP\Directory.build.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.FTP", "FTP\UiPath.FTP\UiPath.FTP.csproj", "{E9137637-B657-4C22-85A5-2E30ADF82566}"

--- a/Activities/FTP/Directory.build.props
+++ b/Activities/FTP/Directory.build.props
@@ -1,4 +1,7 @@
 <Project>
+  <!-- Import first the parent targets -->
+  <Import Project="../Directory.build.props" />
+  
   <PropertyGroup>
     <Product>FTP</Product>
     <Authors>UiPath</Authors>

--- a/Activities/FTP/Directory.build.targets
+++ b/Activities/FTP/Directory.build.targets
@@ -1,0 +1,10 @@
+<Project>
+  <!-- Import first the parent targets -->
+  <Import Project="../Directory.build.targets" />
+
+  <ItemGroup>
+    <PackageReference Update="FluentFTP" Version="51.1.0" />
+    <PackageReference Update="SSH.NET" Version="2024.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" ToolsVersion="Current">
-  <Import Project="..\FTP.build.props" />
   <PropertyGroup>
     <TargetFrameworks>$(WindowsFramework)</TargetFrameworks>
     <OutputPath>$(ProjectDir)..\..\Output\Activities\FTP\</OutputPath>
@@ -32,10 +31,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="UiPath.FTP.Activities.Design.nuspec" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="UiPath.Activities.Api"/>
+    <PackageReference Include="UiPath.Activities.Api" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\UiPath.FTP.Activities.Design.Designer.cs">

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/UiPath.FTP.Activities.Packaging.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/UiPath.FTP.Activities.Packaging.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\FTP.build.props" />
   <PropertyGroup>
     <TargetFrameworks>$(PortableFramework);$(WindowsFramework)</TargetFrameworks>
     <OutputPath>..\..\Output\Activities\FTP\</OutputPath>
@@ -31,9 +30,9 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="System.Activities.ViewModels"/>
-    <PackageReference Include="FluentFTP" Version="51.1.0" />
-    <PackageReference Include="SSH.NET" Version="2024.1.0" />
+    <PackageReference Include="System.Activities.ViewModels" />
+    <PackageReference Include="FluentFTP" />
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
 
 	<Target Name="AddDlls">
@@ -46,37 +45,22 @@
 			<BuildOutputInPackage Include="$(OutputPath)UiPath.FTP.dll" />
 			<BuildOutputInPackage Include="$(OutputPath)UiPath.FTP.Activities.dll" />
 
-			<BuildOutputInPackage Include="$(OutputPath)fr\UiPath.FTP.resources.dll" TargetPath="fr\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ja\UiPath.FTP.resources.dll" TargetPath="ja\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ru\UiPath.FTP.resources.dll" TargetPath="ru\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)de\UiPath.FTP.resources.dll" TargetPath="de\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)es\UiPath.FTP.resources.dll" TargetPath="es\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)es-MX\UiPath.FTP.resources.dll" TargetPath="es-MX\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ko\UiPath.FTP.resources.dll" TargetPath="ko\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)pt\UiPath.FTP.resources.dll" TargetPath="pt\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)pt-BR\UiPath.FTP.resources.dll" TargetPath="pt-BR\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)tr\UiPath.FTP.resources.dll" TargetPath="tr\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)zh-CN\UiPath.FTP.resources.dll" TargetPath="zh-CN\UiPath.FTP.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)zh-TW\UiPath.FTP.resources.dll" TargetPath="zh-TW\UiPath.FTP.resources.dll" />
+      <FtpResources Include="$(OutputPath)**\UiPath.FTP.resources.dll" />
+      <BuildOutputInPackage Include="@(FtpResources)">
+        <TargetPath>%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      </BuildOutputInPackage>
 
-			<BuildOutputInPackage Include="$(OutputPath)fr\UiPath.FTP.Activities.resources.dll" TargetPath="fr\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ja\UiPath.FTP.Activities.resources.dll" TargetPath="ja\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ru\UiPath.FTP.Activities.resources.dll" TargetPath="ru\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)de\UiPath.FTP.Activities.resources.dll" TargetPath="de\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)es\UiPath.FTP.Activities.resources.dll" TargetPath="es\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)es-MX\UiPath.FTP.Activities.resources.dll" TargetPath="es-MX\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)ko\UiPath.FTP.Activities.resources.dll" TargetPath="ko\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)pt\UiPath.FTP.Activities.resources.dll" TargetPath="pt\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)pt-BR\UiPath.FTP.Activities.resources.dll" TargetPath="pt-BR\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)tr\UiPath.FTP.Activities.resources.dll" TargetPath="tr\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)zh-CN\UiPath.FTP.Activities.resources.dll" TargetPath="zh-CN\UiPath.FTP.Activities.resources.dll" />
-			<BuildOutputInPackage Include="$(OutputPath)zh-TW\UiPath.FTP.Activities.resources.dll" TargetPath="zh-TW\UiPath.FTP.Activities.resources.dll" />
-
+      <FtpActivitiesResources Include="$(OutputPath)**\UiPath.FTP.Activities.resources.dll" />
+      <BuildOutputInPackage Include="@(FtpActivitiesResources)">
+        <TargetPath>%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      </BuildOutputInPackage>
 		</ItemGroup>
+    
 		<ItemGroup Condition=" '$(TargetFramework)' != '$(PortableFramework)' ">
 			<BuildOutputInPackage Include="$(OutputPath)UiPath.FTP.Activities.Design.dll" />
 		</ItemGroup>
 	</Target>
+  
 	<Target Name="CleanPackageFiles" BeforeTargets="Build">
 		<Message Text="Deleting packages ..." />
 		<ItemGroup>

--- a/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
@@ -28,7 +28,7 @@ namespace UiPath.FTP.Activities
         [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Description))]
         [DefaultValue(FtpFilterObjectType.Directory | FtpFilterObjectType.File)]
-        public FtpFilterObjectType Filter { get; set; } = FtpFilterObjectType.Directory | FtpFilterObjectType.File;
+        public FtpFilterObjectType Filter { get; set; } = FtpFilterObjectType.All;
 
         [LocalizedCategory(nameof(Resources.Output))]
         [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Files_Name))]

--- a/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
@@ -2,10 +2,10 @@
 using System.Activities;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.FTP.Activities.Properties;
-using UiPath.Shared.Activities;
 
 namespace UiPath.FTP.Activities
 {
@@ -24,6 +24,12 @@ namespace UiPath.FTP.Activities
         [LocalizedDescription(nameof(Resources.Activity_EnumerateObjects_Property_Recursive_Description))]
         public bool Recursive { get; set; }
 
+        [LocalizedCategory(nameof(Resources.Options))]
+        [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Description))]
+        [DefaultValue(FtpFilterObjectType.Directory | FtpFilterObjectType.File)]
+        public FtpFilterObjectType Filter { get; set; } = FtpFilterObjectType.Directory | FtpFilterObjectType.File;
+
         [LocalizedCategory(nameof(Resources.Output))]
         [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Files_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EnumerateObjects_Property_Files_Description))]
@@ -40,6 +46,28 @@ namespace UiPath.FTP.Activities
             }
 
             IEnumerable<FtpObjectInfo> files = await ftpSession.EnumerateObjectsAsync(RemotePath.Get(context), Recursive, cancellationToken);
+
+            //Filter the returned objects based on user's selection
+            //If none selected, clear all
+            if (Filter == FtpFilterObjectType.None)
+            {
+                files = Enumerable.Empty<FtpObjectInfo>();
+            }
+            //filter based on what the user selection
+            else if (Filter != FtpFilterObjectType.All)
+            {
+                files = files.Where(x =>
+                {
+                    return x.Type switch
+                    {
+                        FtpObjectType.Directory => (Filter & FtpFilterObjectType.Directory) != 0,
+                        FtpObjectType.File => (Filter & FtpFilterObjectType.File) != 0,
+                        FtpObjectType.Link => (Filter & FtpFilterObjectType.Link) != 0,
+                        FtpObjectType.Other => (Filter & FtpFilterObjectType.Other) != 0,
+                        _ => false,
+                    };
+                });
+            }
 
             return (asyncCodeActivityContext) =>
             {

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/BaseFtpViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/BaseFtpViewModel.cs
@@ -1,21 +1,21 @@
-﻿using System.Activities.DesignViewModels;
+using System.Activities.DesignViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    internal class DeleteViewModel : BaseFtpViewModel
+    internal abstract class BaseFtpViewModel : DesignPropertiesViewModel
     {
         /// <summary>
         /// Basic constructor
         /// </summary>
         /// <param name="services"></param>
-        public DeleteViewModel(IDesignServices services) : base(services)
+        public BaseFtpViewModel(IDesignServices services) : base(services)
         {
         }
 
         /// <summary>
-        /// The path of the file that is to be removed from the FTP server.
+        /// Specifies if the automation should continue even when the activity throws an error.
         /// </summary>
-        public DesignInArgument<string> RemotePath { get; set; }
+        public DesignInArgument<bool> ContinueOnError { get; set; }
 
         protected override void InitializeModel()
         {

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/DirectoryExistsViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/DirectoryExistsViewModel.cs
@@ -1,9 +1,8 @@
 ﻿using System.Activities.DesignViewModels;
-using System.Activities.ViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class DirectoryExistsViewModel : DesignPropertiesViewModel
+    internal class DirectoryExistsViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/DownloadFilesViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/DownloadFilesViewModel.cs
@@ -1,9 +1,8 @@
 ﻿using System.Activities.DesignViewModels;
-using System.Activities.ViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class DownloadFilesViewModel : DesignPropertiesViewModel
+    internal class DownloadFilesViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
@@ -1,12 +1,15 @@
-﻿using System.Activities.DesignViewModels;
+﻿using System;
+using System.Activities.DesignViewModels;
 using System.Activities.ViewModels;
-using System.Threading.Tasks;
-using UiPath.FTP.Activities.NetCore.ViewModels;
-
+using System.Collections.Generic;
+using System.Linq;
+using UiPath.FTP.Activities.Properties;
+using UiPath.Shared;
+using UiPath.Shared.Activities;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class EnumerateObjectsViewModel : DesignPropertiesViewModel
+    internal class EnumerateObjectsViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor
@@ -14,6 +17,7 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         /// <param name="services"></param>
         public EnumerateObjectsViewModel(IDesignServices services) : base(services)
         {
+            InitializeFilterObjectsDataSource();
         }
 
         /// <summary>
@@ -27,9 +31,16 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         public DesignProperty<bool> Recursive { get; set; }
 
         /// <summary>
+        /// Configure what type of objects to filter 
+        /// </summary>
+        public DesignProperty<FtpFilterObjectType> Filter { get; set; }
+
+        /// <summary>
         /// A collection of files that have been found on the FTP server.
         /// </summary>
         public DesignOutArgument<System.Collections.Generic.IEnumerable<FtpObjectInfo>> Files { get; set; }
+
+        private static DataSource<FtpFilterObjectType> _filterObjectDataSource;
 
         protected override void InitializeModel()
         {
@@ -40,9 +51,82 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
 
             RemotePath.OrderIndex = propertyOrderIndex++;
             Files.OrderIndex = propertyOrderIndex++;
-            Recursive.OrderIndex = propertyOrderIndex;
+            Recursive.OrderIndex = propertyOrderIndex++;
+            Filter.OrderIndex = propertyOrderIndex;
 
             Recursive.Widget = new DefaultWidget { Type = ViewModelWidgetType.Toggle };
+            Filter.Widget = new DefaultWidget { Type = ViewModelWidgetType.MultiSelect };
+
+            Filter.DataSource = _filterObjectDataSource;
+        }
+
+        private static void InitializeFilterObjectsDataSource()
+        {
+            if (_filterObjectDataSource is not null)
+            {
+                return;
+            }
+
+            var protocols = Enum.GetValues<FtpFilterObjectType>()
+                .Where(s => s != FtpFilterObjectType.None && s != FtpFilterObjectType.All)
+                .OrderBy(s => s)
+                .ToList();
+
+            _filterObjectDataSource = DataSourceBuilder<FtpFilterObjectType>
+                .WithId(s => Enum.GetName(s))
+                .WithLabel(s => GetFtpFilterObjectTypeLabel(s))
+                .WithMultipleSelection<FtpFilterObjectType>(
+                    selectionToValue: s =>
+                    {
+                        if (s.Count == 0)
+                        {
+                            return FtpFilterObjectType.None;
+                        }
+
+                        return s.Aggregate((a, b) => a | b);
+                    },
+                    valueToSelection: s => Decompose(s).ToArray()
+                    )
+                .WithData(protocols)
+                .Build();
+        }
+
+        private static List<FtpFilterObjectType> Decompose(FtpFilterObjectType value)
+        {
+            var bits = EnumExtensions<FtpFilterObjectType>.Decompose(value);
+            return bits;
+        }
+
+        // gets the value of a localized enum and appends Obsolete if necessary
+        private static string GetFtpFilterObjectTypeLabel(FtpFilterObjectType value)
+        {
+            List<string> labels = new();
+            foreach (var flag in Decompose(value))
+            {
+                labels.Add(GetFilteObjectTypeFlagLabel(flag));
+            }
+
+            return string.Join(" | ", labels);
+        }
+
+        /// <summary>
+        /// Returns the localized name of an enum flag (i.e. a single enum value, not a combination).
+        ///  Localized names of obsolete values are marked appropriately.
+        /// </summary>
+        /// <param name="flag"></param>
+        /// <returns>The localized name</returns>
+        private static string GetFilteObjectTypeFlagLabel(FtpFilterObjectType flag)
+        {
+            var localizedName = LocalizedEnum.GetLocalizedValue(typeof(FtpFilterObjectType), flag).Name;
+
+            // get the attributes of the enum value
+            var field = typeof(FtpFilterObjectType).GetField(flag.ToString());
+            if (field.GetCustomAttributesData().Any(a => a.AttributeType == typeof(ObsoleteAttribute)))
+            {
+                return string.Format(Resources.ObsoleteEnumValue, localizedName);
+            }
+
+            return localizedName;
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
@@ -103,7 +103,7 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
             List<string> labels = new();
             foreach (var flag in Decompose(value))
             {
-                labels.Add(GetFilteObjectTypeFlagLabel(flag));
+                labels.Add(GetFilterObjectTypeFlagLabel(flag));
             }
 
             return string.Join(" | ", labels);
@@ -115,7 +115,7 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         /// </summary>
         /// <param name="flag"></param>
         /// <returns>The localized name</returns>
-        private static string GetFilteObjectTypeFlagLabel(FtpFilterObjectType flag)
+        private static string GetFilterObjectTypeFlagLabel(FtpFilterObjectType flag)
         {
             var localizedName = LocalizedEnum.GetLocalizedValue(typeof(FtpFilterObjectType), flag).Name;
 

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/FileExistsViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/FileExistsViewModel.cs
@@ -1,9 +1,8 @@
 ﻿using System.Activities.DesignViewModels;
-using System.Activities.ViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class FileExistsViewModel : DesignPropertiesViewModel
+    internal class FileExistsViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/MoveItemViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/MoveItemViewModel.cs
@@ -3,7 +3,7 @@ using System.Activities.ViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class MoveItemViewModel : DesignPropertiesViewModel
+    internal class MoveItemViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor
@@ -27,11 +27,6 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         /// If this box is checked, the files will be overwritten in the new remote directory if they're already stored there.
         /// </summary>
         public DesignProperty<bool> Overwrite { get; set; }
-
-        /// <summary>
-        /// Specifies if the automation should continue even when the activity throws an error.
-        /// </summary>
-        public DesignInArgument<bool> ContinueOnError { get; set; }
 
         protected override void InitializeModel()
         {

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/UploadFilesViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/UploadFilesViewModel.cs
@@ -1,9 +1,8 @@
 ﻿using System.Activities.DesignViewModels;
-using System.Activities.ViewModels;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class UploadFilesViewModel : DesignPropertiesViewModel
+    internal class UploadFilesViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/WithFtpSessionViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/WithFtpSessionViewModel.cs
@@ -11,7 +11,7 @@ using UiPath.Shared.Activities;
 
 namespace UiPath.FTP.Activities.NetCore.ViewModels
 {
-    public partial class WithFtpSessionViewModel : DesignPropertiesViewModel
+    internal class WithFtpSessionViewModel : BaseFtpViewModel
     {
         /// <summary>
         /// Basic constructor
@@ -96,11 +96,6 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         /// If this box is checked, all certificates will be accepted, including the ones that are expired or not verified.
         /// </summary>
         public DesignProperty<bool> AcceptAllCertificates { get; set; }
-
-        /// <summary>
-        /// Specifies if the automation should continue even when the activity throws an error.
-        /// </summary>
-        public DesignInArgument<bool> ContinueOnError { get; set; }
 
         /// <summary>
         /// The type of proxy used

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/AssemblyInfo.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Markup;
 
@@ -14,3 +15,5 @@ using System.Windows.Markup;
 // The following GUID is for the ID of the typelib if this project is exposed to COM.
 
 [assembly: Guid("fdfc92ee-090c-4e23-9422-f90eb94c43dd")]
+
+[assembly: InternalsVisibleTo("UiPath.FTP.Tests")]

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -304,6 +304,33 @@ namespace UiPath.FTP.Activities.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filters items based on type (what is selected will be included).
+        /// </summary>
+        public static string Activity_EnumerateObjects_Property_Filter_Description {
+            get {
+                return ResourceManager.GetString("Activity_EnumerateObjects_Property_Filter_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Object types.
+        /// </summary>
+        public static string Activity_EnumerateObjects_Property_Filter_Name {
+            get {
+                return ResourceManager.GetString("Activity_EnumerateObjects_Property_Filter_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select object types to include.
+        /// </summary>
+        public static string Activity_EnumerateObjects_Property_Filter_Placeholder {
+            get {
+                return ResourceManager.GetString("Activity_EnumerateObjects_Property_Filter_Placeholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If this check box is selected, the subfolders are also included in the enumeration of the files on the FTP server..
         /// </summary>
         public static string Activity_EnumerateObjects_Property_Recursive_Description {

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -766,4 +766,15 @@
   <data name="Activity_WithFtpSession_Property_ProxySecurePassword_Name" xml:space="preserve">
     <value>Proxy Secure Password</value>
   </data>
+  <data name="Activity_EnumerateObjects_Property_Filter_Description" xml:space="preserve">
+    <value>Filters items based on type (what is selected will be included)</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_EnumerateObjects_Property_Filter_Name" xml:space="preserve">
+    <value>Object types</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_EnumerateObjects_Property_Filter_Placeholder" xml:space="preserve">
+    <value>Select object types to include</value>
+  </data>
 </root>

--- a/Activities/FTP/UiPath.FTP.Activities/Resources/ActivitiesMetadata.json
+++ b/Activities/FTP/UiPath.FTP.Activities/Resources/ActivitiesMetadata.json
@@ -18,6 +18,17 @@
           "Category": {
             "DisplayNameKey": "Input"
           }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
+          }
         }
       ],
       "ViewModelType": "UiPath.FTP.Activities.NetCore.ViewModels.DeleteViewModel"
@@ -38,6 +49,17 @@
           "IsVisible": true,
           "Category": {
             "DisplayNameKey": "Input"
+          }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
           }
         },
         {
@@ -115,6 +137,17 @@
           "Category": {
             "DisplayNameKey": "Category_Others_Name"
           }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
+          }
         }
       ],
       "ViewModelType": "UiPath.FTP.Activities.NetCore.ViewModels.DownloadFilesViewModel"
@@ -141,6 +174,29 @@
           "Name": "Recursive",
           "DisplayNameKey": "Activity_EnumerateObjects_Property_Recursive_Name",
           "TooltipKey": "Activity_EnumerateObjects_Property_Recursive_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
+          }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
+          }
+        },
+        {
+          "Name": "Filter",
+          "DisplayNameKey": "Activity_EnumerateObjects_Property_Filter_Name",
+          "TooltipKey": "Activity_EnumerateObjects_Property_Filter_Description",
+          "placeholderKey": "Activity_EnumerateObjects_Property_Filter_Placeholder",
           "IsRequired": false,
           "IsPrincipal": false,
           "IsVisible": true,
@@ -178,6 +234,17 @@
           "IsVisible": true,
           "Category": {
             "DisplayNameKey": "Category_Principal_Name"
+          }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
           }
         },
         {
@@ -303,6 +370,17 @@
           "Name": "Overwrite",
           "DisplayNameKey": "Activity_UploadFiles_Property_Overwrite_Name",
           "TooltipKey": "Activity_UploadFiles_Property_Overwrite_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "DisplayNameKey": "Category_Others_Name"
+          }
+        },
+        {
+          "Name": "ContinueOnError",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_ContinueOnError_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_ContinueOnError_Description",
           "IsRequired": false,
           "IsPrincipal": false,
           "IsVisible": true,

--- a/Activities/FTP/UiPath.FTP.Activities/UiPath.FTP.Activities.csproj
+++ b/Activities/FTP/UiPath.FTP.Activities/UiPath.FTP.Activities.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
-  <Import Project="..\FTP.build.props" />
   <PropertyGroup>
     <PackageId>.noconflict</PackageId>
     <TargetFrameworks>$(PortableFramework);$(WindowsFramework)</TargetFrameworks>
@@ -17,14 +16,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\ActivitiesMetadata.json" />
-    <EmbeddedResource Include="Resources\Icons\Delete_file_or_folder.svg" />
-    <EmbeddedResource Include="Resources\Icons\Download_files.svg" />
-    <EmbeddedResource Include="Resources\Icons\File_exists.svg" />
-    <EmbeddedResource Include="Resources\Icons\Folder_exists.svg" />
-    <EmbeddedResource Include="Resources\Icons\FTP_Connection.svg" />
-    <EmbeddedResource Include="Resources\Icons\Get_files.svg" />
-    <EmbeddedResource Include="Resources\Icons\Move_file_or_folder.svg" />
-    <EmbeddedResource Include="Resources\Icons\Upload_files.svg" />
+    <EmbeddedResource Include="Resources\Icons\*.svg" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UiPath.FTP\UiPath.FTP.csproj">
@@ -50,6 +42,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-  	<InternalsVisibleTo Include="UiPath.FTP.Activities.Design" />
+    <InternalsVisibleTo Include="UiPath.FTP.Activities.Design" />
   </ItemGroup>
 </Project>

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -19,6 +19,8 @@ namespace UiPath.FTP.Activities
     {
         private IFtpSession _ftpSession;
 
+        private readonly IFtpSession _setFtpSession; //used for unittests
+
         public static readonly string FtpSessionPropertyName = "FtpSession";
 
         [Browsable(false)]
@@ -161,6 +163,11 @@ namespace UiPath.FTP.Activities
             };
         }
 
+        internal WithFtpSession(IFtpSession setFtpSession): this()
+        {
+            _setFtpSession = setFtpSession;
+        }
+
         protected override void CacheMetadata(NativeActivityMetadata metadata)
         {
             base.CacheMetadata(metadata);
@@ -172,8 +179,6 @@ namespace UiPath.FTP.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
-            IFtpSession ftpSession = null;
-
             string passwordValue = Password.Get(context);
             SecureString securePasswordValue = SecurePassword.Get(context);
             string clientCertificatePasswordValue = ClientCertificatePassword.Get(context);
@@ -229,13 +234,14 @@ namespace UiPath.FTP.Activities
                 }
             }
 
+            IFtpSession ftpSession = _setFtpSession;
             if (UseSftp)
             {
-                ftpSession = new SftpSession(ftpConfiguration);
+                ftpSession ??= new SftpSession(ftpConfiguration);
             }
             else
             {
-                ftpSession = new FtpSession(ftpConfiguration, FtpsMode);
+                ftpSession ??= new FtpSession(ftpConfiguration, FtpsMode);
             }
 
             await ftpSession.OpenAsync(cancellationToken);
@@ -263,11 +269,8 @@ namespace UiPath.FTP.Activities
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
-            PropertyDescriptor ftpSessionProperty = faultContext.DataContext.GetProperties()[WithFtpSession.FtpSessionPropertyName];
-            IFtpSession ftpSession = ftpSessionProperty?.GetValue(faultContext.DataContext) as IFtpSession;
-
-            ftpSession?.Close();
-            ftpSession?.Dispose();
+            _ftpSession?.Close();
+            _ftpSession?.Dispose();
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/EnumerateObjectsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/EnumerateObjectsTests.cs
@@ -1,0 +1,110 @@
+﻿using Moq;
+using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UiPath.FTP.Activities;
+using Xunit;
+
+namespace UiPath.FTP.Tests.ActivitiesTests
+{
+    public class EnumerateObjectsTests
+    {
+        [Theory]
+        [InlineData(FtpFilterObjectType.None)]
+        [InlineData(FtpFilterObjectType.All)]
+        [InlineData(FtpFilterObjectType.Directory)]
+        [InlineData(FtpFilterObjectType.File)]
+        [InlineData(FtpFilterObjectType.Other)]
+        [InlineData(FtpFilterObjectType.Directory | FtpFilterObjectType.File)]
+        public void EnumerateObjects_FilterTests(FtpFilterObjectType filter)
+        {
+            var session = new Mock<IFtpSession>();
+            SetupFtpMock();
+
+            //the actual files returned
+            var files = new List<FtpObjectInfo>();
+
+            var filesVariable = new Variable<IEnumerable<FtpObjectInfo>>();
+            var activity = new WithFtpSession(session.Object)
+            {
+                Host = new InArgument<string>("SomeHost"),
+                Username = new InArgument<string>("SomeUsername"),
+                Password = new InArgument<string>("SomePassword"),
+            };
+
+            if (activity.Body.Handler is Sequence mainSeq)
+            {
+                mainSeq.Variables.Add(filesVariable);
+                var enumerateObjects = new EnumerateObjects()
+                {
+                    RemotePath = new InArgument<string>("."),
+                    Filter = filter,
+                    Files = new OutArgument<IEnumerable<FtpObjectInfo>>(filesVariable)
+                };
+                mainSeq.Activities.Add(enumerateObjects);
+                //Do some trick here to retrieve the list of items returned
+                mainSeq.Activities.Add(new InvokeMethod()
+                {
+                    TargetType = typeof(TestsHelper),
+                    MethodName = nameof(TestsHelper.CopyObjects),
+                    Parameters =
+                    {
+                        new InArgument<IEnumerable<FtpObjectInfo>>(ctx => filesVariable.Get(ctx)),
+                        new InArgument<IList<FtpObjectInfo>>(ctx => files),
+                    }
+                });
+            }
+
+            var res = WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
+
+            Verify();
+
+            void Verify()
+            {
+                if ((filter & FtpFilterObjectType.Directory) != 0)
+                    Assert.Equal(4, files.Where(x => x.Type == FtpObjectType.Directory).ToList().Count());
+                else
+                    Assert.Empty(files.Where(x => x.Type == FtpObjectType.Directory).ToList());
+                
+                if ((filter & FtpFilterObjectType.File) != 0)
+                    Assert.Equal(3, files.Where(x => x.Type == FtpObjectType.File).Count());
+                else
+                    Assert.Empty(files.Where(x => x.Type == FtpObjectType.File).ToList());
+                
+                if ((filter & FtpFilterObjectType.Link) != 0)
+                    Assert.Equal(2, files.Where(x => x.Type == FtpObjectType.Link).Count());
+                else
+                    Assert.Empty(files.Where(x => x.Type == FtpObjectType.Link).ToList());
+
+                if ((filter & FtpFilterObjectType.Other) != 0)
+                    Assert.Single(files, x => x.Type == FtpObjectType.Other);
+                else
+                    Assert.Empty(files.Where(x => x.Type == FtpObjectType.Other).ToList());
+            }
+
+            void SetupFtpMock()
+            {
+                IEnumerable<FtpObjectInfo> lstObjects = new FtpObjectInfo[]
+                {
+                    new FtpObjectInfo() {Name = "Directory1", Type = FtpObjectType.Directory},
+                    new FtpObjectInfo() {Name = "Directory2", Type = FtpObjectType.Directory},
+                    new FtpObjectInfo() {Name = "Directory3", Type = FtpObjectType.Directory},
+                    new FtpObjectInfo() {Name = "Directory4", Type = FtpObjectType.Directory},
+                    new FtpObjectInfo() {Name = "File1", Type = FtpObjectType.File},
+                    new FtpObjectInfo() {Name = "File2", Type = FtpObjectType.File},
+                    new FtpObjectInfo() {Name = "File3", Type = FtpObjectType.File},
+                    new FtpObjectInfo() {Name = "Link1", Type = FtpObjectType.Link},
+                    new FtpObjectInfo() {Name = "Link2", Type = FtpObjectType.Link},
+                    new FtpObjectInfo() {Name = "Other1", Type = FtpObjectType.Other},
+                };
+
+                var resultTask = Task.FromResult(lstObjects);
+                session.Setup(a => a.EnumerateObjectsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(resultTask);
+            }
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/WithFtpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/WithFtpSessionTests.cs
@@ -1,0 +1,31 @@
+﻿using Moq;
+using System;
+using System.Activities;
+using System.Threading;
+using UiPath.FTP.Activities;
+using Xunit;
+
+namespace UiPath.FTP.Tests
+{
+    public class WithFtpSessionTests
+    {
+        [Fact]
+        public void WithFtpSession_MainScenarioTests()
+        {
+            var session = new Mock<IFtpSession>();
+            var activity = new WithFtpSession(session.Object)
+            {
+                Host = new InArgument<string>("NonUsed"),
+                Username = new InArgument<string>("NonUsed"),
+                Password = new InArgument<string>("NonUsed"),
+            };
+
+            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
+
+            //Check that connection and disposig API was called properly
+            session.Verify(a => a.OpenAsync(It.IsAny<CancellationToken>()), Times.Once);
+            session.Verify(a => a.Close(), Times.Once);
+            session.Verify(a => a.Dispose(), Times.Once);
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Xunit;
+
+namespace UiPath.FTP.Tests
+{
+    public class FtpSessionTests
+    {
+        [Fact]
+        public void FTP_TestConnect()
+        {
+            //Maybe to initialize a in-memory FTP Server using FubarDev.FtpServer??
+            IFtpSession session = new FtpSession(new FtpConfiguration("ToThrow"), default);
+            Assert.ThrowsAny<Exception>(session.Open);
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Xunit;
+
+namespace UiPath.FTP.Tests
+{
+    public class SftpSessionTests
+    {
+        [Fact]
+        public void SFTP_TestConnect()
+        {
+            IFtpSession session = new SftpSession(new FtpConfiguration("ToThrow") {Username = "Some", Password = "NotUsed", Host = "Some"});
+            Assert.ThrowsAny<Exception>(session.Open);
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/TestsHelper.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/TestsHelper.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace UiPath.FTP.Tests
+{
+    public class TestsHelper
+    {
+        //Used in order to retrieve the value of an out argument from a child (it needs to be public)
+        public static void CopyObjects(IEnumerable<FtpObjectInfo> lstObjects, IList<FtpObjectInfo> newObjects)
+        {
+            newObjects.Clear();
+            foreach (var obj in lstObjects)
+                newObjects.Add(obj);
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/UiPath.FTP.Tests.csproj
+++ b/Activities/FTP/UiPath.FTP.Tests/UiPath.FTP.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{D35ADF63-DD01-476A-8D15-CD3FB412AE5D}</ProjectGuid>
-    <TargetFrameworks>$(WindowsFramework)</TargetFrameworks>
+    <TargetFrameworks>$(PortableFramework);$(WindowsFramework)</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyTitle>UiPath.FTP.Tests</AssemblyTitle>
@@ -19,8 +19,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="UiPath.Activities.Api" PrivateAssets="All" />
+    <PackageReference Include="UiPath.Workflow" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(WindowsFramework)' ">
+    <PackageReference Include="System.Activities.Core.Presentation" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UiPath.FTP.Activities\UiPath.FTP.Activities.csproj" />
+    <ProjectReference Include="..\UiPath.FTP\UiPath.FTP.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="SessionsTests\" />
   </ItemGroup>
 
 </Project>

--- a/Activities/FTP/UiPath.FTP/Extensions.cs
+++ b/Activities/FTP/UiPath.FTP/Extensions.cs
@@ -52,7 +52,7 @@ namespace UiPath.FTP
                 case FluentFTP.FtpObjectType.Link:
                     return UiPath.FTP.FtpObjectType.Link;
                 default:
-                    throw new NotSupportedException(Resources.UnsupportedObjectTypeException);
+                    return UiPath.FTP.FtpObjectType.Other;
             }
         }
 
@@ -76,7 +76,7 @@ namespace UiPath.FTP
                 return UiPath.FTP.FtpObjectType.Link;
             }
 
-            throw new NotSupportedException(Resources.UnsupportedObjectTypeException);
+            return UiPath.FTP.FtpObjectType.Other;
         }
 
         public static FtpPermissions ToFtpPermissions(this FtpPermission ftpPermission)

--- a/Activities/FTP/UiPath.FTP/FtpObjectType.cs
+++ b/Activities/FTP/UiPath.FTP/FtpObjectType.cs
@@ -1,9 +1,23 @@
-﻿namespace UiPath.FTP
+﻿using System;
+
+namespace UiPath.FTP
 {
     public enum FtpObjectType
     {
         Directory,
         File,
-        Link
+        Link,
+        Other //named pipe, device, etc.
+    }
+
+    [Flags]
+    public enum FtpFilterObjectType
+    {
+        None = 0,
+        Directory = 1 << 0,
+        File = 1 << 1,
+        Link = 1 << 2,
+        Other = 1 << 3,
+        All = Directory | File | Link | Other
     }
 }

--- a/Activities/FTP/UiPath.FTP/FtpSession.cs
+++ b/Activities/FTP/UiPath.FTP/FtpSession.cs
@@ -85,7 +85,7 @@ namespace UiPath.FTP
 
             if (ftpsMode != FtpsMode.None)
             {
-                _ftpClient.Config.SslProtocols = (SslProtocols)ftpConfiguration.SslProtocols; //viorel -> to review
+                _ftpClient.Config.SslProtocols = (SslProtocols)ftpConfiguration.SslProtocols;
                 _ftpClient.ValidateCertificate += (control, e) => _ftpClient_ValidateCertificate(control as FtpClient, e, ftpConfiguration.AcceptAllCertificates);
 
                 if (string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath) == false)

--- a/Activities/FTP/UiPath.FTP/Properties/AssemblyInfo.cs
+++ b/Activities/FTP/UiPath.FTP/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Markup;
 
@@ -12,3 +13,4 @@ using System.Windows.Markup;
 // The following GUID is for the ID of the typelib if this project is exposed to COM.
 
 [assembly: Guid("e9137637-b657-4c22-85a5-2e30adf82566")]
+

--- a/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
+++ b/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
-  <Import Project="..\FTP.build.props" />
   <PropertyGroup>
     <TargetFrameworks>$(PortableFramework);$(WindowsFramework)</TargetFrameworks>
     <OutputPath>..\..\Output\Activities\FTP\</OutputPath>
@@ -12,8 +11,8 @@
     <PackageReference Include="UiPath.Workflow" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="51.1.0" />
-    <PackageReference Include="SSH.NET" Version="2024.1.0" />
+    <PackageReference Include="FluentFTP" />
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Move package versions to props and targets files
Add specific Directory.build.props
Add specific Directory.build.targets
Add missing Continue on error property for all FTP activities (it was hidden by mistake when moving to viewmodels) Add filter property for EnumerateObjects
Cleanup package project
Add unittests


https://uipath.atlassian.net/browse/STUD-76148

<img width="1520" height="802" alt="image" src="https://github.com/user-attachments/assets/34096e20-b8be-46db-8ac3-6b1e010df18d" />

<img width="1450" height="636" alt="image" src="https://github.com/user-attachments/assets/7685ff0c-2570-4812-9780-fe8720e75506" />
