### PR TITLE
Add telemetry support to Python activities

### DIFF
--- a/Activities/Activities.Python.sln
+++ b/Activities/Activities.Python.sln
@@ -90,6 +90,7 @@ Global
 		Shared\UiPath.Shared.Service\UiPath.Shared.Service.projitems*{bcba78df-1513-44d3-83b3-37655a7f3887}*SharedItemsImports = 5
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{bcba78df-1513-44d3-83b3-37655a7f3887}*SharedItemsImports = 5
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{e270608b-ba9e-4972-a18e-34b93e6552b4}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Telemetry\UiPath.Shared.Telemetry.projitems*{e270608b-ba9e-4972-a18e-34b93e6552b4}*SharedItemsImports = 5
 		Shared\UiPath.Shared\UiPath.Shared.projitems*{e270608b-ba9e-4972-a18e-34b93e6552b4}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/Activities/Python/UiPath.Python.Activities/GetObject.cs
+++ b/Activities/Python/UiPath.Python.Activities/GetObject.cs
@@ -2,6 +2,10 @@
 using System.Activities;
 using System.Diagnostics;
 using UiPath.Python.Activities.Properties;
+using UiPath.Shared.Activities;
+#if ENABLE_DEFAULT_TELEMETRY
+using UiPath.Shared.Telemetry.Services;
+#endif
 
 namespace UiPath.Python.Activities
 {
@@ -25,22 +29,32 @@ namespace UiPath.Python.Activities
 
         protected override void Execute(CodeActivityContext context)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             IEngine pythonEngine = PythonScope.GetPythonEngine(context);
             PythonObject pyObject = PythonObject.Get(context);
             if (null == pyObject)
             {
-                throw new ArgumentNullException(nameof(PythonObject));
+                var ex = new ArgumentNullException(nameof(PythonObject));
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             T result;
             try
             {
                 result = (T)pythonEngine.Convert(pyObject, typeof(T));
+                telemetryOperation?.Send();
             }
             catch (Exception e)
             {
                 Trace.TraceError($"Error casting Python object: {e}");
-                throw new InvalidOperationException(Resources.ConvertException, e);
+                var ex = new InvalidOperationException(Resources.ConvertException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             Result.Set(context, result);

--- a/Activities/Python/UiPath.Python.Activities/InvokeMethod.cs
+++ b/Activities/Python/UiPath.Python.Activities/InvokeMethod.cs
@@ -6,6 +6,11 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.Python.Activities.Properties;
+using UiPath.Shared.Activities;
+
+#if ENABLE_DEFAULT_TELEMETRY
+using UiPath.Shared.Telemetry.Services;
+#endif
 
 namespace UiPath.Python.Activities
 {
@@ -40,10 +45,17 @@ namespace UiPath.Python.Activities
 
         protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             IEngine pythonEngine = PythonScope.GetPythonEngine(context);
             if (pythonEngine == null)
             {
-                throw new InvalidOperationException(Resources.PythonEngineNotFoundException);
+                var ex = new InvalidOperationException(Resources.PythonEngineNotFoundException);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             PythonObject pyObject = Instance.Get(context);
@@ -53,18 +65,23 @@ namespace UiPath.Python.Activities
             // safeguard checks
             if (methodName.IsNullOrEmpty())
             {
-                throw new InvalidOperationException(Resources.InvalidMethodNameException);
+                var ex = new InvalidOperationException(Resources.InvalidMethodNameException);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             PythonObject result = null;
             try
             {
                 result = await pythonEngine.InvokeMethod(pyObject, methodName, parameters, cancellationToken);
+                telemetryOperation?.Send();
             }
             catch (Exception e)
             {
                 Trace.TraceError($"Error invoking Python function: {e}");
-                throw new InvalidOperationException(Resources.InvokeException, e);
+                var ex = new InvalidOperationException(Resources.InvokeException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             return asyncCodeActivityContext =>

--- a/Activities/Python/UiPath.Python.Activities/LoadScript.cs
+++ b/Activities/Python/UiPath.Python.Activities/LoadScript.cs
@@ -6,6 +6,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.Python.Activities.Properties;
+using UiPath.Shared.Activities;
+#if ENABLE_DEFAULT_TELEMETRY
+using UiPath.Shared.Telemetry.Services;
+#endif
 
 namespace UiPath.Python.Activities
 {
@@ -37,6 +41,11 @@ namespace UiPath.Python.Activities
 
         protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             IEngine pythonEngine = PythonScope.GetPythonEngine(context);
 
             string scriptFile = ScriptFile.Get(context);
@@ -45,11 +54,15 @@ namespace UiPath.Python.Activities
             // safeguard checks
             if (scriptFile.IsNullOrEmpty() && scriptCode.IsNullOrEmpty())
             {
-                throw new InvalidOperationException(Resources.NoScriptSpecifiedException);
+                var ex = new InvalidOperationException(Resources.NoScriptSpecifiedException);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
             if (!scriptFile.IsNullOrEmpty() && !File.Exists(scriptFile))
             {
-                throw new FileNotFoundException(Resources.ScriptFileNotFoundException, scriptFile);
+                var ex = new FileNotFoundException(Resources.ScriptFileNotFoundException, scriptFile);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             // load script from file if not specified
@@ -62,11 +75,14 @@ namespace UiPath.Python.Activities
             try
             {
                 result = await pythonEngine.LoadScript(scriptCode, cancellationToken);
+                telemetryOperation?.Send();
             }
             catch (Exception e)
             {
                 Trace.TraceError($"Error loading Python script: {e}");
-                throw new InvalidOperationException(Resources.LoadScriptException, e);
+                var ex = new InvalidOperationException(Resources.LoadScriptException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             return (asyncCodeActivityContext) =>

--- a/Activities/Python/UiPath.Python.Activities/PythonScope.cs
+++ b/Activities/Python/UiPath.Python.Activities/PythonScope.cs
@@ -9,6 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using UiPath.Python.Activities.Properties;
 using UiPath.Shared.Activities;
+#if ENABLE_DEFAULT_TELEMETRY
+using UiPath.Shared.Telemetry.Services;
+#endif
 
 namespace UiPath.Python.Activities
 {
@@ -106,11 +109,18 @@ namespace UiPath.Python.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             string path = Path.Get(context);
             string libraryPath = LibraryPath.Get(context);
             if (!path.IsNullOrEmpty() && !Directory.Exists(path))
             {
-                throw new DirectoryNotFoundException(string.Format(Resources.InvalidPathException, path));
+                var ex = new DirectoryNotFoundException(string.Format(Resources.InvalidPathException, path));
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -118,7 +128,23 @@ namespace UiPath.Python.Activities
             _pythonEngine = EngineProvider.Get(Version, path, libraryPath, !Isolated, TargetPlatform, ShowConsole);
 
             if (_pythonEngine.Version == Version.Python_310 && TargetPlatform == TargetPlatform.x86)
-                throw new InvalidOperationException(Resources.ValidationErrorPlatformUnsupported);
+            {
+                var ex = new InvalidOperationException(Resources.ValidationErrorPlatformUnsupported);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
+            }
+
+            if (Version != Version.Auto)
+            {
+                Version autodetected = Version.Auto;
+                EngineProvider.Autodetect(path, out autodetected);
+                if (autodetected != Version.Auto && autodetected != Version)
+                {
+                    var ex = new InvalidOperationException(string.Format(Resources.InvalidVersionException, Version.ToFriendlyString(), autodetected.ToFriendlyString()));
+                    telemetryOperation?.SendWithException(ex);
+                    throw ex;
+                }
+            }
 
             var workingFolder = WorkingFolder.Get(context);
             if (!workingFolder.IsNullOrEmpty())
@@ -126,7 +152,9 @@ namespace UiPath.Python.Activities
                 var dir = new DirectoryInfo(workingFolder);
                 if (!dir.Exists)
                 {
-                    throw new DirectoryNotFoundException(Resources.WorkingFolderPathInvalid);
+                    var ex = new DirectoryNotFoundException(Resources.WorkingFolderPathInvalid);
+                    telemetryOperation?.SendWithException(ex);
+                    throw ex;
                 }
                 workingFolder = dir.FullName; //we need to pass an absolute path to the python host
             }
@@ -143,20 +171,21 @@ namespace UiPath.Python.Activities
             }
             catch (Exception e)
             {
-                Trace.TraceError($"Error initializing Python engine: {e.ToString()}");
+                Trace.TraceError($"Error initializing Python engine: {e}");
+                Exception cleanupEx = null;
                 try
                 {
                     Cleanup();
                 }
-                catch (Exception) { }
-                if (Version != Version.Auto)
+                catch (Exception cEx)
                 {
-                    Version autodetected = Version.Auto;
-                    EngineProvider.Autodetect(path, out autodetected);
-                    if (autodetected != Version.Auto && autodetected != Version)
-                        throw new InvalidOperationException(string.Format(Resources.InvalidVersionException, Version.ToFriendlyString(), autodetected.ToFriendlyString()));
+                    cleanupEx = cEx;
                 }
-                throw new InvalidOperationException(Resources.PythonInitializeException, e);
+
+                var innerEx = cleanupEx != null ? new AggregateException(e, cleanupEx) : e;
+                var ex = new InvalidOperationException(Resources.PythonInitializeException, innerEx);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -169,12 +198,20 @@ namespace UiPath.Python.Activities
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
+#if ENABLE_DEFAULT_TELEMETRY
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+            telemetryOperation?.SendWithException(propagatedException);
+#endif
             faultContext.CancelChildren();
             Cleanup();
         }
 
         private void OnCompleted(NativeActivityContext context, ActivityInstance completedInstance)
         {
+#if ENABLE_DEFAULT_TELEMETRY
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            telemetryOperation?.Send();
+#endif
             Cleanup();
         }
 

--- a/Activities/Python/UiPath.Python.Activities/RunScript.cs
+++ b/Activities/Python/UiPath.Python.Activities/RunScript.cs
@@ -6,6 +6,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.Python.Activities.Properties;
+using UiPath.Shared.Activities;
+#if ENABLE_DEFAULT_TELEMETRY
+using UiPath.Shared.Telemetry.Services;
+#endif
 
 namespace UiPath.Python.Activities
 {
@@ -32,6 +36,11 @@ namespace UiPath.Python.Activities
 
         protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             IEngine pythonEngine = PythonScope.GetPythonEngine(context);
 
             string scriptFile = ScriptFile.Get(context);
@@ -41,11 +50,15 @@ namespace UiPath.Python.Activities
             // safeguard checks
             if (scriptFile.IsNullOrEmpty() && scriptCode.IsNullOrEmpty())
             {
-                throw new InvalidOperationException(Resources.NoScriptSpecifiedException);
+                var ex = new InvalidOperationException(Resources.NoScriptSpecifiedException);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
             if (!scriptFile.IsNullOrEmpty() && !File.Exists(scriptFile))
             {
-                throw new FileNotFoundException(Resources.ScriptFileNotFoundException, scriptFile);
+                var ex = new FileNotFoundException(Resources.ScriptFileNotFoundException, scriptFile);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             // load script from file if not specified
@@ -57,11 +70,14 @@ namespace UiPath.Python.Activities
             try
             {
                 await pythonEngine.Execute(scriptCode, cancellationToken);
+                telemetryOperation?.Send();
             }
             catch (Exception e)
             {
                 Trace.TraceError($"Error running Python script: {e}");
-                throw new InvalidOperationException(Resources.RunScriptException, e);
+                var ex = new InvalidOperationException(Resources.RunScriptException, e);
+                telemetryOperation?.SendWithException(ex);
+                throw ex;
             }
 
             return (asyncCodeActivityContext) =>

--- a/Activities/Python/UiPath.Python.Activities/UiPath.Python.Activities.csproj
+++ b/Activities/Python/UiPath.Python.Activities/UiPath.Python.Activities.csproj
@@ -43,4 +43,6 @@
       <DependentUpon>UiPath.Python.Activities.resx</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Import Project="..\..\Shared\UiPath.Shared.Telemetry\UiPath.Shared.Telemetry.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
Integrate `UiPath.Shared.Telemetry` service to enable telemetry functionality in UiPath Python activities. Telemetry operations are conditionally included using `#if ENABLE_DEFAULT_TELEMETRY` directives. Enhance exception handling to capture and send exceptions to the telemetry service before re-throwing. Update `UiPath.Python.Activities.csproj` to import telemetry project items, and modify the solution file to include telemetry components. Ensure telemetry data is sent only when the `ENABLE_DEFAULT_TELEMETRY` flag is defined.