### PR TITLE
database: Add AI-generated XAML activity documentation [STUD-79288]

### DIFF
--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
@@ -18,11 +18,6 @@ Updates a database table via Bulk operations of the specific database driver. Fa
 | `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
 | `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
-
 ### Output
 
 | Name | Display Name | Kind | Type | Description |

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
@@ -1,0 +1,38 @@
+# Bulk Insert
+
+`UiPath.Database.Activities.BulkInsert`
+
+Updates a database table via Bulk operations of the specific database driver. Falls back to Insert Data Table if the database driver does not support Bulk operations.
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be inserted into the Table. The DataTable columns' name and description must match the ones from the database table. |
+| `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
+| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `AffectedRecords` | Affected rows count | OutArgument | `long` | Number of affected rows. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:BulkInsert DisplayName="Bulk Insert" ExistingDbConnection="[value]" DataTable="[value]" TableName="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
@@ -20,11 +20,6 @@ Updates a compatible DataTable in an existing database table. The activity also 
 | `ColumnNames` | Columns used for matching rows | InArgument | `string[]` | Yes |  | Column names used for row matching | The collection of column names used for row matching. These column names will not be changed by the Bulk Update activity. |
 | `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
-
 ### Output
 
 | Name | Display Name | Kind | Type | Description |
@@ -35,6 +30,6 @@ Updates a compatible DataTable in an existing database table. The activity also 
 
 ```xml
 <Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
-  <db:BulkUpdate DisplayName="Bulk Update" ExistingDbConnection="[value]" DataTable="[value]" TableName="[value]" />
+  <db:BulkUpdate DisplayName="Bulk Update" ExistingDbConnection="[value]" DataTable="[value]" TableName="[value]" ColumnNames="[value]" />
 </Activity>
 ```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
@@ -1,0 +1,40 @@
+# Bulk Update
+
+`UiPath.Database.Activities.BulkUpdate`
+
+Updates a compatible DataTable in an existing database table. The activity also updates all the columns that are not in the collection of column names used as a primary key. Returns the number of rows affected.
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be used to update the database table. The DataTable columns' name and description must match the columns from the database table and be a subset of them. |
+| `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be updated. |
+| `BulkUpdateFlag` | Bulk/batch update | Property | `bool` |  |  |  | Check this box to enable the creation of a temp table using Bulk insert and to update using join between tables. Otherwise, bulk updates are issued in batch. |
+| `ColumnNames` | Columns used for matching rows | InArgument | `string[]` | Yes |  | Column names used for row matching | The collection of column names used for row matching. These column names will not be changed by the Bulk Update activity. |
+| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `AffectedRecords` | Affected rows count | OutArgument | `long` | Number of affected rows. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:BulkUpdate DisplayName="Bulk Update" ExistingDbConnection="[value]" DataTable="[value]" TableName="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseConnect.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseConnect.md
@@ -1,0 +1,37 @@
+# Connect to Database
+
+`UiPath.Database.Activities.DatabaseConnect`
+
+Connects to a database by using a standard connection string
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ProviderName` | Provider name | InArgument | `string` | Yes |  | Please provide the database provider name | The name of the database provider used to access the database. Please see the documentation for more examples. |
+| `ConnectionString` | Connection string | InArgument | `string` | Yes |  | Please provide the database connection string | The connection string used to establish a database connection. Please see the documentation for more examples. |
+| `ConnectionSecureString` | Secure connection string | InArgument | `SecureString` | Yes |  | Please provide the database connection SecureString variable | The connection string used to establish a database connection provided as a SecureString. Please see the documentation for more examples. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `DatabaseConnection` | Database connection | OutArgument | `DatabaseConnection` | The database connection used for the operations within this activity. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:DatabaseConnect DisplayName="Connect to Database" ProviderName="[value]" ConnectionString="[value]" ConnectionSecureString="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseConnect.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseConnect.md
@@ -14,13 +14,8 @@ Connects to a database by using a standard connection string
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
 | `ProviderName` | Provider name | InArgument | `string` | Yes |  | Please provide the database provider name | The name of the database provider used to access the database. Please see the documentation for more examples. |
-| `ConnectionString` | Connection string | InArgument | `string` | Yes |  | Please provide the database connection string | The connection string used to establish a database connection. Please see the documentation for more examples. |
-| `ConnectionSecureString` | Secure connection string | InArgument | `SecureString` | Yes |  | Please provide the database connection SecureString variable | The connection string used to establish a database connection provided as a SecureString. Please see the documentation for more examples. |
-
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ConnectionString` | Connection string | InArgument | `string` |  |  | Please provide the database connection string | The connection string used to establish a database connection. Provide either `ConnectionString` or `ConnectionSecureString`. Please see the documentation for more examples. |
+| `ConnectionSecureString` | Secure connection string | InArgument | `SecureString` |  |  | Please provide the database connection SecureString variable | The connection string used to establish a database connection provided as a SecureString. Provide either `ConnectionString` or `ConnectionSecureString`. Please see the documentation for more examples. |
 
 ### Output
 
@@ -32,6 +27,6 @@ Connects to a database by using a standard connection string
 
 ```xml
 <Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
-  <db:DatabaseConnect DisplayName="Connect to Database" ProviderName="[value]" ConnectionString="[value]" ConnectionSecureString="[value]" />
+  <db:DatabaseConnect DisplayName="Connect to Database" ProviderName="[value]" ConnectionString="[value]" DatabaseConnection="[dbConn]" />
 </Activity>
 ```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseDisconnect.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseDisconnect.md
@@ -1,0 +1,34 @@
+# Disconnect from Database
+
+`UiPath.Database.Activities.DatabaseDisconnect`
+
+Closes a connection to a database
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `DatabaseConnection` | Existing connection | InArgument | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:DatabaseDisconnect DisplayName="Disconnect from Database" DatabaseConnection="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseDisconnect.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/DatabaseDisconnect.md
@@ -15,11 +15,6 @@ Closes a connection to a database
 |------|-------------|------|------|----------|---------|-------------|-------------|
 | `DatabaseConnection` | Existing connection | InArgument | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
 
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
-
 ### Output
 
 | Name | Display Name | Kind | Type | Description |

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
@@ -1,0 +1,40 @@
+# Run Command
+
+`UiPath.Database.Activities.ExecuteNonQuery`
+
+Executes an SQL statement on a database. For UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the command. For all other types of statements, the return value is -1.
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
+| `Sql` | SQL command | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL command to be executed. This property must be completed according to the selection from the Command type property |
+| `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
+| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 miliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `AffectedRecords` | Affected rows count | OutArgument | `int` | The result of the execution of the SQL command. For UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the command. For all other types of statements, the return value is -1. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:ExecuteNonQuery DisplayName="Run Command" ExistingDbConnection="[value]" CommandType="[value]" Sql="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
@@ -17,13 +17,8 @@ Executes an SQL statement on a database. For UPDATE, INSERT, and DELETE statemen
 | `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
 | `Sql` | SQL command | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL command to be executed. This property must be completed according to the selection from the Command type property |
 | `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
-| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 miliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
+| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 milliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
 | `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
@@ -1,0 +1,40 @@
+# Run Query
+
+`UiPath.Database.Activities.ExecuteQuery`
+
+Executes a query on a database and returns the query result as a Data Table
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
+| `Sql` | SQL query | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL query to be executed. This property must be completed according to the selection from the Command type property |
+| `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
+| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 miliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `DataTable` | Data table | OutArgument | `DataTable` | The output of the SQL command wrapped in a DataTable variable. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:ExecuteQuery DisplayName="Run Query" ExistingDbConnection="[value]" CommandType="[value]" Sql="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
@@ -17,13 +17,8 @@ Executes a query on a database and returns the query result as a Data Table
 | `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
 | `Sql` | SQL query | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL query to be executed. This property must be completed according to the selection from the Command type property |
 | `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
-| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 miliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
+| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 milliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
 | `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
@@ -1,0 +1,38 @@
+# Insert
+
+`UiPath.Database.Activities.InsertDataTable`
+
+Inserts a compatible DataTable in an existing database table. Returns the number of rows affected.
+
+**Package:** `UiPath.Database.Activities`
+**Category:** Database
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be inserted into the Table. The DataTable columns' name and description must match the ones from the database table. |
+| `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
+| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Input/Output
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `AffectedRecords` | Affected rows count | OutArgument | `int` | Number of affected rows. |
+
+## XAML Example
+
+```xml
+<Activity mc:Ignorable="sap sap2010" xmlns:db="clr-namespace:UiPath.Database.Activities;assembly=UiPath.Database.Activities">
+  <db:InsertDataTable DisplayName="Insert" ExistingDbConnection="[value]" DataTable="[value]" TableName="[value]" />
+</Activity>
+```

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
@@ -18,11 +18,6 @@ Inserts a compatible DataTable in an existing database table. Returns the number
 | `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
 | `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
-### Input/Output
-
-| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
-|------|-------------|------|------|----------|---------|-------------|-------------|
-
 ### Output
 
 | Name | Display Name | Kind | Type | Description |

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/overview.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/overview.md
@@ -1,0 +1,21 @@
+# UiPath Database Activities
+
+`UiPath.Database.Activities`
+
+## Documentation
+
+- [XAML Activities Reference](activities/) - Per-activity documentation for XAML workflows
+
+## Activities
+
+### Database
+
+| Activity | Description |
+|----------|-------------|
+| [Bulk Insert](activities/BulkInsert.md) | Updates a database table via Bulk operations of the specific database driver. Falls back to Insert Data Table if the database driver does not support Bulk operations. |
+| [Bulk Update](activities/BulkUpdate.md) | Updates a compatible DataTable in an existing database table. The activity also updates all the columns that are not in the collection of column names used as a primary key. Returns the number of rows affected. |
+| [Connect to Database](activities/DatabaseConnect.md) | Connects to a database by using a standard connection string |
+| [Disconnect from Database](activities/DatabaseDisconnect.md) | Closes a connection to a database |
+| [Insert](activities/InsertDataTable.md) | Inserts a compatible DataTable in an existing database table. Returns the number of rows affected. |
+| [Run Command](activities/ExecuteNonQuery.md) | Executes an SQL statement on a database. For UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the command. For all other types of statements, the return value is -1. |
+| [Run Query](activities/ExecuteQuery.md) | Executes a query on a database and returns the query result as a Data Table |


### PR DESCRIPTION
## What changed?
Added structured markdown documentation for all Database activity package activities. The docs include per-activity reference files covering inputs, outputs, configuration options, and copy-paste XAML examples, plus a package-level overview. Activities documented: BulkInsert, BulkUpdate, DatabaseConnect, DatabaseDisconnect, ExecuteNonQuery, ExecuteQuery, InsertDataTable.

## Why?
These docs are generated to support LLM CLI tooling (Claude Code and similar agents) that need machine-readable, structured activity references to assist developers working with the Database package.

## Jira Link
[STUD-79288]

## Dependencies
- [x] None

[STUD-79288]: https://uipath.atlassian.net/browse/STUD-79288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ