### PR TITLE
FTP: EnumerateObjects filter (25.8) [STUD-76148]

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/EnumerateObjects.cs
@@ -27,8 +27,8 @@ namespace UiPath.FTP.Activities
         [LocalizedCategory(nameof(Resources.Options))]
         [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EnumerateObjects_Property_Filter_Description))]
-        [DefaultValue(FtpFilterObjectType.Directory | FtpFilterObjectType.File)]
-        public FtpFilterObjectType Filter { get; set; } = FtpFilterObjectType.All;
+        [DefaultValue(FtpFilterObjectType.Directory | FtpFilterObjectType.File | FtpFilterObjectType.Link | FtpFilterObjectType.Other)]
+        public FtpFilterObjectType Filter { get; set; } = FtpFilterObjectType.Directory | FtpFilterObjectType.File | FtpFilterObjectType.Link | FtpFilterObjectType.Other;
 
         [LocalizedCategory(nameof(Resources.Output))]
         [LocalizedDisplayName(nameof(Resources.Activity_EnumerateObjects_Property_Files_Name))]
@@ -54,16 +54,20 @@ namespace UiPath.FTP.Activities
                 files = Enumerable.Empty<FtpObjectInfo>();
             }
             //filter based on what the user selection
-            else if (Filter != FtpFilterObjectType.All)
+            else if (Filter != (FtpFilterObjectType.Directory | FtpFilterObjectType.File | FtpFilterObjectType.Link | FtpFilterObjectType.Other))
             {
+                bool includeDirectories = (Filter & FtpFilterObjectType.Directory) != 0;
+                bool includeFiles = (Filter & FtpFilterObjectType.File) != 0;
+                bool includeLinks = (Filter & FtpFilterObjectType.Link) != 0;
+                bool includeOthers = (Filter & FtpFilterObjectType.Other) != 0;
                 files = files.Where(x =>
                 {
                     return x.Type switch
                     {
-                        FtpObjectType.Directory => (Filter & FtpFilterObjectType.Directory) != 0,
-                        FtpObjectType.File => (Filter & FtpFilterObjectType.File) != 0,
-                        FtpObjectType.Link => (Filter & FtpFilterObjectType.Link) != 0,
-                        FtpObjectType.Other => (Filter & FtpFilterObjectType.Other) != 0,
+                        FtpObjectType.Directory => includeDirectories,
+                        FtpObjectType.File => includeFiles,
+                        FtpObjectType.Link => includeLinks,
+                        FtpObjectType.Other => includeOthers,
                         _ => false,
                     };
                 });

--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/EnumerateObjectsViewModel.cs
@@ -67,8 +67,8 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
                 return;
             }
 
-            var protocols = Enum.GetValues<FtpFilterObjectType>()
-                .Where(s => s != FtpFilterObjectType.None && s != FtpFilterObjectType.All)
+            var objectTypes = Enum.GetValues<FtpFilterObjectType>()
+                .Where(s => s != FtpFilterObjectType.None)
                 .OrderBy(s => s)
                 .ToList();
 
@@ -87,7 +87,7 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
                     },
                     valueToSelection: s => Decompose(s).ToArray()
                     )
-                .WithData(protocols)
+                .WithData(objectTypes)
                 .Build();
         }
 

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/EnumerateObjectsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/EnumerateObjectsTests.cs
@@ -15,11 +15,11 @@ namespace UiPath.FTP.Tests.ActivitiesTests
     {
         [Theory]
         [InlineData(FtpFilterObjectType.None)]
-        [InlineData(FtpFilterObjectType.All)]
         [InlineData(FtpFilterObjectType.Directory)]
         [InlineData(FtpFilterObjectType.File)]
         [InlineData(FtpFilterObjectType.Other)]
         [InlineData(FtpFilterObjectType.Directory | FtpFilterObjectType.File)]
+        [InlineData(FtpFilterObjectType.Directory | FtpFilterObjectType.File | FtpFilterObjectType.Link | FtpFilterObjectType.Other)]
         public void EnumerateObjects_FilterTests(FtpFilterObjectType filter)
         {
             var session = new Mock<IFtpSession>();
@@ -105,6 +105,13 @@ namespace UiPath.FTP.Tests.ActivitiesTests
                 var resultTask = Task.FromResult(lstObjects);
                 session.Setup(a => a.EnumerateObjectsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(resultTask);
             }
+        }
+
+        //If the filters will change, make sure to adjust the activity also
+        [Fact]
+        public void TestFilterOptions_EnumValues()
+        {
+            Assert.Equal(5, Enum.GetValues(typeof(FtpFilterObjectType)).Length);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP/FtpObjectType.cs
+++ b/Activities/FTP/UiPath.FTP/FtpObjectType.cs
@@ -18,6 +18,5 @@ namespace UiPath.FTP
         File = 1 << 1,
         Link = 1 << 2,
         Other = 1 << 3,
-        All = Directory | File | Link | Other
     }
 }


### PR DESCRIPTION
Make sure that every value in the enum has only 1 bit set
Update unitetst

https://uipath.atlassian.net/browse/STUD-76148

EnumeExtensions.Decompose doesn't work as expected if a value of an enum flags is aggregated. 
The user shouldn't be impacted since the option (All) was hidden for the user anyway.