### PR TITLE
credentials: Add AI-generated XAML activity docs for Credentials package [STUD-79292]

### DIFF
--- a/Activities/Credentials/UiPath.Credentials.Activities.ViewModels/Resources/ActivitiesMetadataWindows.json
+++ b/Activities/Credentials/UiPath.Credentials.Activities.ViewModels/Resources/ActivitiesMetadataWindows.json
@@ -98,7 +98,7 @@
     },
     {
       "fullName": "UiPath.Credentials.Activities.DeleteCredential",
-      "shortName": "AddCredential",
+      "shortName": "DeleteCredential",
       "displayNameKey": "Activity_DeleteCredential_Property_DeleteCredentialDisplayName_Name",
       "descriptionKey": "Activity_DeleteCredential_Property_DeleteCredentialDescription_Description",
       "displayNameAliasKeys": [
@@ -134,7 +134,7 @@
     },
     {
       "fullName": "UiPath.Credentials.Activities.GetSecureCredential",
-      "shortName": "AddCredential",
+      "shortName": "GetSecureCredential",
       "displayNameKey": "Activity_GetSecureCredential_Property_GetSecureCredentialDisplayName_Name",
       "descriptionKey": "Activity_GetSecureCredential_Property_GetSecureCredentialDescription_Description",
       "displayNameAliasKeys": [
@@ -157,8 +157,8 @@
         },
         {
           "name": "CredentialType",
-          "displayNameKey": "Activity_AddCredential_Property_CredentialType_Name",
-          "tooltipKey": "Activity_AddCredential_Property_CredentialType_Description",
+          "displayNameKey": "Activity_GetSecureCredential_Property_CredentialType_Name",
+          "tooltipKey": "Activity_GetSecureCredential_Property_CredentialType_Description",
           "isRequired": false,
           "isVisible": true,
           "isPrincipal": false,
@@ -187,7 +187,7 @@
           "isVisible": true,
           "isPrincipal": false,
           "category": {
-            "name": "Outpu",
+            "name": "Output",
             "displayNameKey": "Output"
           }
         },
@@ -218,7 +218,7 @@
     },
     {
       "fullName": "UiPath.Credentials.Activities.RequestCredential",
-      "shortName": "AddCredential",
+      "shortName": "RequestCredential",
       "displayNameKey": "Activity_RequestCredential_Property_RequestCredentialDisplayName_Name",
       "descriptionKey": "Activity_RequestCredential_Property_RequestCredentialDescription_Description",
       "displayNameAliasKeys": [

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/AddCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/AddCredential.md
@@ -81,6 +81,6 @@ Providing both or neither raises an exception at runtime.
 
 ## Notes
 
-- `Password` and `PasswordSecureString` are mutually exclusive. Providing both throws `ArgumentException`; providing neither throws `ArgumentNullException`.
+- `Password` and `PasswordSecureString` are mutually exclusive. Providing both throws `ArgumentException`; providing neither throws `ArgumentNullException`. Note: empty strings are treated as "provided" only in the mutual-exclusion check (so `Password=""` with `PasswordSecureString=<value>` raises `ArgumentException`), but as "not provided" in the neither-nor check (so `Password=""` with `PasswordSecureString=null` raises `ArgumentNullException`).
 - `CredentialType` accepts only `Generic` or `DomainPassword`. Using another value (e.g., `DomainCertificate`) produces a designer validation error.
 - This activity uses the Windows Credential Manager API (via the `CredentialManagement` library) and requires Windows.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/AddCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/AddCredential.md
@@ -1,0 +1,86 @@
+# Add Credentials
+
+`UiPath.Credentials.Activities.AddCredential`
+
+Stores a username and password credential in the Windows Credential Manager. Returns `true` if the credential was saved successfully.
+
+**Package:** `UiPath.Credentials.Activities`
+**Category:** System > Credentials
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Target` | Target | InArgument | `String` | Yes | | The application name or network location used as the credential key in Windows Credential Manager. |
+| `Username` | Username | InArgument | `String` | Yes | | The username to store. |
+| `CredentialType` | Credential Type | Property | `CredentialType` | | `Generic` | The type of credential. Only `Generic` and `DomainPassword` are supported; other values cause a validation error. |
+| `Password` | Password | InArgument | `String` | | | The plain-text password to store. Provide exactly one of `Password` or `PasswordSecureString`. |
+| `PasswordSecureString` | Secure String Password | InArgument | `SecureString` | | | The password as a `SecureString`. Provide exactly one of `Password` or `PasswordSecureString`. |
+| `PersistanceType` | PersistanceType | Property | `PersistanceType` | | `Enterprise` | Controls how long the credential persists in Windows Credential Manager. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `Boolean` | `True` if the credential was saved successfully; `False` otherwise. |
+
+### Enum Reference
+
+**`CredentialType`**: `Generic`, `DomainPassword`
+
+> Only `Generic` and `DomainPassword` are valid for this activity. Specifying any other value raises a validation error in the designer.
+
+**`PersistanceType`**:
+
+| Value | Description |
+|-------|-------------|
+| `Session` | Persists only for the life of the current logon session. |
+| `LocalComputer` | Persists on the local machine until explicitly deleted. |
+| `Enterprise` | Persists across all future logon sessions until explicitly deleted. |
+
+## Valid Configurations
+
+Exactly one password field must be provided:
+
+**Plain-text password** — Set `Password` to a string value. Leave `PasswordSecureString` unset.
+
+**Secure string password** — Set `PasswordSecureString` to a `SecureString` variable. Leave `Password` unset.
+
+Providing both or neither raises an exception at runtime.
+
+## XAML Example
+
+```xml
+<!-- Using plain-text password -->
+<cr:AddCredential
+    DisplayName="Add Credentials"
+    Target="MyApplication"
+    Username="domain\jsmith"
+    Password="[myPassword]"
+    CredentialType="Generic"
+    PersistanceType="Enterprise"
+    Result="[credentialSaved]"
+    xmlns:cr="clr-namespace:UiPath.Credentials.Activities;assembly=UiPath.Credentials.Activities" />
+```
+
+```xml
+<!-- Using secure string password -->
+<cr:AddCredential
+    DisplayName="Add Credentials"
+    Target="MyApplication"
+    Username="domain\jsmith"
+    PasswordSecureString="[mySecurePassword]"
+    CredentialType="Generic"
+    PersistanceType="Enterprise"
+    Result="[credentialSaved]"
+    xmlns:cr="clr-namespace:UiPath.Credentials.Activities;assembly=UiPath.Credentials.Activities" />
+```
+
+## Notes
+
+- `Password` and `PasswordSecureString` are mutually exclusive. Providing both throws `ArgumentException`; providing neither throws `ArgumentNullException`.
+- `CredentialType` accepts only `Generic` or `DomainPassword`. Using another value (e.g., `DomainCertificate`) produces a designer validation error.
+- This activity uses the Windows Credential Manager API (via the `CredentialManagement` library) and requires Windows.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/DeleteCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/DeleteCredential.md
@@ -34,5 +34,5 @@ Removes a stored credential from the Windows Credential Manager by its target na
 
 ## Notes
 
-- If no credential with the specified `Target` exists, the activity returns `false` without throwing an exception.
 - This activity uses the Windows Credential Manager API (via the `CredentialManagement` library) and requires Windows.
+- The behavior when a credential is not found depends on the underlying `CredentialManagement` library. Typically, the activity returns `false` if the credential does not exist, but this behavior is not guaranteed by the code in this package.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/DeleteCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/DeleteCredential.md
@@ -1,0 +1,38 @@
+# Delete Credentials
+
+`UiPath.Credentials.Activities.DeleteCredential`
+
+Removes a stored credential from the Windows Credential Manager by its target name. Returns `true` if the credential was deleted successfully.
+
+**Package:** `UiPath.Credentials.Activities`
+**Category:** System > Credentials
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Target` | Target | InArgument | `String` | Yes | | The application name or network location identifying the credential to delete. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `Boolean` | `True` if the credential was deleted successfully; `False` if it was not found. |
+
+## XAML Example
+
+```xml
+<cr:DeleteCredential
+    DisplayName="Delete Credentials"
+    Target="MyApplication"
+    Result="[credentialDeleted]"
+    xmlns:cr="clr-namespace:UiPath.Credentials.Activities;assembly=UiPath.Credentials.Activities" />
+```
+
+## Notes
+
+- If no credential with the specified `Target` exists, the activity returns `false` without throwing an exception.
+- This activity uses the Windows Credential Manager API (via the `CredentialManagement` library) and requires Windows.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/GetSecureCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/GetSecureCredential.md
@@ -1,0 +1,59 @@
+# Get Secure Credentials
+
+`UiPath.Credentials.Activities.GetSecureCredential`
+
+Retrieves a stored credential from the Windows Credential Manager, returning the password as a `SecureString`. Returns `true` if the credential was found and loaded successfully.
+
+**Package:** `UiPath.Credentials.Activities`
+**Category:** System > Credentials
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Target` | Target | InArgument | `String` | Yes | | The application name or network location identifying the credential to retrieve. |
+| `CredentialType` | Credential Type | Property | `CredentialType` | | `Generic` | The type of credential to look up. |
+| `PersistanceType` | PersistanceType | Property | `PersistanceType` | | `Enterprise` | The persistence scope of the credential to look up. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Username` | Username | OutArgument | `String` | The username retrieved from Credential Manager. |
+| `Password` | Password | OutArgument | `SecureString` | The password retrieved from Credential Manager as a `SecureString`. |
+| `Result` | Result | OutArgument | `Boolean` | `True` if the credential was found and loaded; `False` if no matching credential exists. |
+
+### Enum Reference
+
+**`CredentialType`**: `Generic`, `DomainPassword`, `DomainCertificate`, `DomainVisiblePassword`, `GenericCertificate`, `DomainExtended`, `Maximum`, `MaximumEx`
+
+**`PersistanceType`**:
+
+| Value | Description |
+|-------|-------------|
+| `Session` | Persists only for the life of the current logon session. |
+| `LocalComputer` | Persists on the local machine until explicitly deleted. |
+| `Enterprise` | Persists across all future logon sessions until explicitly deleted. |
+
+## XAML Example
+
+```xml
+<cr:GetSecureCredential
+    DisplayName="Get Secure Credentials"
+    Target="MyApplication"
+    CredentialType="Generic"
+    PersistanceType="Enterprise"
+    Username="[retrievedUsername]"
+    Password="[retrievedSecurePassword]"
+    Result="[credentialFound]"
+    xmlns:cr="clr-namespace:UiPath.Credentials.Activities;assembly=UiPath.Credentials.Activities" />
+```
+
+## Notes
+
+- The password output is a `SecureString`, which is safer to use in downstream activities than a plain string. Use `System.Runtime.InteropServices.Marshal.PtrToStringBSTR(...)` or pass it directly to activities that accept `SecureString` inputs.
+- If no matching credential is found, `Result` is `false` and `Username`/`Password` are not set.
+- This activity uses the Windows Credential Manager API (via the `CredentialManagement` library) and requires Windows.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/RequestCredential.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/activities/RequestCredential.md
@@ -1,0 +1,48 @@
+# Request Credentials
+
+`UiPath.Credentials.Activities.RequestCredential`
+
+Displays the Windows Vista-style credential prompt dialog and returns the username and password entered by the user. Returns `true` if the user confirmed the dialog, or `false` if they cancelled.
+
+**Package:** `UiPath.Credentials.Activities`
+**Category:** System > Credentials
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Message` | Message | InArgument | `String` | | | Optional message to display in the credential prompt dialog. |
+| `Title` | Title | InArgument | `String` | | | Optional title for the credential prompt dialog. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Username` | Username | OutArgument | `String` | The username entered by the user. |
+| `Password` | Password | OutArgument | `String` | The password entered by the user as a plain-text string. |
+| `PasswordSecureString` | Secure String Password | OutArgument | `SecureString` | The password entered by the user as a `SecureString`. |
+| `Result` | Result | OutArgument | `Boolean` | `True` if the user clicked OK; `False` if the user cancelled the dialog. |
+
+## XAML Example
+
+```xml
+<cr:RequestCredential
+    DisplayName="Request Credentials"
+    Title="Enter your credentials"
+    Message="Please provide your login details to continue."
+    Username="[enteredUsername]"
+    Password="[enteredPassword]"
+    PasswordSecureString="[enteredSecurePassword]"
+    Result="[userConfirmed]"
+    xmlns:cr="clr-namespace:UiPath.Credentials.Activities;assembly=UiPath.Credentials.Activities" />
+```
+
+## Notes
+
+- Both `Password` (plain string) and `PasswordSecureString` (secure string) output the same value. Use `PasswordSecureString` when passing to activities that accept `SecureString` inputs for better security.
+- If `Result` is `false` (user cancelled), `Username`, `Password`, and `PasswordSecureString` are not populated.
+- This activity requires an interactive desktop session where a user can respond to the dialog. It is not suitable for unattended automation.
+- Uses the `VistaPrompt` from the `CredentialManagement` library with `GenericCredentials = true`.

--- a/Activities/Credentials/UiPath.Credentials.Packages/docs/overview.md
+++ b/Activities/Credentials/UiPath.Credentials.Packages/docs/overview.md
@@ -1,0 +1,16 @@
+# UiPath Credentials Activities
+
+**Package:** `UiPath.Credentials.Activities`
+
+Activities for reading and writing credentials stored in the **Windows Credential Manager**. Use these activities to securely manage application credentials in automation workflows.
+
+> **Platform:** All activities in this package are **Windows only**.
+
+## Activities
+
+| Activity | Description |
+|----------|-------------|
+| [Add Credentials](activities/AddCredential.md) | Stores a username and password in the Windows Credential Manager. |
+| [Delete Credentials](activities/DeleteCredential.md) | Removes a stored credential from the Windows Credential Manager. |
+| [Get Secure Credentials](activities/GetSecureCredential.md) | Retrieves a stored credential, returning the password as a `SecureString`. |
+| [Request Credentials](activities/RequestCredential.md) | Displays a Windows credential prompt dialog and returns the entered username and password. |


### PR DESCRIPTION
## What changed?
Added structured markdown documentation for all four activities in the UiPath Credentials package, plus a package overview:

- \AddCredential.md\ - inputs, outputs, configuration, and XAML example
- \DeleteCredential.md\ - inputs, outputs, configuration, and XAML example
- \GetSecureCredential.md\ - inputs, outputs, configuration, and XAML example
- \RequestCredential.md\ - inputs, outputs, configuration, and XAML example
- \overview.md\ - package-level summary and activity index

All files follow the per-activity reference format: property tables (type, default, description), valid combinations, and copy-paste XAML snippets.

## Why?
These docs are generated to support LLM CLI tooling (Claude Code and similar agents) that need structured, machine-readable activity references to assist with automation authoring. Covers the full Credentials package surface area.

## Jira Link
[STUD-79292]

## Dependencies
- [x] None

[STUD-79292]: https://uipath.atlassian.net/browse/STUD-79292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ