### PR TITLE
ftp: Add AI-generated XAML activity documentation [STUD-79289]

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/Delete.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/Delete.md
@@ -1,0 +1,34 @@
+# Delete File or Folder
+
+`UiPath.FTP.Activities.Delete`
+
+Removes a specified file from an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | File or folder to delete | Property | `Object` | Yes |  |  | Remote path to the file or folder |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `-` | - | - | `-` | - |
+
+## XAML Example
+
+```xml
+<ftp:Delete DisplayName="Delete File or Folder" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/Delete.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/Delete.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.Delete`
 
-Removes a specified file from an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+Removes a specified file from an FTP server. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,22 +13,16 @@ Removes a specified file from an FTP server. This activity only works if it is p
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | File or folder to delete | Property | `Object` | Yes |  |  | Remote path to the file or folder |
+| `RemotePath` | File or folder to delete | InArgument | `string` | Yes |  |  | Remote path to the file or folder. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Output
-
-| Name | Display Name | Kind | Type | Description |
-|------|-------------|------|------|-------------|
-| `-` | - | - | `-` | - |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ## XAML Example
 
 ```xml
-<ftp:Delete DisplayName="Delete File or Folder" />
+<ftp:Delete DisplayName="Delete File or Folder" RemotePath="/remote/path/file.txt" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DirectoryExists.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DirectoryExists.md
@@ -1,0 +1,34 @@
+# Directory Exists
+
+`UiPath.FTP.Activities.DirectoryExists`
+
+Checks whether a certain directory exists on an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | Folder Path | Property | `Object` | Yes |  |  | Remote folder path to check |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Exists` | Exists | OutArgument | `Object` | A boolean variable that states whether the indicated directory was found or not. |
+
+## XAML Example
+
+```xml
+<ftp:DirectoryExists DisplayName="Directory Exists" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DirectoryExists.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DirectoryExists.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.DirectoryExists`
 
-Checks whether a certain directory exists on an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+Checks whether a certain directory exists on an FTP server. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,22 +13,22 @@ Checks whether a certain directory exists on an FTP server. This activity only w
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | Folder Path | Property | `Object` | Yes |  |  | Remote folder path to check |
+| `RemotePath` | Folder Path | InArgument | `string` | Yes |  |  | Remote folder path to check. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Exists` | Exists | OutArgument | `Object` | A boolean variable that states whether the indicated directory was found or not. |
+| `Exists` | Exists | OutArgument | `bool` | A boolean variable that states whether the indicated directory was found or not. |
 
 ## XAML Example
 
 ```xml
-<ftp:DirectoryExists DisplayName="Directory Exists" />
+<ftp:DirectoryExists DisplayName="Directory Exists" RemotePath="/remote/folder" Exists="[dirExists]" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DownloadFiles.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DownloadFiles.md
@@ -1,0 +1,38 @@
+# Download Files
+
+`UiPath.FTP.Activities.DownloadFiles`
+
+Downloads the specified files from an FTP server to the specified local folder. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | Path to files to download | Property | `Object` | Yes |  |  | The path of the files on the FTP server that are to be downloaded. |
+| `LocalPath` | Where to download | Property | `Object` | Yes |  |  | The local path for the files that are to be downloaded. |
+| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this box is checked, the folders will be downloaded with their respective subfolders. |
+| `Create` | Create | Property | `Object` |  |  |  | If this box is checked, the folder path will be created locally in case it does not already exist. |
+| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten locally if they're already stored there. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `-` | - | - | `-` | - |
+
+## XAML Example
+
+```xml
+<ftp:DownloadFiles DisplayName="Download Files" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DownloadFiles.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/DownloadFiles.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.DownloadFiles`
 
-Downloads the specified files from an FTP server to the specified local folder. This activity only works if it is placed inside a With FTP Session scope activity.
+Downloads the specified files from an FTP server to the specified local folder. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,26 +13,20 @@ Downloads the specified files from an FTP server to the specified local folder. 
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | Path to files to download | Property | `Object` | Yes |  |  | The path of the files on the FTP server that are to be downloaded. |
-| `LocalPath` | Where to download | Property | `Object` | Yes |  |  | The local path for the files that are to be downloaded. |
-| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this box is checked, the folders will be downloaded with their respective subfolders. |
-| `Create` | Create | Property | `Object` |  |  |  | If this box is checked, the folder path will be created locally in case it does not already exist. |
-| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten locally if they're already stored there. |
+| `RemotePath` | Path to files to download | InArgument | `string` | Yes |  |  | The path of the files on the FTP server that are to be downloaded. |
+| `LocalPath` | Where to download | InArgument | `string` | Yes |  |  | The local path for the files that are to be downloaded. |
+| `Recursive` | Include subfolders | Property | `bool` |  |  |  | If this box is checked, the folders will be downloaded with their respective subfolders. |
+| `Create` | Create | Property | `bool` |  |  |  | If this box is checked, the folder path will be created locally in case it does not already exist. |
+| `Overwrite` | Overwrite | Property | `bool` |  |  |  | If this box is checked, the files will be overwritten locally if they're already stored there. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Output
-
-| Name | Display Name | Kind | Type | Description |
-|------|-------------|------|------|-------------|
-| `-` | - | - | `-` | - |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ## XAML Example
 
 ```xml
-<ftp:DownloadFiles DisplayName="Download Files" />
+<ftp:DownloadFiles DisplayName="Download Files" RemotePath="/remote/files/*" LocalPath="C:\\local\\downloads" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/EnumerateObjects.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/EnumerateObjects.md
@@ -1,0 +1,36 @@
+# Enumerate Objects
+
+`UiPath.FTP.Activities.EnumerateObjects`
+
+Generates a collection of files that have been found on the FTP server. Subfolders can also be included in the search by checking the Includes subfolders box. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | Remote Path | Property | `Object` | Yes |  |  | The path of the directory on the FTP server whose files are to be enumerated. |
+| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this check box is selected, the subfolders are also included in the enumeration of the files on the FTP server. |
+| `Filter` | Object types | Property | `Object` |  |  |  | Filters items based on type (what is selected will be included) |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Files` | Files | OutArgument | `Object` | A collection of files that have been found on the FTP server. |
+
+## XAML Example
+
+```xml
+<ftp:EnumerateObjects DisplayName="Enumerate Objects" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/EnumerateObjects.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/EnumerateObjects.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.EnumerateObjects`
 
-Generates a collection of files that have been found on the FTP server. Subfolders can also be included in the search by checking the Includes subfolders box. This activity only works if it is placed inside a With FTP Session scope activity.
+Generates a collection of files that have been found on the FTP server. Subfolders can also be included in the search by checking the Includes subfolders box. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,24 +13,24 @@ Generates a collection of files that have been found on the FTP server. Subfolde
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | Remote Path | Property | `Object` | Yes |  |  | The path of the directory on the FTP server whose files are to be enumerated. |
-| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this check box is selected, the subfolders are also included in the enumeration of the files on the FTP server. |
-| `Filter` | Object types | Property | `Object` |  |  |  | Filters items based on type (what is selected will be included) |
+| `RemotePath` | Remote Path | InArgument | `string` | Yes |  |  | The path of the directory on the FTP server whose files are to be enumerated. |
+| `Recursive` | Include subfolders | Property | `bool` |  |  |  | If this check box is selected, the subfolders are also included in the enumeration of the files on the FTP server. |
+| `Filter` | Object types | Property | `FtpFilterObjectType` |  |  |  | Filters items based on type (what is selected will be included). |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Files` | Files | OutArgument | `Object` | A collection of files that have been found on the FTP server. |
+| `Files` | Files | OutArgument | `IEnumerable<FtpObjectInfo>` | A collection of files that have been found on the FTP server. |
 
 ## XAML Example
 
 ```xml
-<ftp:EnumerateObjects DisplayName="Enumerate Objects" />
+<ftp:EnumerateObjects DisplayName="Enumerate Objects" RemotePath="/remote/files" Files="[ftpFiles]" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/FileExists.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/FileExists.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.FileExists`
 
-Checks whether a certain file exists in the specified FTP directory. This activity only works if it is placed inside a With FTP Session scope activity.
+Checks whether a certain file exists in the specified FTP directory. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,22 +13,22 @@ Checks whether a certain file exists in the specified FTP directory. This activi
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | File Path | Property | `Object` | Yes |  |  | Remote file path to check |
+| `RemotePath` | File Path | InArgument | `string` | Yes |  |  | Remote file path to check. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `Exists` | Exists | OutArgument | `Object` | A boolean variable that states whether the indicated file was found or not. |
+| `Exists` | Exists | OutArgument | `bool` | A boolean variable that states whether the indicated file was found or not. |
 
 ## XAML Example
 
 ```xml
-<ftp:FileExists DisplayName="File Exists" />
+<ftp:FileExists DisplayName="File Exists" RemotePath="/remote/path/file.txt" Exists="[fileExists]" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/FileExists.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/FileExists.md
@@ -1,0 +1,34 @@
+# File Exists
+
+`UiPath.FTP.Activities.FileExists`
+
+Checks whether a certain file exists in the specified FTP directory. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | File Path | Property | `Object` | Yes |  |  | Remote file path to check |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Exists` | Exists | OutArgument | `Object` | A boolean variable that states whether the indicated file was found or not. |
+
+## XAML Example
+
+```xml
+<ftp:FileExists DisplayName="File Exists" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/MoveItem.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/MoveItem.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.MoveItem`
 
-Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a With FTP
+Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,24 +13,18 @@ Moves an item on an FTP server to a different remote path. This activity only wo
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `RemotePath` | File or folder to move | Property | `Object` | Yes |  |  | Remote path |
-| `NewPath` | Where to move | Property | `Object` | Yes |  |  | The new path where to move the item |
-| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten in the new remote directory if they're already stored there. |
+| `RemotePath` | File or folder to move | InArgument | `string` | Yes |  |  | Remote path of the item to move. |
+| `NewPath` | Where to move | InArgument | `string` | Yes |  |  | The new remote path to move the item to. |
+| `Overwrite` | Overwrite | Property | `bool` |  |  |  | If this box is checked, the files will be overwritten in the new remote directory if they're already stored there. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Output
-
-| Name | Display Name | Kind | Type | Description |
-|------|-------------|------|------|-------------|
-| `-` | - | - | `-` | - |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ## XAML Example
 
 ```xml
-<ftp:MoveItem DisplayName="Move File or Folder" />
+<ftp:MoveItem DisplayName="Move File or Folder" RemotePath="/remote/source/file.txt" NewPath="/remote/destination/file.txt" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/MoveItem.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/MoveItem.md
@@ -1,0 +1,36 @@
+# Move File or Folder
+
+`UiPath.FTP.Activities.MoveItem`
+
+Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a With FTP
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RemotePath` | File or folder to move | Property | `Object` | Yes |  |  | Remote path |
+| `NewPath` | Where to move | Property | `Object` | Yes |  |  | The new path where to move the item |
+| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten in the new remote directory if they're already stored there. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `-` | - | - | `-` | - |
+
+## XAML Example
+
+```xml
+<ftp:MoveItem DisplayName="Move File or Folder" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/UploadFiles.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/UploadFiles.md
@@ -2,7 +2,7 @@
 
 `UiPath.FTP.Activities.UploadFiles`
 
-Uploads a file to an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+Uploads a file to an FTP server. This activity only works if it is placed inside a [Use FTP Connection](WithFtpSession.md) scope activity.
 
 **Package:** `UiPath.FTP.Activities`
 **Category:** FTP
@@ -13,26 +13,20 @@ Uploads a file to an FTP server. This activity only works if it is placed inside
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `LocalPath` | Files to upload | Property | `Object` | Yes |  |  | Local path |
-| `RemotePath` | Where to upload | Property | `Object` | Yes |  |  | Remote path |
-| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this box is checked, the folders will be uploaded with their respective subfolders. |
-| `Create` | Create | Property | `Object` |  |  |  | If this box is checked, the folder path will be created on the FTP server in case it does not already exist. |
-| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten on the FTP server if they're already stored there. |
+| `LocalPath` | Files to upload | InArgument | `string` | Yes |  |  | Local path of the files to upload. |
+| `RemotePath` | Where to upload | InArgument | `string` | Yes |  |  | Remote destination path on the FTP server. |
+| `Recursive` | Include subfolders | Property | `bool` |  |  |  | If this box is checked, the folders will be uploaded with their respective subfolders. |
+| `Create` | Create | Property | `bool` |  |  |  | If this box is checked, the folder path will be created on the FTP server in case it does not already exist. |
+| `Overwrite` | Overwrite | Property | `bool` |  |  |  | If this box is checked, the files will be overwritten on the FTP server if they're already stored there. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Output
-
-| Name | Display Name | Kind | Type | Description |
-|------|-------------|------|------|-------------|
-| `-` | - | - | `-` | - |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ## XAML Example
 
 ```xml
-<ftp:UploadFiles DisplayName="Upload Files" />
+<ftp:UploadFiles DisplayName="Upload Files" LocalPath="C:\\local\\files" RemotePath="/remote/destination" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/UploadFiles.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/UploadFiles.md
@@ -1,0 +1,38 @@
+# Upload Files
+
+`UiPath.FTP.Activities.UploadFiles`
+
+Uploads a file to an FTP server. This activity only works if it is placed inside a With FTP Session scope activity.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `LocalPath` | Files to upload | Property | `Object` | Yes |  |  | Local path |
+| `RemotePath` | Where to upload | Property | `Object` | Yes |  |  | Remote path |
+| `Recursive` | Include subfolders | Property | `Object` |  |  |  | If this box is checked, the folders will be uploaded with their respective subfolders. |
+| `Create` | Create | Property | `Object` |  |  |  | If this box is checked, the folder path will be created on the FTP server in case it does not already exist. |
+| `Overwrite` | Overwrite | Property | `Object` |  |  |  | If this box is checked, the files will be overwritten on the FTP server if they're already stored there. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `-` | - | - | `-` | - |
+
+## XAML Example
+
+```xml
+<ftp:UploadFiles DisplayName="Upload Files" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/WithFtpSession.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/WithFtpSession.md
@@ -1,0 +1,57 @@
+# Use FTP Connection
+
+`UiPath.FTP.Activities.WithFtpSession`
+
+Connects to FTP server and provides a scope for other FTP activities.
+
+**Package:** `UiPath.FTP.Activities`
+**Category:** FTP
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Body` | Body | Property | `Object` |  |  |  |  |
+| `Host` | Host | Property | `Object` | Yes |  |  | The URL of the FTP server that you want to connect to. |
+| `Port` | Port | Property | `Object` |  |  |  | The port of the FTP server that you want to connect to. |
+| `Timeout` | Timeout (milliseconds) | Property | `Object` |  |  |  | The timeout value (in milliseconds) for the FTP/SFTP connection. If not set, the default timeout of the underlying library is used. |
+| `Username` | Username | Property | `Object` |  |  |  | The username that will be used to connect to the FTP server. |
+| `Password` | Password | Property | `Object` |  |  |  | The password that will be used to connect to the FTP server. |
+| `SecurePassword` | Secure Password | Property | `Object` |  |  |  | The password in secure string format |
+| `PasswordInputModeSwitch` | PasswordInputModeSwitch | Property | `Object` |  |  |  | The switch for password input mode |
+| `UseAnonymousLogin` | Use Anonymous Login | Property | `Object` |  |  |  | When this box is checked, the username and password fields are ignored, and a standard anonymous user is used instead. |
+| `FtpsMode` | FTPS Mode | Property | `Object` |  |  |  | Switches to the FTPS protocol. Choose one of the two available options: Explicit or Implicit. |
+| `SslProtocols` | SSL Protocols | Property | `Object` |  |  |  | Select the SSL protocol to be used for the FTPS connection |
+| `UseSftp` | Use SFTP | Property | `Object` |  |  |  | Check this box if you want to use the SFTP transfer protocol. |
+| `ClientCertificatePath` | Client Certificate File | Property | `Object` |  |  |  | The path to the certificate used to verify the identity of the client. |
+| `ClientCertificatePassword` | Client Certificate Password | Property | `Object` |  |  |  | The password for the client certificate. |
+| `ClientCertificateSecurePassword` | Client Certificate Secure Password | Property | `Object` |  |  |  | The password for client certificate in secure string format |
+| `CertificatePasswordInputModeSwitch` | SecurePasswordInputModeSwitch | Property | `Object` |  |  |  | The switch for certificate password input mode |
+| `AcceptAllCertificates` | Accept All Certificates | Property | `Object` |  |  |  | If this box is checked, all certificates will be accepted, including the ones that are expired or not verified. |
+| `ProxyType` | Proxy Type | Property | `Object` |  |  |  | The type of proxy |
+| `ProxyServer` | Proxy Host | Property | `Object` |  |  |  | Proxy host name |
+| `ProxyPort` | Proxy Host Port | Property | `Object` |  |  |  | Proxy port number |
+| `ProxyUser` | Proxy Username | Property | `Object` |  |  |  | The user used for proxy if authentication is required |
+| `ProxyPassword` | Proxy Password | Property | `Object` |  |  |  | The password used for proxy if authentication is required |
+| `ProxySecurePassword` | Proxy Secure Password | Property | `Object` |  |  |  | The proxy password in secure string format |
+| `ProxyPasswordInputModeSwitch` | ProxyPasswordInputModeSwitch | Property | `Object` |  |  |  |  |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `-` | - | - | `-` | - |
+
+## XAML Example
+
+```xml
+<ftp:WithFtpSession DisplayName="Use FTP Connection" />
+```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/WithFtpSession.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/activities/WithFtpSession.md
@@ -13,45 +13,35 @@ Connects to FTP server and provides a scope for other FTP activities.
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `Body` | Body | Property | `Object` |  |  |  |  |
-| `Host` | Host | Property | `Object` | Yes |  |  | The URL of the FTP server that you want to connect to. |
-| `Port` | Port | Property | `Object` |  |  |  | The port of the FTP server that you want to connect to. |
-| `Timeout` | Timeout (milliseconds) | Property | `Object` |  |  |  | The timeout value (in milliseconds) for the FTP/SFTP connection. If not set, the default timeout of the underlying library is used. |
-| `Username` | Username | Property | `Object` |  |  |  | The username that will be used to connect to the FTP server. |
-| `Password` | Password | Property | `Object` |  |  |  | The password that will be used to connect to the FTP server. |
-| `SecurePassword` | Secure Password | Property | `Object` |  |  |  | The password in secure string format |
-| `PasswordInputModeSwitch` | PasswordInputModeSwitch | Property | `Object` |  |  |  | The switch for password input mode |
-| `UseAnonymousLogin` | Use Anonymous Login | Property | `Object` |  |  |  | When this box is checked, the username and password fields are ignored, and a standard anonymous user is used instead. |
-| `FtpsMode` | FTPS Mode | Property | `Object` |  |  |  | Switches to the FTPS protocol. Choose one of the two available options: Explicit or Implicit. |
-| `SslProtocols` | SSL Protocols | Property | `Object` |  |  |  | Select the SSL protocol to be used for the FTPS connection |
-| `UseSftp` | Use SFTP | Property | `Object` |  |  |  | Check this box if you want to use the SFTP transfer protocol. |
-| `ClientCertificatePath` | Client Certificate File | Property | `Object` |  |  |  | The path to the certificate used to verify the identity of the client. |
-| `ClientCertificatePassword` | Client Certificate Password | Property | `Object` |  |  |  | The password for the client certificate. |
-| `ClientCertificateSecurePassword` | Client Certificate Secure Password | Property | `Object` |  |  |  | The password for client certificate in secure string format |
-| `CertificatePasswordInputModeSwitch` | SecurePasswordInputModeSwitch | Property | `Object` |  |  |  | The switch for certificate password input mode |
-| `AcceptAllCertificates` | Accept All Certificates | Property | `Object` |  |  |  | If this box is checked, all certificates will be accepted, including the ones that are expired or not verified. |
-| `ProxyType` | Proxy Type | Property | `Object` |  |  |  | The type of proxy |
-| `ProxyServer` | Proxy Host | Property | `Object` |  |  |  | Proxy host name |
-| `ProxyPort` | Proxy Host Port | Property | `Object` |  |  |  | Proxy port number |
-| `ProxyUser` | Proxy Username | Property | `Object` |  |  |  | The user used for proxy if authentication is required |
-| `ProxyPassword` | Proxy Password | Property | `Object` |  |  |  | The password used for proxy if authentication is required |
-| `ProxySecurePassword` | Proxy Secure Password | Property | `Object` |  |  |  | The proxy password in secure string format |
-| `ProxyPasswordInputModeSwitch` | ProxyPasswordInputModeSwitch | Property | `Object` |  |  |  |  |
+| `Host` | Host | InArgument | `string` | Yes |  |  | The URL of the FTP server that you want to connect to. |
+| `Port` | Port | InArgument | `int` |  |  |  | The port of the FTP server that you want to connect to. |
+| `Timeout` | Timeout (milliseconds) | InArgument | `int` |  |  |  | The timeout value (in milliseconds) for the FTP/SFTP connection. If not set, the default timeout of the underlying library is used. |
+| `Username` | Username | InArgument | `string` |  |  |  | The username that will be used to connect to the FTP server. |
+| `Password` | Password | InArgument | `string` |  |  |  | The password that will be used to connect to the FTP server. |
+| `SecurePassword` | Secure Password | InArgument | `SecureString` |  |  |  | The password in secure string format. Provide either `Password` or `SecurePassword`. |
+| `UseAnonymousLogin` | Use Anonymous Login | Property | `bool` |  |  |  | When this box is checked, the username and password fields are ignored, and a standard anonymous user is used instead. |
+| `FtpsMode` | FTPS Mode | Property | `FtpsMode` |  |  |  | Switches to the FTPS protocol. Choose one of the two available options: Explicit or Implicit. |
+| `SslProtocols` | SSL Protocols | Property | `FtpSslProtocols` |  |  |  | Select the SSL protocol to be used for the FTPS connection. |
+| `UseSftp` | Use SFTP | Property | `bool` |  |  |  | Check this box if you want to use the SFTP transfer protocol. |
+| `ClientCertificatePath` | Client Certificate File | InArgument | `string` |  |  |  | The path to the certificate used to verify the identity of the client. |
+| `ClientCertificatePassword` | Client Certificate Password | InArgument | `string` |  |  |  | The password for the client certificate. |
+| `ClientCertificateSecurePassword` | Client Certificate Secure Password | InArgument | `SecureString` |  |  |  | The password for client certificate in secure string format. |
+| `AcceptAllCertificates` | Accept All Certificates | Property | `bool` |  |  |  | If this box is checked, all certificates will be accepted, including the ones that are expired or not verified. |
+| `ProxyType` | Proxy Type | Property | `FtpProxyType` |  |  |  | The type of proxy. |
+| `ProxyServer` | Proxy Host | InArgument | `string` |  |  |  | Proxy host name. |
+| `ProxyPort` | Proxy Host Port | InArgument | `int` |  |  |  | Proxy port number. |
+| `ProxyUser` | Proxy Username | InArgument | `string` |  |  |  | The user used for proxy if authentication is required. |
+| `ProxyPassword` | Proxy Password | InArgument | `string` |  |  |  | The password used for proxy if authentication is required. |
+| `ProxySecurePassword` | Proxy Secure Password | InArgument | `SecureString` |  |  |  | The proxy password in secure string format. |
 
 ### Configuration
 
 | Name | Display Name | Type | Default | Description |
 |------|-------------|------|---------|-------------|
-| `ContinueOnError` | Continue On Error | `Object` |  | Specifies if the automation should continue even when the activity throws an error. |
-
-### Output
-
-| Name | Display Name | Kind | Type | Description |
-|------|-------------|------|------|-------------|
-| `-` | - | - | `-` | - |
+| `ContinueOnError` | Continue On Error | `bool` |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ## XAML Example
 
 ```xml
-<ftp:WithFtpSession DisplayName="Use FTP Connection" />
+<ftp:WithFtpSession DisplayName="Use FTP Connection" Host="ftp.example.com" Username="[ftpUser]" Password="[ftpPass]" />
 ```

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/overview.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/overview.md
@@ -11,6 +11,6 @@
 | [Download Files](activities/DownloadFiles.md) | Downloads the specified files from an FTP server to the specified local folder. This activity only works if it is placed inside a With FTP Session scope activity. |
 | [Enumerate Objects](activities/EnumerateObjects.md) | Generates a collection of files that have been found on the FTP server. Subfolders can also be included in the search by checking the Includes subfolders box. This activity only works if it is placed inside a With FTP Session scope activity. |
 | [File Exists](activities/FileExists.md) | Checks whether a certain file exists in the specified FTP directory. This activity only works if it is placed inside a With FTP Session scope activity. |
-| [Move File or Folder](activities/MoveItem.md) | Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a With FTP |
+| [Move File or Folder](activities/MoveItem.md) | Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a With FTP Session scope activity. |
 | [Upload Files](activities/UploadFiles.md) | Uploads a file to an FTP server. This activity only works if it is placed inside a With FTP Session scope activity. |
 | [Use FTP Connection](activities/WithFtpSession.md) | Connects to FTP server and provides a scope for other FTP activities. |

--- a/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/overview.md
+++ b/Activities/FTP/UiPath.FTP.Activities.Packaging/docs/overview.md
@@ -1,0 +1,16 @@
+# UiPath FTP Activities
+
+`UiPath.FTP.Activities`
+
+## Activities
+
+| Activity | Description |
+|----------|-------------|
+| [Delete File or Folder](activities/Delete.md) | Removes a specified file from an FTP server. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [Directory Exists](activities/DirectoryExists.md) | Checks whether a certain directory exists on an FTP server. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [Download Files](activities/DownloadFiles.md) | Downloads the specified files from an FTP server to the specified local folder. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [Enumerate Objects](activities/EnumerateObjects.md) | Generates a collection of files that have been found on the FTP server. Subfolders can also be included in the search by checking the Includes subfolders box. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [File Exists](activities/FileExists.md) | Checks whether a certain file exists in the specified FTP directory. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [Move File or Folder](activities/MoveItem.md) | Moves an item on an FTP server to a different remote path. This activity only works if it is placed inside a With FTP |
+| [Upload Files](activities/UploadFiles.md) | Uploads a file to an FTP server. This activity only works if it is placed inside a With FTP Session scope activity. |
+| [Use FTP Connection](activities/WithFtpSession.md) | Connects to FTP server and provides a scope for other FTP activities. |


### PR DESCRIPTION
## What changed?
Added structured per-activity markdown documentation for all 8 FTP activities plus a package overview:
- \WithFtpSession\, \UploadFiles\, \DownloadFiles\, \Delete\, \MoveItem\, \DirectoryExists\, \FileExists\, \EnumerateObjects\

Each doc covers inputs, outputs, configuration properties, and copy-paste XAML examples. A \docs/overview.md\ summarizes the package scope and activity index.

## Why?
These docs are generated to support LLM CLI tooling (Claude Code and similar agents) that need machine-readable, per-activity reference files to answer questions about activity usage without reading source code directly.

## Jira Link
[STUD-79289]

## Dependencies
- [x] None

[STUD-79289]: https://uipath.atlassian.net/browse/STUD-79289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ