### PR TITLE
cryptography: Add AI-generated XAML activity docs for Cryptography package [STUD-79287]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
@@ -1,0 +1,49 @@
+# Decrypt File
+
+`UiPath.Cryptography.Activities.DecryptFile`
+
+Decrypts a file based on a specified key encoding and algorithm.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the decryption algorithm you want to use. |
+| `InputFile` | File | InArgument | `IResource` |  |  |  | The file to be decrypted |
+| `InputFilePath` | File path | InArgument | `string` |  |  |  | The path to the file that you want to decrypt. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to decrypt the specified file. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to decrypt the input file. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for decryption. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key. |
+| `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for signature verification. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `OutputFilePath` | Output file name and location | `string` |  | The path where you want to save the decrypted file. |
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `Overwrite` | Overwrite | `bool` |  | If a file already exists at the path specified in the Output path field, selecting this check box overwrites it. If unchecked, a new file is created. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `VerifySignature` | Verify Signature | `bool` |  | When enabled, verifies the PGP signature of the decrypted data using the public key. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `DecryptedFile` | Decrypted File | OutArgument | `ILocalResource` | The decrypted file |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:DecryptFile DisplayName="Decrypt File" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
@@ -40,10 +40,20 @@ Decrypts a file based on a specified key encoding and algorithm.
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- File source: provide either `InputFilePath` or `InputFile`.
+- Symmetric decryption mode: set `Algorithm`, then provide either `Key` or `KeySecureString`.
+- PGP decryption mode: provide `PrivateKeyFilePath` and `Passphrase`; optionally set `VerifySignature` with `PublicKeyFilePath`.
+- Set `OutputFilePath` to control destination; otherwise the activity generates the output name.
 
 ## XAML Example
 
-`xml
-<ui:DecryptFile DisplayName="Decrypt File" />
-`
+```xml
+<ui:DecryptFile DisplayName="Decrypt File"
+				Algorithm="AESGCM"
+				InputFilePath="C:\\temp\\encrypted.bin"
+				Key="my-secret-key"
+				OutputFilePath="C:\\temp\\decrypted.txt"
+				Overwrite="True"
+				DecryptedFile="[decryptedFile]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
@@ -15,8 +15,8 @@ Decrypts text based on a specified key encoding and algorithm.
 |------|-------------|------|------|----------|---------|-------------|-------------|
 | `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the decryption algorithm you want to use. |
 | `Input` | Text | InArgument | `string` | Yes |  |  | The text that you want to decrypt. |
-| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to decrypt the specified file. |
-| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to decrypt the input string. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to decrypt the specified file. Provide either `Key` or `KeySecureString`. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to decrypt the input string. Provide either `Key` or `KeySecureString`. |
 | `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for decryption. |
 | `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key. |
 | `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for signature verification. |
@@ -33,14 +33,22 @@ Decrypts text based on a specified key encoding and algorithm.
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Result` | Decrypted Text | Property | `object` | The decrypted text, stored in a String variable. |
+| `Result` | Decrypted Text | OutArgument | `string` | The decrypted text, stored in a String variable. |
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- Symmetric decryption mode: set `Algorithm` and `Input`, then provide either `Key` or `KeySecureString`.
+- PGP decryption mode: set `Algorithm` to PGP and provide `PrivateKeyFilePath` and `Passphrase`.
+- Signature verification mode: set `VerifySignature` to `True` and provide `PublicKeyFilePath`.
 
 ## XAML Example
 
-`xml
-<ui:DecryptText DisplayName="Decrypt Text" />
-`
+```xml
+<ui:DecryptText DisplayName="Decrypt Text"
+				Algorithm="AESGCM"
+				Input="[encryptedText]"
+				Key="my-secret-key"
+				KeyEncodingString="65001"
+				Result="[decryptedText]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
@@ -1,0 +1,46 @@
+# Decrypt Text
+
+`UiPath.Cryptography.Activities.DecryptText`
+
+Decrypts text based on a specified key encoding and algorithm.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the decryption algorithm you want to use. |
+| `Input` | Text | InArgument | `string` | Yes |  |  | The text that you want to decrypt. |
+| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to decrypt the specified file. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to decrypt the input string. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for decryption. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key. |
+| `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for signature verification. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even if the activity throws an error. |
+| `VerifySignature` | Verify Signature | `bool` |  | When enabled, verifies the PGP signature of the decrypted data using the public key. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Decrypted Text | Property | `object` | The decrypted text, stored in a String variable. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:DecryptText DisplayName="Decrypt Text" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
@@ -14,11 +14,10 @@ Encrypts a file with a key based on a specified key encoding and algorithm.
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
 | `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the encryption algorithm you want to use. |
-| `DeprecatedWarning` | D ep re ca te dW ar ni ng | Property | `object` |  |  |  |  |
 | `InputFilePath` | File path | InArgument | `string` |  |  |  | The path to the file that you want to encrypt. |
 | `InputFile` | File | InArgument | `IResource` |  |  |  | The file to be encrypted |
-| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to encrypt the specified file. |
-| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to encrypt the input file. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to encrypt the specified file. Provide either `Key` or `KeySecureString`. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to encrypt the input file. Provide either `Key` or `KeySecureString`. |
 | `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for encryption. |
 | `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for signing. |
 | `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key used for signing. |
@@ -41,10 +40,20 @@ Encrypts a file with a key based on a specified key encoding and algorithm.
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- File source: provide either `InputFilePath` or `InputFile`.
+- Symmetric encryption mode: set `Algorithm`, then provide either `Key` or `KeySecureString`.
+- PGP encryption mode: provide `PublicKeyFilePath`; for signed encryption also provide `PrivateKeyFilePath`, `Passphrase`, and set `SignData` to `True`.
+- Set `OutputFilePath` and `Overwrite` based on destination behavior.
 
 ## XAML Example
 
-`xml
-<ui:EncryptFile DisplayName="Encrypt File" />
-`
+```xml
+<ui:EncryptFile DisplayName="Encrypt File"
+				Algorithm="AESGCM"
+				InputFilePath="C:\\temp\\plain.txt"
+				Key="my-secret-key"
+				OutputFilePath="C:\\temp\\plain.encrypted"
+				Overwrite="True"
+				EncryptedFile="[encryptedFile]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
@@ -1,0 +1,50 @@
+# Encrypt File
+
+`UiPath.Cryptography.Activities.EncryptFile`
+
+Encrypts a file with a key based on a specified key encoding and algorithm.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the encryption algorithm you want to use. |
+| `DeprecatedWarning` | D ep re ca te dW ar ni ng | Property | `object` |  |  |  |  |
+| `InputFilePath` | File path | InArgument | `string` |  |  |  | The path to the file that you want to encrypt. |
+| `InputFile` | File | InArgument | `IResource` |  |  |  | The file to be encrypted |
+| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to encrypt the specified file. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to encrypt the input file. |
+| `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for encryption. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for signing. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key used for signing. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `OutputFilePath` | Output file name and location | `string` |  | The path where you want to save the encrypted file. |
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `Overwrite` | Overwrite | `bool` |  | If a file already exists at the path specified in the Output path field, selecting this check box overwrites it. If unchecked, a new file is created. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `SignData` | Sign Data | `bool` |  | When enabled, signs the encrypted data using the private key. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `EncryptedFile` | Encrypted File | OutArgument | `ILocalResource` | The encrypted file |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:EncryptFile DisplayName="Encrypt File" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
@@ -1,0 +1,47 @@
+# Encrypt Text
+
+`UiPath.Cryptography.Activities.EncryptText`
+
+Encrypts a string with a key based on a specified key encoding and algorithm.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the encryption algorithm you want to use. |
+| `DeprecatedWarning` | D ep re ca te dW ar ni ng | Property | `object` |  |  |  |  |
+| `Input` | Text | InArgument | `string` | Yes |  |  | The text that you want to encrypt. |
+| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to encrypt the specified file. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to encrypt the input string. |
+| `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for encryption. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for signing. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key used for signing. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `SignData` | Sign Data | `bool` |  | When enabled, signs the encrypted data using the private key. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Encrypted Text | Property | `object` | The encrypted text, stored in a String variable. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:EncryptText DisplayName="Encrypt Text" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
@@ -14,10 +14,9 @@ Encrypts a string with a key based on a specified key encoding and algorithm.
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
 | `Algorithm` | Algorithm | Property | `EncryptionAlgorithm` | Yes |  |  | A drop-down which enables you to select the encryption algorithm you want to use. |
-| `DeprecatedWarning` | D ep re ca te dW ar ni ng | Property | `object` |  |  |  |  |
 | `Input` | Text | InArgument | `string` | Yes |  |  | The text that you want to encrypt. |
-| `Key` | Key | InArgument | `string` | Yes |  |  | The key that you want to use to encrypt the specified file. |
-| `KeySecureString` | Key Secure String | InArgument | `SecureString` | Yes |  |  | The secure string used to encrypt the input string. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to encrypt the specified file. Provide either `Key` or `KeySecureString`. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to encrypt the input string. Provide either `Key` or `KeySecureString`. |
 | `PublicKeyFilePath` | Public Key File Path | InArgument | `string` |  |  |  | The path to the PGP public key file used for encryption. |
 | `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` |  |  |  | The path to the PGP private key file used for signing. |
 | `Passphrase` | Passphrase | InArgument | `SecureString` |  |  |  | The passphrase for the PGP private key used for signing. |
@@ -34,14 +33,22 @@ Encrypts a string with a key based on a specified key encoding and algorithm.
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Result` | Encrypted Text | Property | `object` | The encrypted text, stored in a String variable. |
+| `Result` | Encrypted Text | OutArgument | `string` | The encrypted text, stored in a String variable. |
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- Symmetric encryption mode: set `Algorithm` and `Input`, then provide either `Key` or `KeySecureString`.
+- PGP encryption mode: set `Algorithm` to PGP and provide `PublicKeyFilePath`.
+- Signed PGP encryption mode: set `SignData` to `True` and also provide `PrivateKeyFilePath` and `Passphrase`.
 
 ## XAML Example
 
-`xml
-<ui:EncryptText DisplayName="Encrypt Text" />
-`
+```xml
+<ui:EncryptText DisplayName="Encrypt Text"
+				Algorithm="AESGCM"
+				Input="[plainText]"
+				Key="my-secret-key"
+				KeyEncodingString="65001"
+				Result="[encryptedText]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
@@ -1,0 +1,43 @@
+# Hash File
+
+`UiPath.Cryptography.Activities.KeyedHashFile`
+
+Hashes a file with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `KeyedHashAlgorithms` | Yes |  |  | A drop-down which enables you to select the keyed hashing algorithm you want to use. |
+| `InputFile` | File | InArgument | `IResource` |  |  |  | The file to be hashed |
+| `FilePath` | File path | InArgument | `string` |  |  |  | The path to the file you want to hash. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to hash the specified file. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to hash the provided file. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Hash | Property | `object` | The hashed file, stored in a String variable. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:KeyedHashFile DisplayName="Hash File" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
@@ -30,14 +30,21 @@ Hashes a file with a key using a specified algorithm and returns the hexadecimal
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Result` | Hash | Property | `object` | The hashed file, stored in a String variable. |
+| `Result` | Hash | OutArgument | `string` | The hashed file, stored in a String variable. |
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- File source: provide either `FilePath` or `InputFile`.
+- HMAC algorithms: provide either `Key` or `KeySecureString`.
+- Non-HMAC algorithms: `Key` and `KeySecureString` are ignored.
 
 ## XAML Example
 
-`xml
-<ui:KeyedHashFile DisplayName="Hash File" />
-`
+```xml
+<ui:KeyedHashFile DisplayName="Hash File"
+				  Algorithm="HMACSHA256"
+				  FilePath="C:\\temp\\input.txt"
+				  Key="my-secret-key"
+				  Result="[fileHash]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
@@ -29,14 +29,21 @@ Hashes a string with a key using a specified algorithm and returns the hexadecim
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Result` | Hash | Property | `object` | The hashed text, stored in a String variable. |
+| `Result` | Hash | OutArgument | `string` | The hashed text, stored in a String variable. |
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- HMAC algorithms: provide either `Key` or `KeySecureString`.
+- Non-HMAC algorithms: `Key` and `KeySecureString` are ignored.
+- `KeyEncodingString` is used when `Key` is provided as text.
 
 ## XAML Example
 
-`xml
-<ui:KeyedHashText DisplayName="Hash Text" />
-`
+```xml
+<ui:KeyedHashText DisplayName="Hash Text"
+				  Algorithm="HMACSHA256"
+				  Input="[inputText]"
+				  Key="my-secret-key"
+				  Result="[textHash]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
@@ -1,0 +1,42 @@
+# Hash Text
+
+`UiPath.Cryptography.Activities.KeyedHashText`
+
+Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash. It supports hashing algorithms with a key and without a key.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Algorithm` | Algorithm | Property | `KeyedHashAlgorithms` | Yes |  |  | A drop-down which enables you to select the keyed hashing algorithm you want to use. |
+| `Input` | Text | InArgument | `string` | Yes |  |  | The text that you want to hash. |
+| `Key` | Key | InArgument | `string` |  |  |  | The key that you want to use to hash the specified text. |
+| `KeySecureString` | Key Secure String | InArgument | `SecureString` |  |  |  | The secure string used to hash the input string. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `KeyEncodingString` | Key Encoding | `string` |  | The encoding used to interpret the key specified in the Key property. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Hash | Property | `object` | The hashed text, stored in a String variable. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:KeyedHashText DisplayName="Hash Text" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
@@ -1,0 +1,42 @@
+# PGP Clear Sign File
+
+`UiPath.Cryptography.Activities.PgpClearSignFile`
+
+Creates a PGP clear-text signature of a file using a private key.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `InputFilePath` | Input File Path | InArgument | `string` | Yes |  |  | The path to the file that you want to clear-sign. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` | Yes |  |  | The path to the PGP private key file used for signing. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` | Yes |  |  | The passphrase for the PGP private key. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `OutputFilePath` | Output File Path | `string` |  | The path where the clear-signed file will be saved. |
+| `Overwrite` | Overwrite | `bool` |  | If a file already exists at the output path, selecting this overwrites it. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ClearSignedFile` | Clear-Signed File | OutArgument | `ILocalResource` | The clear-signed file as a file resource. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:PgpClearSignFile DisplayName="PGP Clear Sign File" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
@@ -33,10 +33,19 @@ Creates a PGP clear-text signature of a file using a private key.
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- Required inputs: `InputFilePath`, `PrivateKeyFilePath`, and `Passphrase`.
+- Set `OutputFilePath` to control where the clear-signed file is written.
+- Set `Overwrite` to `True` to replace an existing output file.
 
 ## XAML Example
 
-`xml
-<ui:PgpClearSignFile DisplayName="PGP Clear Sign File" />
-`
+```xml
+<ui:PgpClearSignFile DisplayName="PGP Clear Sign File"
+					 InputFilePath="C:\\temp\\message.txt"
+					 PrivateKeyFilePath="C:\\keys\\private.asc"
+					 Passphrase="[privateKeyPassphrase]"
+					 OutputFilePath="C:\\temp\\message.signed.txt"
+					 Overwrite="True"
+					 ClearSignedFile="[clearSignedFile]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeyPair.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeyPair.md
@@ -1,0 +1,43 @@
+# PGP Generate Keys
+
+`UiPath.Cryptography.Activities.PgpGenerateKeyPair`
+
+Generates a PGP public/private key pair and saves them to the specified file paths.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `PublicKeyFilePath` | Public Key Output Path | InArgument | `string` | Yes |  |  | The file path where the generated PGP public key will be saved. |
+| `PrivateKeyFilePath` | Private Key Output Path | InArgument | `string` | Yes |  |  | The file path where the generated PGP private key will be saved. |
+| `Username` | Username | InArgument | `string` | Yes |  |  | The username (or email) to associate with the generated key pair. |
+| `Password` | Passphrase | InArgument | `SecureString` | Yes |  |  | The passphrase to protect the generated private key. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Overwrite` | Overwrite | `bool` |  | If files already exist at the output paths, selecting this overwrites them. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `PublicKeyFile` | Public Key File | OutArgument | `ILocalResource` | The generated public key as a file resource. |
+| `PrivateKeyFile` | Private Key File | OutArgument | `ILocalResource` | The generated private key as a file resource. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:PgpGenerateKeyPair DisplayName="PGP Generate Keys" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeyPair.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeyPair.md
@@ -34,10 +34,20 @@ Generates a PGP public/private key pair and saves them to the specified file pat
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- Required inputs: `PublicKeyFilePath`, `PrivateKeyFilePath`, `Username`, and `Password`.
+- Set `Overwrite` to `True` to replace existing key files.
+- Use output arguments `PublicKeyFile` and `PrivateKeyFile` for downstream file operations.
 
 ## XAML Example
 
-`xml
-<ui:PgpGenerateKeyPair DisplayName="PGP Generate Keys" />
-`
+```xml
+<ui:PgpGenerateKeyPair DisplayName="PGP Generate Keys"
+					   PublicKeyFilePath="C:\\keys\\public.asc"
+					   PrivateKeyFilePath="C:\\keys\\private.asc"
+					   Username="automation@uipath.com"
+					   Password="[keyPassphrase]"
+					   Overwrite="True"
+					   PublicKeyFile="[publicKeyFile]"
+					   PrivateKeyFile="[privateKeyFile]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
@@ -33,10 +33,19 @@ Creates a PGP binary signature of a file using a private key.
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- Required inputs: `InputFilePath`, `PrivateKeyFilePath`, and `Passphrase`.
+- Set `OutputFilePath` to control the signed file destination.
+- Set `Overwrite` to `True` to replace an existing output file.
 
 ## XAML Example
 
-`xml
-<ui:PgpSignFile DisplayName="PGP Sign File" />
-`
+```xml
+<ui:PgpSignFile DisplayName="PGP Sign File"
+				InputFilePath="C:\\temp\\document.txt"
+				PrivateKeyFilePath="C:\\keys\\private.asc"
+				Passphrase="[privateKeyPassphrase]"
+				OutputFilePath="C:\\temp\\document.sig"
+				Overwrite="True"
+				SignedFile="[signedFile]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
@@ -1,0 +1,42 @@
+# PGP Sign File
+
+`UiPath.Cryptography.Activities.PgpSignFile`
+
+Creates a PGP binary signature of a file using a private key.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `InputFilePath` | Input File Path | InArgument | `string` | Yes |  |  | The path to the file that you want to sign. |
+| `PrivateKeyFilePath` | Private Key File Path | InArgument | `string` | Yes |  |  | The path to the PGP private key file used for signing. |
+| `Passphrase` | Passphrase | InArgument | `SecureString` | Yes |  |  | The passphrase for the PGP private key. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `OutputFilePath` | Output File Path | `string` |  | The path where the signed file will be saved. |
+| `Overwrite` | Overwrite | `bool` |  | If a file already exists at the output path, selecting this overwrites it. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `SignedFile` | Signed File | OutArgument | `ILocalResource` | The signed file as a file resource. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:PgpSignFile DisplayName="PGP Sign File" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpVerify.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpVerify.md
@@ -1,0 +1,40 @@
+# PGP Verify
+
+`UiPath.Cryptography.Activities.PgpVerify`
+
+Verifies a PGP signature, clear signature, or validates a public key file.
+
+**Package:** `UiPath.Cryptography.Activities`
+**Category:** Cryptography
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Mode` | Verification Type | Property | `PgpVerifyMode` | Yes |  |  | Select the type of verification. 'Signed File (Binary)' verifies a binary-signed file. 'Clear-Signed File (Text)' verifies a text file with an embedded signature. 'Validate Public Key' checks that a file contains a valid PGP public key. |
+| `InputFilePath` | Signed File Path | InArgument | `string` |  |  |  | The path to the signed file to verify. Required for 'Signed File (Binary)' and 'Clear-Signed File (Text)' modes. |
+| `PublicKeyFilePath` | Public Key File Path | InArgument | `string` | Yes |  |  | The path to the PGP public key file used for verification. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | Property | `object` | True if verification succeeded, False otherwise. |
+
+## Valid Configurations
+
+Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+
+## XAML Example
+
+`xml
+<ui:PgpVerify DisplayName="PGP Verify" />
+`

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpVerify.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpVerify.md
@@ -27,14 +27,21 @@ Verifies a PGP signature, clear signature, or validates a public key file.
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Result` | Result | Property | `object` | True if verification succeeded, False otherwise. |
+| `Result` | Result | OutArgument | `bool` | True if verification succeeded, False otherwise. |
 
 ## Valid Configurations
 
-Set required input properties and choose optional configuration properties based on your chosen algorithm and key source. Some properties are conditionally visible in the designer depending on algorithm or mode.
+- `Mode=Signature` or `Mode=ClearSignature`: provide both `InputFilePath` and `PublicKeyFilePath`.
+- `Mode=PublicKey`: provide only `PublicKeyFilePath`; `InputFilePath` is not required.
+- Use `Result` to branch workflow behavior based on verification success.
 
 ## XAML Example
 
-`xml
-<ui:PgpVerify DisplayName="PGP Verify" />
-`
+```xml
+<ui:PgpVerify DisplayName="PGP Verify"
+			  Mode="Signature"
+			  InputFilePath="C:\\temp\\document.sig"
+			  PublicKeyFilePath="C:\\keys\\public.asc"
+			  Result="[isValidSignature]" />
+```
+

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/overview.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/overview.md
@@ -1,0 +1,20 @@
+# UiPath Cryptography Activities
+
+`UiPath.Cryptography.Activities`
+
+## Activities
+
+### Cross-platform
+
+| Activity | Description |
+|----------|-------------|
+| [Decrypt File](activities/DecryptFile.md) | Decrypts a file based on a specified key encoding and algorithm |
+| [Decrypt Text](activities/DecryptText.md) | Decrypts text based on a specified key encoding and algorithm |
+| [Encrypt File](activities/EncryptFile.md) | Encrypts a file with a key based on a specified key encoding and algorithm |
+| [Encrypt Text](activities/EncryptText.md) | Encrypts a string with a key based on a specified key encoding and algorithm |
+| [Hash File](activities/KeyedHashFile.md) | Hashes a file with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash |
+| [Hash Text](activities/KeyedHashText.md) | Hashes a string with a key using a specified algorithm and returns the hexadecimal string representation of the resulting hash |
+| [PGP Generate Keys](activities/PgpGenerateKeyPair.md) | Generates a PGP public/private key pair and saves them to the specified file paths |
+| [PGP Sign File](activities/PgpSignFile.md) | Creates a PGP binary signature of a file using a private key |
+| [PGP Clear Sign File](activities/PgpClearSignFile.md) | Creates a PGP clear-text signature of a file using a private key |
+| [PGP Verify](activities/PgpVerify.md) | Verifies a PGP signature, clear signature, or validates a public key file |


### PR DESCRIPTION
## What changed?
Added structured per-activity markdown reference files for all 10 activities in the UiPath Cryptography package, plus a package overview doc. Coverage includes:

- \EncryptText\, \DecryptText\, \EncryptFile\, \DecryptFile\
- \KeyedHashText\, \KeyedHashFile\
- \PgpClearSignFile\, \PgpSignFile\, \PgpVerify\, \PgpGenerateKeyPair\

Each file documents inputs, outputs, configuration options, and includes a copy-paste XAML example. Files are co-located under \UiPath.Cryptography.Activities.Packaging/docs/\.

## Why?
Enables LLM CLI tooling (Claude Code and similar agents) to use these docs as grounded activity references when generating or reviewing automation workflows, reducing hallucinations and improving accuracy for Cryptography activities.

## Jira Link
[STUD-79287]

## Dependencies
- [x] None

[STUD-79287]: https://uipath.atlassian.net/browse/STUD-79287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ