### PR TITLE
Add timeout property to FTP Scope activity

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/WithFtpSessionViewModel.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/NetCore/ViewModels/WithFtpSessionViewModel.cs
@@ -34,6 +34,11 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
         public DesignInArgument<int> Port { get; set; }
 
         /// <summary>
+        /// The connection timeout in milliseconds.
+        /// </summary>
+        public DesignInArgument<int> Timeout { get; set; }
+
+        /// <summary>
         /// The username that will be used to connect to the FTP server.
         /// </summary>
         public DesignInArgument<string> Username { get; set; }
@@ -149,6 +154,7 @@ namespace UiPath.FTP.Activities.NetCore.ViewModels
             Password.OrderIndex = propertyOrderIndex++;
             SecurePassword.OrderIndex = propertyOrderIndex++;
             Port.OrderIndex = propertyOrderIndex++;
+            Timeout.OrderIndex = propertyOrderIndex++;
             UseAnonymousLogin.OrderIndex = propertyOrderIndex++;
             ContinueOnError.OrderIndex = propertyOrderIndex++;
             AcceptAllCertificates.OrderIndex = propertyOrderIndex++;

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -997,7 +997,7 @@ namespace UiPath.FTP.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The timeout value (in milliseconds) for the FTP connection. If not set, the default timeout of the underlying library is used..
+        ///   Looks up a localized string similar to The timeout value (in milliseconds) for the FTP/SFTP connection. If not set, the default timeout of the underlying library is used..
         /// </summary>
         public static string Activity_WithFtpSession_Property_Timeout_Description {
             get {

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -997,6 +997,24 @@ namespace UiPath.FTP.Activities.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The timeout value (in milliseconds) for the FTP connection. If not set, the default timeout of the underlying library is used..
+        /// </summary>
+        public static string Activity_WithFtpSession_Property_Timeout_Description {
+            get {
+                return ResourceManager.GetString("Activity_WithFtpSession_Property_Timeout_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Timeout (milliseconds).
+        /// </summary>
+        public static string Activity_WithFtpSession_Property_Timeout_Name {
+            get {
+                return ResourceManager.GetString("Activity_WithFtpSession_Property_Timeout_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to When this box is checked, the username and password fields are ignored, and a standard anonymous user is used instead..
         /// </summary>
         public static string Activity_WithFtpSession_Property_UseAnonymousLogin_Description {

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -1267,6 +1267,15 @@ namespace UiPath.FTP.Activities.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Timeout must be greater than or equal to 0..
+        /// </summary>
+        public static string InvalidTimeoutException {
+            get {
+                return ResourceManager.GetString("InvalidTimeoutException", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Username cannot be empty..
         /// </summary>
         public static string EmptyUsernameException {

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -541,7 +541,7 @@
     <comment>Property description</comment>
   </data>
   <data name="Activity_WithFtpSession_Property_Timeout_Description" xml:space="preserve">
-    <value>The timeout value (in milliseconds) for the FTP connection. If not set, the default timeout of the underlying library is used.</value>
+    <value>The timeout value (in milliseconds) for the FTP/SFTP connection. If not set, the default timeout of the underlying library is used.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_WithFtpSession_Property_Timeout_Name" xml:space="preserve">

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -540,6 +540,14 @@
     <value>Select the SSL protocol to be used for the FTPS connection</value>
     <comment>Property description</comment>
   </data>
+  <data name="Activity_WithFtpSession_Property_Timeout_Description" xml:space="preserve">
+    <value>The timeout value (in milliseconds) for the FTP connection. If not set, the default timeout of the underlying library is used.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_WithFtpSession_Property_Timeout_Name" xml:space="preserve">
+    <value>Timeout (milliseconds)</value>
+    <comment>Property name</comment>
+  </data>
   <data name="Activity_WithFtpSession_Property_SslProtocols_Name" xml:space="preserve">
     <value>SSL Protocols</value>
     <comment>Property name</comment>

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -210,6 +210,9 @@
   <data name="EmptyUsernameException" xml:space="preserve">
     <value>Username cannot be empty.</value>
   </data>
+  <data name="InvalidTimeoutException" xml:space="preserve">
+    <value>Timeout must be greater than or equal to 0.</value>
+  </data>
   <data name="SslProtocols" xml:space="preserve">
     <value>SSL protocols</value>
   </data>

--- a/Activities/FTP/UiPath.FTP.Activities/Resources/ActivitiesMetadata.json
+++ b/Activities/FTP/UiPath.FTP.Activities/Resources/ActivitiesMetadata.json
@@ -419,6 +419,14 @@
           "IsVisible": true
         },
         {
+          "Name": "Timeout",
+          "DisplayNameKey": "Activity_WithFtpSession_Property_Timeout_Name",
+          "TooltipKey": "Activity_WithFtpSession_Property_Timeout_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true
+        },
+        {
           "Name": "Username",
           "DisplayNameKey": "Activity_WithFtpSession_Property_Username_Name",
           "TooltipKey": "Activity_WithFtpSession_Property_Username_Description",

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -112,6 +112,12 @@ namespace UiPath.FTP.Activities
         [LocalizedDescription(nameof(Resources.Activity_WithFtpSession_Property_AcceptAllCertificates_Description))]
         public bool AcceptAllCertificates { get; set; }
 
+        [DefaultValue(null)]
+        [LocalizedCategory(nameof(Resources.Server))]
+        [LocalizedDisplayName(nameof(Resources.Activity_WithFtpSession_Property_Timeout_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_WithFtpSession_Property_Timeout_Description))]
+        public InArgument<int> Timeout { get; set; }
+
         [LocalizedCategory(nameof(Resources.Common))]
         [LocalizedDisplayName(nameof(Resources.Activity_WithFtpSession_Property_ContinueOnError_Name))]
         [LocalizedDescription(nameof(Resources.Activity_WithFtpSession_Property_ContinueOnError_Description))]
@@ -196,6 +202,7 @@ namespace UiPath.FTP.Activities
 
                 FtpConfiguration ftpConfiguration = new FtpConfiguration(Host.Get(context));
                 ftpConfiguration.Port = Port.Expression == null ? null : (int?)Port.Get(context);
+                ftpConfiguration.Timeout = Timeout.Expression == null ? null : (int?)Timeout.Get(context);
                 ftpConfiguration.UseAnonymousLogin = UseAnonymousLogin;
                 ftpConfiguration.SslProtocols = SslProtocols;
                 ftpConfiguration.ProxyType = ProxyType;

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -205,7 +205,7 @@ namespace UiPath.FTP.Activities
                 int? timeout = Timeout.Expression == null ? null : (int?)Timeout.Get(context);
                 if (timeout.HasValue && timeout.Value < 0)
                 {
-                    throw new ArgumentException("Timeout must be greater than or equal to 0.");
+                    throw new ArgumentOutOfRangeException(nameof(Timeout), Resources.InvalidTimeoutException);
                 }
                 ftpConfiguration.Timeout = timeout;
                 ftpConfiguration.UseAnonymousLogin = UseAnonymousLogin;

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -202,7 +202,12 @@ namespace UiPath.FTP.Activities
 
                 FtpConfiguration ftpConfiguration = new FtpConfiguration(Host.Get(context));
                 ftpConfiguration.Port = Port.Expression == null ? null : (int?)Port.Get(context);
-                ftpConfiguration.Timeout = Timeout.Expression == null ? null : (int?)Timeout.Get(context);
+                int? timeout = Timeout.Expression == null ? null : (int?)Timeout.Get(context);
+                if (timeout.HasValue && timeout.Value < 0)
+                {
+                    throw new ArgumentException("Timeout must be greater than or equal to 0.");
+                }
+                ftpConfiguration.Timeout = timeout;
                 ftpConfiguration.UseAnonymousLogin = UseAnonymousLogin;
                 ftpConfiguration.SslProtocols = SslProtocols;
                 ftpConfiguration.ProxyType = ProxyType;

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
@@ -44,6 +44,9 @@ namespace UiPath.FTP.Tests
             // When no timeout is set, FluentFTP defaults should be preserved
             var defaultClient = new FtpClient();
             Assert.Equal(defaultClient.Config.ConnectTimeout, ftpClient.Config.ConnectTimeout);
+            Assert.Equal(defaultClient.Config.ReadTimeout, ftpClient.Config.ReadTimeout);
+            Assert.Equal(defaultClient.Config.DataConnectionConnectTimeout, ftpClient.Config.DataConnectionConnectTimeout);
+            Assert.Equal(defaultClient.Config.DataConnectionReadTimeout, ftpClient.Config.DataConnectionReadTimeout);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using FluentFTP;
-using System.Reflection;
 using Xunit;
 
 namespace UiPath.FTP.Tests
@@ -19,11 +18,9 @@ namespace UiPath.FTP.Tests
         public void FTP_TimeoutIsApplied()
         {
             var config = new FtpConfiguration("localhost") { Timeout = 5000 };
-            var session = new FtpSession(config, FtpsMode.None);
+            using var session = new FtpSession(config, FtpsMode.None);
 
-            var ftpClientField = typeof(FtpSession).GetField("_ftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(ftpClientField);
-            var ftpClient = (FtpClient)ftpClientField.GetValue(session);
+            var ftpClient = session.Client;
 
             Assert.Equal(5000, ftpClient.Config.ConnectTimeout);
             Assert.Equal(5000, ftpClient.Config.ReadTimeout);
@@ -35,14 +32,12 @@ namespace UiPath.FTP.Tests
         public void FTP_DefaultTimeoutWhenNotSet()
         {
             var config = new FtpConfiguration("localhost");
-            var session = new FtpSession(config, FtpsMode.None);
+            using var session = new FtpSession(config, FtpsMode.None);
+            using var defaultClient = new FtpClient();
 
-            var ftpClientField = typeof(FtpSession).GetField("_ftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(ftpClientField);
-            var ftpClient = (FtpClient)ftpClientField.GetValue(session);
+            var ftpClient = session.Client;
 
             // When no timeout is set, FluentFTP defaults should be preserved
-            var defaultClient = new FtpClient();
             Assert.Equal(defaultClient.Config.ConnectTimeout, ftpClient.Config.ConnectTimeout);
             Assert.Equal(defaultClient.Config.ReadTimeout, ftpClient.Config.ReadTimeout);
             Assert.Equal(defaultClient.Config.DataConnectionConnectTimeout, ftpClient.Config.DataConnectionConnectTimeout);

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/FtpSessionTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using FluentFTP;
+using System.Reflection;
 using Xunit;
 
 namespace UiPath.FTP.Tests
@@ -11,6 +13,37 @@ namespace UiPath.FTP.Tests
             //Maybe to initialize a in-memory FTP Server using FubarDev.FtpServer??
             IFtpSession session = new FtpSession(new FtpConfiguration("ToThrow"), default);
             Assert.ThrowsAny<Exception>(session.Open);
+        }
+
+        [Fact]
+        public void FTP_TimeoutIsApplied()
+        {
+            var config = new FtpConfiguration("localhost") { Timeout = 5000 };
+            var session = new FtpSession(config, FtpsMode.None);
+
+            var ftpClientField = typeof(FtpSession).GetField("_ftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(ftpClientField);
+            var ftpClient = (FtpClient)ftpClientField.GetValue(session);
+
+            Assert.Equal(5000, ftpClient.Config.ConnectTimeout);
+            Assert.Equal(5000, ftpClient.Config.ReadTimeout);
+            Assert.Equal(5000, ftpClient.Config.DataConnectionConnectTimeout);
+            Assert.Equal(5000, ftpClient.Config.DataConnectionReadTimeout);
+        }
+
+        [Fact]
+        public void FTP_DefaultTimeoutWhenNotSet()
+        {
+            var config = new FtpConfiguration("localhost");
+            var session = new FtpSession(config, FtpsMode.None);
+
+            var ftpClientField = typeof(FtpSession).GetField("_ftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(ftpClientField);
+            var ftpClient = (FtpClient)ftpClientField.GetValue(session);
+
+            // When no timeout is set, FluentFTP defaults should be preserved
+            var defaultClient = new FtpClient();
+            Assert.Equal(defaultClient.Config.ConnectTimeout, ftpClient.Config.ConnectTimeout);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -1,6 +1,5 @@
-﻿using Renci.SshNet;
+using Renci.SshNet;
 using System;
-using System.Reflection;
 using Xunit;
 
 namespace UiPath.FTP.Tests
@@ -17,17 +16,10 @@ namespace UiPath.FTP.Tests
         [Fact]
         public void SFTP_TimeoutIsApplied()
         {
-            var config = new FtpConfiguration("localhost")
-            {
-                Username = "testUser",
-                Password = "notUsed",
-                Timeout = 5000
-            };
-            var session = new SftpSession(config);
+            var config = CreateTestConfig(timeout: 5000);
+            using var session = new SftpSession(config);
 
-            var sftpClientField = typeof(SftpSession).GetField("_sftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(sftpClientField);
-            var sftpClient = (SftpClient)sftpClientField.GetValue(session);
+            var sftpClient = session.Client;
 
             Assert.Equal(TimeSpan.FromMilliseconds(5000), sftpClient.ConnectionInfo.Timeout);
             Assert.Equal(TimeSpan.FromMilliseconds(5000), sftpClient.OperationTimeout);
@@ -36,26 +28,30 @@ namespace UiPath.FTP.Tests
         [Fact]
         public void SFTP_DefaultTimeoutWhenNotSet()
         {
-            var config = new FtpConfiguration("localhost")
-            {
-                Username = "testUser",
-                Password = "notUsed"
-            };
-            var session = new SftpSession(config);
+            var config = CreateTestConfig();
+            using var session = new SftpSession(config);
 
-            var sftpClientField = typeof(SftpSession).GetField("_sftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(sftpClientField);
-            var sftpClient = (SftpClient)sftpClientField.GetValue(session);
+            var sftpClient = session.Client;
 
             // When no timeout is set, SSH.NET defaults should be preserved
             var defaultConnectionInfo = new ConnectionInfo(
                 "localhost",
                 "testUser",
-                new PasswordAuthenticationMethod("testUser", "notUsed"));
-            var defaultSftpClient = new SftpClient(defaultConnectionInfo);
+                new PasswordAuthenticationMethod("testUser", "notUsed")); // NOSONAR - dummy test credentials
+            using var defaultSftpClient = new SftpClient(defaultConnectionInfo);
 
             Assert.Equal(defaultConnectionInfo.Timeout, sftpClient.ConnectionInfo.Timeout);
             Assert.Equal(defaultSftpClient.OperationTimeout, sftpClient.OperationTimeout);
+        }
+
+        private static FtpConfiguration CreateTestConfig(int? timeout = null)
+        {
+            return new FtpConfiguration("localhost")
+            {
+                Username = "testUser",
+                Password = "notUsed", // NOSONAR - dummy test credentials, never connect to any server
+                Timeout = timeout
+            };
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -19,8 +19,8 @@ namespace UiPath.FTP.Tests
         {
             var config = new FtpConfiguration("localhost")
             {
-                Username = "user",
-                Password = "pass",
+                Username = "testUser",
+                Password = "notUsed",
                 Timeout = 5000
             };
             var session = new SftpSession(config);
@@ -38,8 +38,8 @@ namespace UiPath.FTP.Tests
         {
             var config = new FtpConfiguration("localhost")
             {
-                Username = "user",
-                Password = "pass"
+                Username = "testUser",
+                Password = "notUsed"
             };
             var session = new SftpSession(config);
 
@@ -47,8 +47,15 @@ namespace UiPath.FTP.Tests
             Assert.NotNull(sftpClientField);
             var sftpClient = (SftpClient)sftpClientField.GetValue(session);
 
-            // When no timeout is set, SSH.NET default should be preserved (30 seconds)
-            Assert.Equal(TimeSpan.FromSeconds(30), sftpClient.ConnectionInfo.Timeout);
+            // When no timeout is set, SSH.NET defaults should be preserved
+            var defaultConnectionInfo = new ConnectionInfo(
+                "localhost",
+                "testUser",
+                new PasswordAuthenticationMethod("testUser", "notUsed"));
+            var defaultSftpClient = new SftpClient(defaultConnectionInfo);
+
+            Assert.Equal(defaultConnectionInfo.Timeout, sftpClient.ConnectionInfo.Timeout);
+            Assert.Equal(defaultSftpClient.OperationTimeout, sftpClient.OperationTimeout);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Renci.SshNet;
+using System;
+using System.Reflection;
 using Xunit;
 
 namespace UiPath.FTP.Tests
@@ -10,6 +12,43 @@ namespace UiPath.FTP.Tests
         {
             IFtpSession session = new SftpSession(new FtpConfiguration("ToThrow") {Username = "Some", Password = "NotUsed", Host = "Some"});
             Assert.ThrowsAny<Exception>(session.Open);
+        }
+
+        [Fact]
+        public void SFTP_TimeoutIsApplied()
+        {
+            var config = new FtpConfiguration("localhost")
+            {
+                Username = "user",
+                Password = "pass",
+                Timeout = 5000
+            };
+            var session = new SftpSession(config);
+
+            var sftpClientField = typeof(SftpSession).GetField("_sftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(sftpClientField);
+            var sftpClient = (SftpClient)sftpClientField.GetValue(session);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(5000), sftpClient.ConnectionInfo.Timeout);
+            Assert.Equal(TimeSpan.FromMilliseconds(5000), sftpClient.OperationTimeout);
+        }
+
+        [Fact]
+        public void SFTP_DefaultTimeoutWhenNotSet()
+        {
+            var config = new FtpConfiguration("localhost")
+            {
+                Username = "user",
+                Password = "pass"
+            };
+            var session = new SftpSession(config);
+
+            var sftpClientField = typeof(SftpSession).GetField("_sftpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(sftpClientField);
+            var sftpClient = (SftpClient)sftpClientField.GetValue(session);
+
+            // When no timeout is set, SSH.NET default should be preserved (30 seconds)
+            Assert.Equal(TimeSpan.FromSeconds(30), sftpClient.ConnectionInfo.Timeout);
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP/FtpConfiguration.cs
+++ b/Activities/FTP/UiPath.FTP/FtpConfiguration.cs
@@ -21,6 +21,7 @@ namespace UiPath.FTP
         public int? ProxyPort { get; set; }
         public string ProxyUsername { get; set; }
         public string ProxyPassword { get; set; }
+        public int? Timeout { get; set; }
 
         public FtpConfiguration(string host)
         {

--- a/Activities/FTP/UiPath.FTP/FtpSession.cs
+++ b/Activities/FTP/UiPath.FTP/FtpSession.cs
@@ -19,6 +19,8 @@ namespace UiPath.FTP
     {
         private readonly FtpClient _ftpClient;
 
+        internal FtpClient Client => _ftpClient;
+
         private const int DefaultProxyPort = 3128;
 
         public FtpSession(FtpConfiguration ftpConfiguration, FtpsMode ftpsMode)

--- a/Activities/FTP/UiPath.FTP/FtpSession.cs
+++ b/Activities/FTP/UiPath.FTP/FtpSession.cs
@@ -63,6 +63,15 @@ namespace UiPath.FTP
             {
                 _ftpClient.Port = ftpConfiguration.Port.Value;
             }
+
+            if (ftpConfiguration.Timeout != null)
+            {
+                _ftpClient.Config.ConnectTimeout = ftpConfiguration.Timeout.Value;
+                _ftpClient.Config.ReadTimeout = ftpConfiguration.Timeout.Value;
+                _ftpClient.Config.DataConnectionConnectTimeout = ftpConfiguration.Timeout.Value;
+                _ftpClient.Config.DataConnectionReadTimeout = ftpConfiguration.Timeout.Value;
+            }
+
             if (ftpConfiguration.UseAnonymousLogin == false)
             {
                 _ftpClient.Credentials = new NetworkCredential(ftpConfiguration.Username, ftpConfiguration.Password);

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -66,7 +66,17 @@ namespace UiPath.FTP
                 connectionInfo = new ConnectionInfo(ftpConfiguration.Host, ftpPort, ftpConfiguration.Username, ftpConfiguration.ProxyType.ToMaster(),ftpConfiguration.ProxyServer, proxyPort,ftpConfiguration.ProxyUsername,ftpConfiguration.ProxyPassword, authMethods.ToArray());
             }
 
+            if (ftpConfiguration.Timeout != null)
+            {
+                connectionInfo.Timeout = TimeSpan.FromMilliseconds(ftpConfiguration.Timeout.Value);
+            }
+
             _sftpClient = new SftpClient(connectionInfo);
+
+            if (ftpConfiguration.Timeout != null)
+            {
+                _sftpClient.OperationTimeout = TimeSpan.FromMilliseconds(ftpConfiguration.Timeout.Value);
+            }
         }
 
         private IEnumerable<Tuple<string, string>> GetLocalListing(string localPath, string remotePath, bool recursive)

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -66,16 +66,20 @@ namespace UiPath.FTP
                 connectionInfo = new ConnectionInfo(ftpConfiguration.Host, ftpPort, ftpConfiguration.Username, ftpConfiguration.ProxyType.ToMaster(),ftpConfiguration.ProxyServer, proxyPort,ftpConfiguration.ProxyUsername,ftpConfiguration.ProxyPassword, authMethods.ToArray());
             }
 
-            if (ftpConfiguration.Timeout != null)
+            TimeSpan? timeoutSpan = ftpConfiguration.Timeout != null
+                ? TimeSpan.FromMilliseconds(ftpConfiguration.Timeout.Value)
+                : null;
+
+            if (timeoutSpan.HasValue)
             {
-                connectionInfo.Timeout = TimeSpan.FromMilliseconds(ftpConfiguration.Timeout.Value);
+                connectionInfo.Timeout = timeoutSpan.Value;
             }
 
             _sftpClient = new SftpClient(connectionInfo);
 
-            if (ftpConfiguration.Timeout != null)
+            if (timeoutSpan.HasValue)
             {
-                _sftpClient.OperationTimeout = TimeSpan.FromMilliseconds(ftpConfiguration.Timeout.Value);
+                _sftpClient.OperationTimeout = timeoutSpan.Value;
             }
         }
 

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -14,6 +14,9 @@ namespace UiPath.FTP
     public class SftpSession : IFtpSession
     {
         private readonly SftpClient _sftpClient;
+
+        internal SftpClient Client => _sftpClient;
+
         private const int DefaultFtpPort = 21;
         private const int DefaultProxyPort = 3128;
 

--- a/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
+++ b/Activities/FTP/UiPath.FTP/UiPath.FTP.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="SSH.NET" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="UiPath.FTP.Tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem Statement

The `With FTP Session` (FTP Scope) activity has no timeout property. FTP/SFTP connections
can hang indefinitely when the remote server is unresponsive, with no way for users to
control connection or operation timeouts.

## Analysis

Both underlying libraries already support timeouts natively:
- **FluentFTP** (FTP/FTPS): `Config.ConnectTimeout`, `Config.ReadTimeout`,
  `Config.DataConnectionConnectTimeout`, `Config.DataConnectionReadTimeout` — all `int` in milliseconds
- **SSH.NET** (SFTP): `ConnectionInfo.Timeout` and `SftpClient.OperationTimeout` — both `TimeSpan`

The existing codebase uses `InArgument<int>` for the `Port` property with a
`null`-expression check pattern (`Port.Expression == null ? null : (int?)Port.Get(context)`).
The `Timeout` property follows this same pattern for consistency.

Timeout is implemented as **per-connection** (sets connect/read/data timeouts on the
underlying clients), which is the standard approach matching how Python activities handle
timeout. A cumulative scope-level timeout could be added later if needed.

## Considered Use Cases

- User sets a timeout value — all FTP/SFTP connection and operation timeouts are configured
- User does not set a timeout — library defaults are preserved (FluentFTP defaults, SSH.NET 30s)
- FTP with proxy — timeout applies to the proxy-wrapped client equally
- SFTP — both connection timeout (`ConnectionInfo.Timeout`) and data operation timeout
  (`SftpClient.OperationTimeout`) are set to prevent hangs during file transfers
- Backwards compatibility — existing workflows without timeout continue to work unchanged
  (`[DefaultValue(null)]` on the new property)

## Implementation

**Core layer (`UiPath.FTP`):**
- `FtpConfiguration.cs` — Added `int? Timeout` property
- `FtpSession.cs` — Apply timeout to 4 FluentFTP config properties (connect, read,
  data connection connect, data connection read) when set
- `SftpSession.cs` — Apply timeout to `ConnectionInfo.Timeout` (connect) and
  `SftpClient.OperationTimeout` (data operations) when set

**Activity layer (`UiPath.FTP.Activities`):**
- `WithFtpSession.cs` — Added `InArgument<int> Timeout` with localized attributes,
  `[DefaultValue(null)]`, wired to `FtpConfiguration` before the first `await`

**Design layer:**
- `WithFtpSessionViewModel.cs` — Added `DesignInArgument<int> Timeout` with OrderIndex
  after Port
- `ActivitiesMetadata.json` — Registered Timeout property metadata
- `.resx` / `.Designer.cs` — Added localized display name and description strings

**Tests:**
- `FtpSessionTests.cs` — 2 new tests: timeout applied correctly, defaults preserved
- `SftpSessionTests.cs` — 2 new tests: timeout applied to both ConnectionInfo.Timeout
  and OperationTimeout, defaults preserved

## How to Test

1. `dotnet test Activities/Activities.FTP.sln` — all 14 tests pass
2. Manual: Create a workflow with `With FTP Session`, set Timeout to 5000,
   connect to a responsive server — should work normally
3. Manual: Set Timeout to 1, connect to a slow server — should fail with timeout error
4. Manual: Leave Timeout empty — should behave identically to current behavior

jira: https://uipath.atlassian.net/browse/STUD-75804

🤖 Generated with [Claude Code](https://claude.com/claude-code)