### PR TITLE
Refactor Java activity execution and telemetry

### DIFF
--- a/Activities/Activities.Java.sln
+++ b/Activities/Activities.Java.sln
@@ -67,6 +67,9 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Shared\UiPath.Shared.Activities.Design\UiPath.Shared.Activities.Design.projitems*{5e102b9e-dcef-4d8b-8a02-3fdf0fcc0d59}*SharedItemsImports = 5
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{7747a478-8986-4a56-8342-093752fc07c3}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Contracts.Private\UiPath.Shared.Contracts.Private.projitems*{7747a478-8986-4a56-8342-093752fc07c3}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Contracts\UiPath.Shared.Contracts.projitems*{7747a478-8986-4a56-8342-093752fc07c3}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Telemetry\UiPath.Shared.Telemetry.projitems*{7747a478-8986-4a56-8342-093752fc07c3}*SharedItemsImports = 5
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{7747a478-8986-4a56-8342-093752fc07c3}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/Activities/Java/UiPath.Java.Activities/CreateJavaObject.cs
+++ b/Activities/Java/UiPath.Java.Activities/CreateJavaObject.cs
@@ -35,39 +35,34 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
+
+            IInvoker invoker = JavaScope.GetJavaInvoker(context);
+            var className = TargetType.Get(context);
+            if (string.IsNullOrWhiteSpace(className))
+            {
+                throw new ArgumentNullException(nameof(TargetType));
+            }
+            List<object> parameters = GetParameters(context);
+            var types = GetParameterTypes(context, parameters);
+            JavaObject instance = null;
             try
             {
-                IInvoker invoker = JavaScope.GetJavaInvoker(context);
-                var className = TargetType.Get(context);
-                if (string.IsNullOrWhiteSpace(className))
-                {
-                    throw new ArgumentNullException(nameof(TargetType));
-                }
-                List<object> parameters = GetParameters(context);
-                var types = GetParameterTypes(context, parameters);
-                JavaObject instance = null;
-                try
-                {
-                    instance = await invoker.InvokeConstructor(className, parameters, types, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    Trace.TraceError($"Constrcutor could not be invoker: {e}");
-                    throw new InvalidOperationException(Resources.ConstructorException, e);
-                }
-
-                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
-                {
-                    Result.Set(asyncCodeActivityContext, instance);
-                });
+                instance = await invoker.InvokeConstructor(className, parameters, types, cancellationToken);
                 telemetryOperation?.Send();
-                return result;
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                telemetryOperation?.SendWithException(ex);
-                throw;
+                telemetryOperation?.SendWithException(e);
+                Trace.TraceError($"Constructor could not be invoked: {e}");
+                throw new InvalidOperationException(Resources.ConstructorException, e);
             }
+
+            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+            {
+                Result.Set(asyncCodeActivityContext, instance);
+            });
+                
+            return result;
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/CreateJavaObject.cs
+++ b/Activities/Java/UiPath.Java.Activities/CreateJavaObject.cs
@@ -35,34 +35,39 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
-
-            IInvoker invoker = JavaScope.GetJavaInvoker(context);
-            var className = TargetType.Get(context);
-            if (string.IsNullOrWhiteSpace(className))
-            {
-                throw new ArgumentNullException(nameof(TargetType));
-            }
-            List<object> parameters = GetParameters(context);
-            var types = GetParameterTypes(context, parameters);
-            JavaObject instance = null;
             try
             {
-                instance = await invoker.InvokeConstructor(className, parameters, types, cancellationToken);
-                telemetryOperation?.Send();
-            }
-            catch (Exception e)
-            {
-                telemetryOperation?.SendWithException(e);
-                Trace.TraceError($"Constructor could not be invoked: {e}");
-                throw new InvalidOperationException(Resources.ConstructorException, e);
-            }
+                IInvoker invoker = JavaScope.GetJavaInvoker(context);
+                var className = TargetType.Get(context);
+                if (string.IsNullOrWhiteSpace(className))
+                    throw new ArgumentNullException(nameof(TargetType));
 
-            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                List<object> parameters = GetParameters(context);
+                var types = GetParameterTypes(context, parameters);
+                JavaObject instance = null;
+                try
+                {
+                    instance = await invoker.InvokeConstructor(className, parameters, types, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    Trace.TraceError($"Constructor could not be invoked: {e}");
+                    throw new InvalidOperationException(Resources.ConstructorException, e);
+                }
+
+                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                {
+                    Result.Set(asyncCodeActivityContext, instance);
+                });
+
+                telemetryOperation?.Send();
+                return result;
+            }
+            catch (Exception ex)
             {
-                Result.Set(asyncCodeActivityContext, instance);
-            });
-                
-            return result;
+                telemetryOperation?.SendWithException(ex);
+                throw;
+            }
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/GetJavaField.cs
+++ b/Activities/Java/UiPath.Java.Activities/GetJavaField.cs
@@ -45,36 +45,40 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
-
-            IInvoker invoker = JavaScope.GetJavaInvoker(context);
-            var fieldName = FieldName.Get(context) ?? throw new ArgumentNullException(Resources.FieldName);
-            var javaObject = TargetObject.Get(context);
-            var className = TargetType.Get(context);
-
-            if (javaObject == null && className == null)
-            {
-                throw new InvalidOperationException(Resources.InvokationObjectException);
-            }
-
-            JavaObject instance;
             try
             {
-                instance = await invoker.InvokeGetField(javaObject, fieldName, className, cancellationToken);
-                telemetryOperation?.Send();
-            }
-            catch (Exception e)
-            {
-                telemetryOperation?.SendWithException(e);
-                Trace.TraceError($"Could not get java field: {e}");
-                throw new InvalidOperationException(Resources.GetFieldException, e);
-            }
+                IInvoker invoker = JavaScope.GetJavaInvoker(context);
+                var fieldName = FieldName.Get(context) ?? throw new ArgumentNullException(Resources.FieldName);
+                var javaObject = TargetObject.Get(context);
+                var className = TargetType.Get(context);
 
-            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                if (javaObject == null && className == null)
+                    throw new InvalidOperationException(Resources.InvokationObjectException);
+
+                JavaObject instance;
+                try
+                {
+                    instance = await invoker.InvokeGetField(javaObject, fieldName, className, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    Trace.TraceError($"Could not get java field: {e}");
+                    throw new InvalidOperationException(Resources.GetFieldException, e);
+                }
+
+                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                {
+                    Result.Set(asyncCodeActivityContext, instance);
+                });
+
+                telemetryOperation?.Send();
+                return result;
+            }
+            catch (Exception ex)
             {
-                Result.Set(asyncCodeActivityContext, instance);
-            });
-                
-            return result;
+                telemetryOperation?.SendWithException(ex);
+                throw;
+            }
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/GetJavaField.cs
+++ b/Activities/Java/UiPath.Java.Activities/GetJavaField.cs
@@ -45,42 +45,36 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
+
+            IInvoker invoker = JavaScope.GetJavaInvoker(context);
+            var fieldName = FieldName.Get(context) ?? throw new ArgumentNullException(Resources.FieldName);
+            var javaObject = TargetObject.Get(context);
+            var className = TargetType.Get(context);
+
+            if (javaObject == null && className == null)
+            {
+                throw new InvalidOperationException(Resources.InvokationObjectException);
+            }
+
+            JavaObject instance;
             try
             {
-                IInvoker invoker = JavaScope.GetJavaInvoker(context);
-                var fieldName = FieldName.Get(context) ?? throw new ArgumentNullException(Resources.FieldName);
-                var javaObject = TargetObject.Get(context);
-                var className = TargetType.Get(context);
-
-                if (javaObject == null && className == null)
-                {
-                    throw new InvalidOperationException(Resources.InvokationObjectException);
-                }
-
-                JavaObject instance;
-                try
-                {
-                    instance = await invoker.InvokeGetField(javaObject, fieldName, className, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    telemetryOperation?.SendWithException(e);
-                    Trace.TraceError($"Could not get java field: {e}");
-                    throw new InvalidOperationException(Resources.GetFieldException, e);
-                }
-
-                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
-                {
-                    Result.Set(asyncCodeActivityContext, instance);
-                });
+                instance = await invoker.InvokeGetField(javaObject, fieldName, className, cancellationToken);
                 telemetryOperation?.Send();
-                return result;
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                telemetryOperation?.SendWithException(ex);
-                throw;
+                telemetryOperation?.SendWithException(e);
+                Trace.TraceError($"Could not get java field: {e}");
+                throw new InvalidOperationException(Resources.GetFieldException, e);
             }
+
+            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+            {
+                Result.Set(asyncCodeActivityContext, instance);
+            });
+                
+            return result;
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/InvokeJavaMethod.cs
+++ b/Activities/Java/UiPath.Java.Activities/InvokeJavaMethod.cs
@@ -49,44 +49,38 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
+
+            IInvoker invoker = JavaScope.GetJavaInvoker(context);
+            var methodName = MethodName.Get(context) ?? throw new ArgumentNullException(Resources.MethodName);
+            JavaObject javaObject = TargetObject.Get(context);
+            string className = TargetType.Get(context);
+
+            if (javaObject == null && string.IsNullOrWhiteSpace(className))
+            {
+                throw new InvalidOperationException(Resources.InvokationObjectException);
+            }
+
+            List<object> parameters = GetParameters(context);
+            var types = GetParameterTypes(context, parameters);
+            JavaObject instance = null;
+
             try
             {
-                IInvoker invoker = JavaScope.GetJavaInvoker(context);
-                var methodName = MethodName.Get(context) ?? throw new ArgumentNullException(Resources.MethodName);
-                JavaObject javaObject = TargetObject.Get(context);
-                string className = TargetType.Get(context);
-
-                if (javaObject == null && string.IsNullOrWhiteSpace(className))
-                {
-                    throw new InvalidOperationException(Resources.InvokationObjectException);
-                }
-
-                List<object> parameters = GetParameters(context);
-                var types = GetParameterTypes(context, parameters);
-                JavaObject instance = null;
-
-                try
-                {
-                    instance = await invoker.InvokeMethod(methodName, className, javaObject, parameters, types, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    telemetryOperation?.SendWithException(e);
-                    Trace.TraceError($"The method could not be invoked: {e}");
-                    throw new InvalidOperationException(Resources.InvokeMethodException, e);
-                }
-                var result = new Action<AsyncCodeActivityContext> (asyncCodeActivityContext =>
-                {
-                    Result.Set(asyncCodeActivityContext, instance);
-                });
+                instance = await invoker.InvokeMethod(methodName, className, javaObject, parameters, types, cancellationToken);
                 telemetryOperation?.Send();
-                return result; 
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                telemetryOperation?.SendWithException(ex);
-                throw;
+                telemetryOperation?.SendWithException(e);
+                Trace.TraceError($"The method could not be invoked: {e}");
+                throw new InvalidOperationException(Resources.InvokeMethodException, e);
             }
+            var result = new Action<AsyncCodeActivityContext> (asyncCodeActivityContext =>
+            {
+                Result.Set(asyncCodeActivityContext, instance);
+            });
+                
+            return result;
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/InvokeJavaMethod.cs
+++ b/Activities/Java/UiPath.Java.Activities/InvokeJavaMethod.cs
@@ -49,38 +49,43 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
-
-            IInvoker invoker = JavaScope.GetJavaInvoker(context);
-            var methodName = MethodName.Get(context) ?? throw new ArgumentNullException(Resources.MethodName);
-            JavaObject javaObject = TargetObject.Get(context);
-            string className = TargetType.Get(context);
-
-            if (javaObject == null && string.IsNullOrWhiteSpace(className))
-            {
-                throw new InvalidOperationException(Resources.InvokationObjectException);
-            }
-
-            List<object> parameters = GetParameters(context);
-            var types = GetParameterTypes(context, parameters);
-            JavaObject instance = null;
-
             try
             {
-                instance = await invoker.InvokeMethod(methodName, className, javaObject, parameters, types, cancellationToken);
+                IInvoker invoker = JavaScope.GetJavaInvoker(context);
+                var methodName = MethodName.Get(context) ?? throw new ArgumentNullException(Resources.MethodName);
+
+                JavaObject javaObject = TargetObject.Get(context);
+                string className = TargetType.Get(context);
+
+                if (javaObject == null && string.IsNullOrWhiteSpace(className))
+                    throw new InvalidOperationException(Resources.InvokationObjectException);
+
+                List<object> parameters = GetParameters(context);
+                var types = GetParameterTypes(context, parameters);
+                JavaObject instance = null;
+
+                try
+                {
+                    instance = await invoker.InvokeMethod(methodName, className, javaObject, parameters, types, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    Trace.TraceError($"The method could not be invoked: {e}");
+                    throw new InvalidOperationException(Resources.InvokeMethodException, e);
+                }
+                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                {
+                    Result.Set(asyncCodeActivityContext, instance);
+                });
+
                 telemetryOperation?.Send();
+                return result;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                telemetryOperation?.SendWithException(e);
-                Trace.TraceError($"The method could not be invoked: {e}");
-                throw new InvalidOperationException(Resources.InvokeMethodException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw;
             }
-            var result = new Action<AsyncCodeActivityContext> (asyncCodeActivityContext =>
-            {
-                Result.Set(asyncCodeActivityContext, instance);
-            });
-                
-            return result;
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/JavaScope.cs
+++ b/Activities/Java/UiPath.Java.Activities/JavaScope.cs
@@ -64,10 +64,6 @@ namespace UiPath.Java.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken ct)
         {
-            ITelemetryOperationWrapper telemetryOperation = null;
-#if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
-#endif
             try
             {
                 string javaPath = JavaPath.Get(context);
@@ -111,7 +107,10 @@ namespace UiPath.Java.Activities
             }
             catch (Exception ex)
             {
+#if ENABLE_DEFAULT_TELEMETRY
+                ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
                 telemetryOperation?.SendWithException(ex);
+#endif
                 throw;
             }
         }

--- a/Activities/Java/UiPath.Java.Activities/JavaScope.cs
+++ b/Activities/Java/UiPath.Java.Activities/JavaScope.cs
@@ -98,7 +98,6 @@ namespace UiPath.Java.Activities
                 }
                 catch (Exception e)
                 {
-                    telemetryOperation?.SendWithException(e);
                     Trace.TraceError($"Error initializing Java Invoker: {e}");
                     throw new InvalidOperationException(string.Format(Resources.JavaInitiazeException, e.ToString()));
                 }
@@ -107,7 +106,7 @@ namespace UiPath.Java.Activities
                 {
                     ctx.ScheduleAction(Body, _invoker, OnCompleted, OnFaulted);
                 });
-                telemetryOperation?.Send();
+                
                 return result;
             }
             catch (Exception ex)
@@ -119,13 +118,23 @@ namespace UiPath.Java.Activities
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+#endif
             faultContext.CancelChildren();
             Clean().DoNotAwait();
+            telemetryOperation?.SendWithException(propagatedException);
         }
 
         private void OnCompleted(NativeActivityContext context, ActivityInstance completedInstance)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
             Clean().DoNotAwait();
+            telemetryOperation?.Send();
         }
 
         protected override void Cancel(NativeActivityContext context)

--- a/Activities/Java/UiPath.Java.Activities/JavaScope.cs
+++ b/Activities/Java/UiPath.Java.Activities/JavaScope.cs
@@ -118,23 +118,21 @@ namespace UiPath.Java.Activities
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
-            ITelemetryOperationWrapper telemetryOperation = null;
 #if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+            telemetryOperation?.SendWithException(propagatedException);
 #endif
             faultContext.CancelChildren();
             Clean().DoNotAwait();
-            telemetryOperation?.SendWithException(propagatedException);
         }
 
         private void OnCompleted(NativeActivityContext context, ActivityInstance completedInstance)
         {
-            ITelemetryOperationWrapper telemetryOperation = null;
 #if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            telemetryOperation?.Send();
 #endif
             Clean().DoNotAwait();
-            telemetryOperation?.Send();
         }
 
         protected override void Cancel(NativeActivityContext context)

--- a/Activities/Java/UiPath.Java.Activities/LoadJar.cs
+++ b/Activities/Java/UiPath.Java.Activities/LoadJar.cs
@@ -28,26 +28,32 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
-
-            IInvoker invoker = JavaScope.GetJavaInvoker(context);
-            var jarPath = JarPath.Get(context) ?? throw new ArgumentNullException(Resources.JarPathDisplayName);
             try
             {
-                await invoker.LoadJar(jarPath, cancellationToken);
+                IInvoker invoker = JavaScope.GetJavaInvoker(context);
+                var jarPath = JarPath.Get(context) ?? throw new ArgumentNullException(Resources.JarPathDisplayName);
+                try
+                {
+                    await invoker.LoadJar(jarPath, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    Trace.TraceError($"Jar could not be loaded: {e}");
+                    throw new InvalidOperationException(Resources.LoadJarException, e);
+                }
+                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+                {
+                    // No OutArgument
+                });
+
                 telemetryOperation?.Send();
+                return result;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                telemetryOperation?.SendWithException(e);
-                Trace.TraceError($"Jar could not be loaded: {e}");
-                throw new InvalidOperationException(Resources.LoadJarException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw;
             }
-            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
-            {
-                // No OutArgument
-            });
-                
-            return result;
         }
     }
 }

--- a/Activities/Java/UiPath.Java.Activities/LoadJar.cs
+++ b/Activities/Java/UiPath.Java.Activities/LoadJar.cs
@@ -28,32 +28,26 @@ namespace UiPath.Java.Activities
 #if ENABLE_DEFAULT_TELEMETRY
             telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
 #endif
+
+            IInvoker invoker = JavaScope.GetJavaInvoker(context);
+            var jarPath = JarPath.Get(context) ?? throw new ArgumentNullException(Resources.JarPathDisplayName);
             try
             {
-                IInvoker invoker = JavaScope.GetJavaInvoker(context);
-                var jarPath = JarPath.Get(context) ?? throw new ArgumentNullException(Resources.JarPathDisplayName);
-                try
-                {
-                    await invoker.LoadJar(jarPath, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    telemetryOperation?.SendWithException(e);
-                    Trace.TraceError($"Jar could not be loaded{e}");
-                    throw new InvalidOperationException(Resources.LoadJarException, e);
-                }
-                var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
-                {
-                    // No OutArgument
-                });
+                await invoker.LoadJar(jarPath, cancellationToken);
                 telemetryOperation?.Send();
-                return result;
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                telemetryOperation?.SendWithException(ex);
-                throw;
+                telemetryOperation?.SendWithException(e);
+                Trace.TraceError($"Jar could not be loaded: {e}");
+                throw new InvalidOperationException(Resources.LoadJarException, e);
             }
+            var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
+            {
+                // No OutArgument
+            });
+                
+            return result;
         }
     }
 }


### PR DESCRIPTION
Refactored Java activity files to improve code structure by moving variable initializations outside of try blocks. This change affects `CreateJavaObject.cs`, `GetJavaField.cs`, `InvokeJavaMethod.cs`, and `LoadJar.cs`, ensuring that only method invocations are within try-catch blocks. Additionally, telemetry operations are now consistently sent after method invocations. Updated `JavaScope.cs` to handle telemetry operations in `OnFaulted` and `OnCompleted` methods. Added new shared project items to `Activities.Java.sln`.