### PR TITLE
Refactor telemetry handling and resource cleanup

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -182,6 +182,11 @@ namespace UiPath.FTP.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
+            ITelemetryOperationWrapper telemetryOperation = null;
+#if ENABLE_DEFAULT_TELEMETRY
+            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+#endif
+
             try
             {
                 string passwordValue = Password.Get(context);
@@ -260,11 +265,7 @@ namespace UiPath.FTP.Activities
             }
             catch (Exception ex)
             {
-#if ENABLE_DEFAULT_TELEMETRY
-                ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
                 telemetryOperation?.SendWithException(ex);
-#endif
-
                 throw;
             }
 

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -182,11 +182,6 @@ namespace UiPath.FTP.Activities
 
         protected override async Task<Action<NativeActivityContext>> ExecuteAsync(NativeActivityContext context, CancellationToken cancellationToken)
         {
-            ITelemetryOperationWrapper telemetryOperation = null;
-
-#if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
-#endif
             try
             {
                 string passwordValue = Password.Get(context);
@@ -260,14 +255,16 @@ namespace UiPath.FTP.Activities
                         _ftpSession = ftpSession;
                         nativeActivityContext.ScheduleAction(Body, ftpSession, OnCompleted, OnFaulted);
                     }
-                    else
-                        telemetryOperation?.Send();
                 });
                 return result;
             }
             catch (Exception ex)
             {
+#if ENABLE_DEFAULT_TELEMETRY
+                ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
                 telemetryOperation?.SendWithException(ex);
+#endif
+
                 throw;
             }
 
@@ -275,31 +272,27 @@ namespace UiPath.FTP.Activities
 
         private void OnCompleted(NativeActivityContext context, ActivityInstance completedInstance)
         {
+#if ENABLE_DEFAULT_TELEMETRY
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
+            telemetryOperation?.Send();
+#endif
+
             if (_ftpSession == null)
                 throw new InvalidOperationException(Resources.FTPSessionNotFoundException);
 
             _ftpSession.Close();
             _ftpSession.Dispose();
-
-            ITelemetryOperationWrapper telemetryOperation = null;
-
-#if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, context);
-#endif
-            telemetryOperation?.Send();
         }
 
         private void OnFaulted(NativeActivityFaultContext faultContext, Exception propagatedException, ActivityInstance propagatedFrom)
         {
+#if ENABLE_DEFAULT_TELEMETRY
+            ITelemetryOperationWrapper telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
+            telemetryOperation?.SendWithException(propagatedException);
+#endif
+
             _ftpSession?.Close();
             _ftpSession?.Dispose();
-
-            ITelemetryOperationWrapper telemetryOperation = null;
-
-#if ENABLE_DEFAULT_TELEMETRY
-            telemetryOperation = RuntimeTelemetryService.CreateExecutionOperation(this, faultContext);
-#endif
-            telemetryOperation?.SendWithException(propagatedException);
         }
     }
 }


### PR DESCRIPTION
Refactored telemetry operation handling in `ExecuteAsync`, `OnCompleted`, and `OnFaulted` methods to improve consistency and maintainability. Introduced conditional compilation (`#if ENABLE_DEFAULT_TELEMETRY`) for telemetry operations, reducing redundant code. Ensured proper sequencing of telemetry operations and resource cleanup (`_ftpSession.Close()` and `_ftpSession.Dispose()`) in all relevant methods.