### PR TITLE
Refactor telemetry and session handling in WithFtpSession

### DIFF
--- a/Activities/Activities.FTP.sln
+++ b/Activities/Activities.FTP.sln
@@ -69,6 +69,9 @@ Global
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{2e040804-8ed9-4fb8-bb8a-4a38479e2a9e}*SharedItemsImports = 13
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{4e20c041-2f59-408e-adb3-0bcfab48de61}*SharedItemsImports = 13
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Contracts.Private\UiPath.Shared.Contracts.Private.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Contracts\UiPath.Shared.Contracts.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Telemetry\UiPath.Shared.Telemetry.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 5
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -23,7 +23,6 @@ namespace UiPath.FTP.Activities
         private IFtpSession _ftpSession;
 
         private readonly IFtpSession _setFtpSession; //used for unittests
-        private ITelemetryOperationWrapper _telemetryOperation;
 
         public static readonly string FtpSessionPropertyName = "FtpSession";
 
@@ -183,8 +182,10 @@ namespace UiPath.FTP.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+
 #if ENABLE_DEFAULT_TELEMETRY
-            _telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
             try
             {
@@ -260,13 +261,13 @@ namespace UiPath.FTP.Activities
                         nativeActivityContext.ScheduleAction(Body, ftpSession, OnCompleted, OnFaulted);
                     }
                     else
-                        _telemetryOperation?.Send();
+                        telemetryOperation?.Send();
                 });
                 return result;
             }
             catch (Exception ex)
             {
-                _telemetryOperation?.SendWithException(ex);
+                telemetryOperation?.SendWithException(ex);
                 throw;
             }
 
@@ -279,14 +280,26 @@ namespace UiPath.FTP.Activities
 
             _ftpSession.Close();
             _ftpSession.Dispose();
-            _telemetryOperation?.Send();
+
+            ITelemetryOperationWrapper telemetryOperation = null;
+
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+            telemetryOperation?.Send();
         }
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
             _ftpSession?.Close();
             _ftpSession?.Dispose();
-            _telemetryOperation?.SendWithException(propagatedException);
+
+            ITelemetryOperationWrapper telemetryOperation = null;
+
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+#endif
+            telemetryOperation?.SendWithException(propagatedException);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -250,14 +250,15 @@ namespace UiPath.FTP.Activities
                 else
                     ftpSession ??= new FtpSession(ftpConfiguration, FtpsMode);
 
-                _ftpSession = ftpSession;
-
                 await ftpSession.OpenAsync(cancellationToken);
 
                 var result = new Action<NativeActivityContext>(nativeActivityContext =>
                 {
                     if (Body != null)
+                    {
+                        _ftpSession = ftpSession;
                         nativeActivityContext.ScheduleAction(Body, ftpSession, OnCompleted, OnFaulted);
+                    }
                     else
                         _telemetryOperation?.Send();
                 });

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -258,6 +258,8 @@ namespace UiPath.FTP.Activities
                 {
                     if (Body != null)
                         nativeActivityContext.ScheduleAction(Body, ftpSession, OnCompleted, OnFaulted);
+                    else
+                        _telemetryOperation?.Send();
                 });
                 return result;
             }

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -10,7 +10,6 @@ using UiPath.FTP.Enums;
 using System.Security;
 using System.Net;
 using System.Activities.Validation;
-using UiPath.Shared.Activities;
 #if ENABLE_DEFAULT_TELEMETRY
 using UiPath.Shared.Telemetry.Services;
 #endif
@@ -24,6 +23,7 @@ namespace UiPath.FTP.Activities
         private IFtpSession _ftpSession;
 
         private readonly IFtpSession _setFtpSession; //used for unittests
+        private ITelemetryOperationWrapper _telemetryOperation;
 
         public static readonly string FtpSessionPropertyName = "FtpSession";
 
@@ -183,9 +183,8 @@ namespace UiPath.FTP.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
-            ITelemetryOperationWrapper telemetryOperation = null;
 #if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            _telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
             try
             {
@@ -245,31 +244,26 @@ namespace UiPath.FTP.Activities
                 }
 
                 IFtpSession ftpSession = _setFtpSession;
+
                 if (UseSftp)
-                {
                     ftpSession ??= new SftpSession(ftpConfiguration);
-                }
                 else
-                {
                     ftpSession ??= new FtpSession(ftpConfiguration, FtpsMode);
-                }
+
+                _ftpSession = ftpSession;
 
                 await ftpSession.OpenAsync(cancellationToken);
 
                 var result = new Action<NativeActivityContext>(nativeActivityContext =>
                 {
                     if (Body != null)
-                    {
-                        _ftpSession = ftpSession;
                         nativeActivityContext.ScheduleAction(Body, ftpSession, OnCompleted, OnFaulted);
-                    }
                 });
-                telemetryOperation?.Send();
                 return result;
             }
             catch (Exception ex)
             {
-                telemetryOperation?.SendWithException(ex);
+                _telemetryOperation?.SendWithException(ex);
                 throw;
             }
 
@@ -278,18 +272,18 @@ namespace UiPath.FTP.Activities
         private void OnCompleted(NativeActivityContext context, ActivityInstance completedInstance)
         {
             if (_ftpSession == null)
-            {
                 throw new InvalidOperationException(Resources.FTPSessionNotFoundException);
-            }
 
             _ftpSession.Close();
             _ftpSession.Dispose();
+            _telemetryOperation?.Send();
         }
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
             _ftpSession?.Close();
             _ftpSession?.Dispose();
+            _telemetryOperation?.SendWithException(propagatedException);
         }
     }
 }


### PR DESCRIPTION
• Removed premature _telemetryOperation.Send() from ExecuteAsync to avoid duplicate success reporting (now only on completion).
• Assigned _ftpSession immediately after session creation (before OpenAsync) to ensure availability for fault cleanup.
• Adjusted scheduling to use existing _ftpSession without reassign inside delegate. No functional logic changed beyond telemetry flow and lifecycle handling.