### PR TITLE
Database: Query support for DataSet [STUD-77624]

### DIFF
--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
@@ -2,7 +2,7 @@
 
 `UiPath.Database.Activities.ExecuteQuery`
 
-Executes a query on a database and returns the query result as a Data Table
+Executes a query on a database and returns the query result as a Data Table and optionally as a Data Set containing all result sets
 
 **Package:** `UiPath.Database.Activities`
 **Category:** Database
@@ -24,7 +24,8 @@ Executes a query on a database and returns the query result as a Data Table
 
 | Name | Display Name | Kind | Type | Description |
 |------|-------------|------|------|-------------|
-| `DataTable` | Data table | OutArgument | `DataTable` | The output of the SQL command wrapped in a DataTable variable. |
+| `DataTable` | Data table | OutArgument | `DataTable` | The output of the SQL command wrapped in a DataTable variable. Contains the first result set. |
+| `DataSet` | Data set | OutArgument | `DataSet` | The output of the SQL command wrapped in a DataSet variable. Contains all result sets returned by the query. |
 
 ## XAML Example
 

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -54,7 +54,6 @@ namespace UiPath.Database.Activities
 #endif
             try
             {
-                var dataTable = DataTable.Get(context);
                 string connString = null;
                 SecureString connSecureString = null;
                 string provName = null;

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -29,6 +29,12 @@ namespace UiPath.Database.Activities
         [LocalizedDescription(nameof(Resources.Activity_ExecuteQuery_Property_DataTable_Description))]
         public OutArgument<DataTable> DataTable { get; set; }
 
+        [LocalizedCategory(nameof(Resources.Output))]
+        [DefaultValue(null)]
+        [LocalizedDisplayName(nameof(Resources.Activity_ExecuteQuery_Property_DataSet_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_ExecuteQuery_Property_DataSet_Description))]
+        public OutArgument<DataSet> DataSet { get; set; }
+
         public ExecuteQuery()
         {
             CommandType = CommandType.Text;
@@ -95,7 +101,8 @@ namespace UiPath.Database.Activities
                         {
                             return null;
                         }
-                        return new DBExecuteQueryResult(DbConnection.ExecuteQuery(sql, parameters, commandTimeout, CommandType), parameters);
+                        var (resultTable, resultDataSet) = DbConnection.ExecuteQuery(sql, parameters, commandTimeout, CommandType);
+                        return new DBExecuteQueryResult(resultTable, resultDataSet, parameters);
                     });
                 }
                 catch (Exception ex)
@@ -118,7 +125,8 @@ namespace UiPath.Database.Activities
                     DataTable dt = affectedRecords?.Result;
                     if (dt == null) return;
 
-                    DataTable.Set(asyncCodeActivityContext, dt);
+                    DataTable?.Set(asyncCodeActivityContext, dt);
+                    DataSet?.Set(asyncCodeActivityContext, affectedRecords.DataSetResult);
                     foreach (var param in affectedRecords.ParametersBind)
                     {
                         var currentParam = Parameters[param.Key];
@@ -144,17 +152,20 @@ namespace UiPath.Database.Activities
         private class DBExecuteQueryResult
         {
             public DataTable Result { get; }
+            public DataSet DataSetResult { get; }
             public Dictionary<string, ParameterInfo> ParametersBind { get; }
 
             public DBExecuteQueryResult()
             {
                 this.Result = new DataTable();
+                this.DataSetResult = new DataSet();
                 this.ParametersBind = new Dictionary<string, ParameterInfo>();
             }
 
-            public DBExecuteQueryResult(DataTable result, Dictionary<string, ParameterInfo> parametersBind)
+            public DBExecuteQueryResult(DataTable result, DataSet dataSetResult, Dictionary<string, ParameterInfo> parametersBind)
             {
                 this.Result = result;
+                this.DataSetResult = dataSetResult;
                 this.ParametersBind = parametersBind;
             }
         }

--- a/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/ExecuteQueryViewModel.cs
+++ b/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/ExecuteQueryViewModel.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Security;
 using System.Threading.Tasks;
 using UiPath.Database.Activities.NetCore.ViewModels;
+using UiPath.Database.Activities.Properties;
 
 namespace UiPath.Database.Activities
 {
@@ -66,17 +67,24 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
         /// </summary>
         public DesignOutArgument<DataTable> DataTable { get; set; } = new DesignOutArgument<DataTable>();
 
+        /// <summary>
+        /// The result of the execution of the sql command as a DataSet.
+        /// </summary>
+        public DesignOutArgument<DataSet> DataSet { get; set; } = new DesignOutArgument<DataSet>();
+
         protected override void InitializeModel()
         {
             base.InitializeModel();
             int propertyOrderIndex = 1;
             int propertyColumnIndex = 1;
 
+            ExistingDbConnection.DisplayName = Resources.Activity_DatabaseExecute_Property_ExistingDbConnection_Name;
             ExistingDbConnection.IsPrincipal = true;
             ExistingDbConnection.IsRequired = true;
             ExistingDbConnection.OrderIndex = propertyOrderIndex++;
             ExistingDbConnection.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
+            CommandType.DisplayName = Resources.Activity_DatabaseExecute_Property_CommandType_Name;
             CommandType.OrderIndex = propertyOrderIndex++;
             CommandType.IsPrincipal = true;
             CommandType.IsRequired = true;
@@ -88,24 +96,36 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
                 .Build();
             CommandType.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
 
+            Sql.DisplayName = Resources.Activity_ExecuteQuery_Property_Sql_Name;
             Sql.IsPrincipal = true;
             Sql.IsRequired = true;
             Sql.OrderIndex = propertyOrderIndex++;
             Sql.Widget = new DefaultWidget { Type = ViewModelWidgetType.TextComposer };
 
+            Parameters.DisplayName = Resources.Activity_DatabaseExecute_Property_Parameters_Name;
             Parameters.OrderIndex = propertyOrderIndex++;
             Parameters.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dictionary };
 
+            TimeoutMS.DisplayName = Resources.Activity_DatabaseExecute_Property_TimeoutMS_Name;
             TimeoutMS.OrderIndex = propertyOrderIndex;
             TimeoutMS.ColumnOrder = propertyColumnIndex++;
             TimeoutMS.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
+            ContinueOnError.DisplayName = Resources.Activity_DatabaseExecute_Property_ContinueOnError_Name;
             ContinueOnError.OrderIndex = propertyOrderIndex++;
             ContinueOnError.ColumnOrder = propertyColumnIndex;
             ContinueOnError.Widget = new DefaultWidget { Type = ViewModelWidgetType.NullableBoolean };
 
+            DataTable.DisplayName = Resources.Activity_ExecuteQuery_Property_DataTable_Name;
             DataTable.OrderIndex = propertyOrderIndex++;
+            DataTable.Category = Resources.Output;
             DataTable.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
+
+            DataSet.DisplayName = Resources.Activity_ExecuteQuery_Property_DataSet_Name;
+            DataSet.OrderIndex = propertyOrderIndex++;
+            DataSet.Category = Resources.Output;
+            DataSet.Tooltip = Resources.Activity_ExecuteQuery_Property_DataSet_Description;
+            DataSet.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
         }
 
         protected override async ValueTask InitializeModelAsync()

--- a/Activities/Database/UiPath.Database.Activities/Properties/UiPath.Database.Activities.Designer.cs
+++ b/Activities/Database/UiPath.Database.Activities/Properties/UiPath.Database.Activities.Designer.cs
@@ -1088,6 +1088,24 @@ namespace UiPath.Database.Activities.Properties {
                 return ResourceManager.GetString("Activity_ExecuteQuery_Property_DataTable_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The output of the SQL command wrapped in a DataSet variable.
+        /// </summary>
+        public static string Activity_ExecuteQuery_Property_DataSet_Description {
+            get {
+                return ResourceManager.GetString("Activity_ExecuteQuery_Property_DataSet_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Data set.
+        /// </summary>
+        public static string Activity_ExecuteQuery_Property_DataSet_Name {
+            get {
+                return ResourceManager.GetString("Activity_ExecuteQuery_Property_DataSet_Name", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to An SQL query to be executed. This property must be completed according to the selection from the Command type property.

--- a/Activities/Database/UiPath.Database.Activities/Properties/UiPath.Database.Activities.resx
+++ b/Activities/Database/UiPath.Database.Activities/Properties/UiPath.Database.Activities.resx
@@ -580,6 +580,14 @@ If UseTransaction is set to True, the contained operations are executed in a sin
     <value>Data table</value>
     <comment>property name</comment>
   </data>
+  <data name="Activity_ExecuteQuery_Property_DataSet_Description" xml:space="preserve">
+    <value>The output of the SQL command wrapped in a DataSet variable.</value>
+    <comment>property description</comment>
+  </data>
+  <data name="Activity_ExecuteQuery_Property_DataSet_Name" xml:space="preserve">
+    <value>Data set</value>
+    <comment>property name</comment>
+  </data>
   <data name="Activity_DatabaseExecute_Property_ExistingDbConnection_Description" xml:space="preserve">
     <value>An already opened database connection obtained from the Connect or Start Transaction activities. If such a connection is provided, the ConnectionString and SecureConnectionString properties are ignored.</value>
     <comment>property description</comment>

--- a/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
+++ b/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
@@ -110,6 +110,154 @@ namespace UiPath.Database.Tests
         }
 
         [Fact]
+        public void ExecuteQuery_SingleResultSet_ReturnsDataSetWithOneTable()
+        {
+            var con = new Mock<DbConnection>();
+            var cmd = new Mock<DbCommand>();
+            var dbParameterCollection = new Mock<DbParameterCollection>();
+            var iEnum = new List<DbParameter>();
+            var dataReader = new Mock<DbDataReader>();
+
+            con.SetReturnsDefault(cmd.Object);
+            cmd.SetReturnsDefault(dbParameterCollection.Object);
+            cmd.SetReturnsDefault(dataReader.Object);
+            dbParameterCollection.Setup(x => x.GetEnumerator()).Returns(iEnum.GetEnumerator());
+
+            bool readerClosed = false;
+
+            dataReader.Setup(r => r.FieldCount).Returns(1);
+            dataReader.Setup(r => r.GetName(0)).Returns("Col1");
+            dataReader.Setup(r => r.GetFieldType(0)).Returns(typeof(int));
+            dataReader.Setup(r => r.Read()).Returns(false);
+            dataReader.Setup(r => r.IsClosed).Returns(() => readerClosed);
+            dataReader.Setup(r => r.Close()).Callback(() => readerClosed = true);
+            dataReader.Setup(r => r.NextResult()).Returns(() => { readerClosed = true; return false; });
+
+            var databaseConnection = new DatabaseConnection().Initialize(con.Object);
+            var parameters = new Dictionary<string, ParameterInfo>();
+
+            var (resultTable, resultDataSet) = databaseConnection.ExecuteQuery("SELECT 1", parameters, 0);
+
+            Assert.NotNull(resultDataSet);
+            Assert.Single(resultDataSet.Tables);
+            Assert.Same(resultDataSet.Tables[0], resultTable);
+        }
+
+        [Fact]
+        public void ExecuteQuery_MultipleResultSets_ReturnsDataSetWithMultipleTables()
+        {
+            var con = new Mock<DbConnection>();
+            var cmd = new Mock<DbCommand>();
+            var dbParameterCollection = new Mock<DbParameterCollection>();
+            var iEnum = new List<DbParameter>();
+            var dataReader = new Mock<DbDataReader>();
+
+            con.SetReturnsDefault(cmd.Object);
+            cmd.SetReturnsDefault(dbParameterCollection.Object);
+            cmd.SetReturnsDefault(dataReader.Object);
+            dbParameterCollection.Setup(x => x.GetEnumerator()).Returns(iEnum.GetEnumerator());
+
+            // State tracking across result sets
+            bool inSecondResultSet = false;
+            bool secondRowRead = false;
+            bool readerClosed = false;
+
+            // Both result sets have 1 column; names differ to distinguish them
+            dataReader.Setup(r => r.FieldCount).Returns(1);
+            dataReader.Setup(r => r.GetName(0)).Returns(() => inSecondResultSet ? "SecondTableCol" : "FirstTableCol");
+            dataReader.Setup(r => r.GetFieldType(0)).Returns(typeof(string));
+            dataReader.Setup(r => r.Read()).Returns(() =>
+            {
+                if (inSecondResultSet && !secondRowRead)
+                {
+                    secondRowRead = true;
+                    return true;
+                }
+                return false;
+            });
+            dataReader.Setup(r => r.GetValues(It.IsAny<object[]>())).Returns((object[] vals) =>
+            {
+                vals[0] = "TestValue";
+                return 1;
+            });
+
+            // DataTable.Load calls NextResult after consuming first result set.
+            // First call: returns true (more results), advances to second result set.
+            // Second call: returns false (no more), reader is done.
+            int nextResultCalls = 0;
+            dataReader.Setup(r => r.NextResult()).Returns(() =>
+            {
+                nextResultCalls++;
+                if (nextResultCalls == 1) { inSecondResultSet = true; return true; }
+                readerClosed = true;
+                return false;
+            });
+
+            dataReader.Setup(r => r.IsClosed).Returns(() => readerClosed);
+            dataReader.Setup(r => r.Close()).Callback(() => readerClosed = true);
+
+            var databaseConnection = new DatabaseConnection().Initialize(con.Object);
+            var parameters = new Dictionary<string, ParameterInfo>();
+
+            var (resultTable, resultDataSet) = databaseConnection.ExecuteQuery("SELECT 1; SELECT 2", parameters, 0);
+
+            Assert.NotNull(resultDataSet);
+            Assert.Equal(2, resultDataSet.Tables.Count);
+            Assert.Same(resultDataSet.Tables[0], resultTable);
+            Assert.Single(resultDataSet.Tables[1].Columns);
+            Assert.Equal("SecondTableCol", resultDataSet.Tables[1].Columns[0].ColumnName);
+            Assert.Single(resultDataSet.Tables[1].Rows);
+            Assert.Equal("TestValue", resultDataSet.Tables[1].Rows[0][0]);
+        }
+
+        [Fact]
+        public void ExecuteQuery_DuplicateColumnNames_DeduplicatesInSubsequentResultSets()
+        {
+            var con = new Mock<DbConnection>();
+            var cmd = new Mock<DbCommand>();
+            var dbParameterCollection = new Mock<DbParameterCollection>();
+            var iEnum = new List<DbParameter>();
+            var dataReader = new Mock<DbDataReader>();
+
+            con.SetReturnsDefault(cmd.Object);
+            cmd.SetReturnsDefault(dbParameterCollection.Object);
+            cmd.SetReturnsDefault(dataReader.Object);
+            dbParameterCollection.Setup(x => x.GetEnumerator()).Returns(iEnum.GetEnumerator());
+
+            bool inSecondResultSet = false;
+            bool readerClosed = false;
+
+            // First result set: 1 column. Second: 2 columns with same name "Col".
+            dataReader.Setup(r => r.FieldCount).Returns(() => inSecondResultSet ? 2 : 1);
+            dataReader.Setup(r => r.GetName(It.IsAny<int>())).Returns("Col");
+            dataReader.Setup(r => r.GetFieldType(It.IsAny<int>())).Returns(typeof(string));
+            dataReader.Setup(r => r.Read()).Returns(false);
+
+            int nextResultCalls = 0;
+            dataReader.Setup(r => r.NextResult()).Returns(() =>
+            {
+                nextResultCalls++;
+                if (nextResultCalls == 1) { inSecondResultSet = true; return true; }
+                readerClosed = true;
+                return false;
+            });
+
+            dataReader.Setup(r => r.IsClosed).Returns(() => readerClosed);
+            dataReader.Setup(r => r.Close()).Callback(() => readerClosed = true);
+
+            var databaseConnection = new DatabaseConnection().Initialize(con.Object);
+            var parameters = new Dictionary<string, ParameterInfo>();
+
+            var (_, resultDataSet) = databaseConnection.ExecuteQuery("SELECT 1; SELECT 2", parameters, 0);
+
+            Assert.Equal(2, resultDataSet.Tables.Count);
+            var secondTable = resultDataSet.Tables[1];
+            Assert.Equal(2, secondTable.Columns.Count);
+            Assert.Equal("Col", secondTable.Columns[0].ColumnName);
+            Assert.Equal("Col1", secondTable.Columns[1].ColumnName);
+        }
+
+        [Fact]
         public void BulkInsertTest()
         {
             var dbDataTable = new DataTable();

--- a/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
+++ b/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
@@ -93,6 +93,10 @@ namespace UiPath.Database.Tests
             param.SetupAllProperties();
             param.SetReturnsDefault(ParameterDirection.InputOutput);
 
+            dataReader.Setup(r => r.FieldCount).Returns(0);
+            dataReader.Setup(r => r.Read()).Returns(false);
+            dataReader.Setup(r => r.NextResult()).Returns(false);
+
             var databaseConnection = new DatabaseConnection().Initialize(con.Object);
             var parameters = new Dictionary<string, ParameterInfo>() { 
                 { "param1", new ParameterInfo() {Value = "", Direction = ArgumentDirection.Out}

--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -64,13 +64,41 @@ namespace UiPath.Database
             _transaction = _connection.BeginTransaction();
         }
 
-        public virtual DataTable ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
+        // Caps the number of result sets read from a single ExecuteQuery call.
+        // Prevents unbounded iteration when a command returns an unexpected number of result sets.
+        private const int MaxResultSets = 100;
+
+        public virtual (DataTable ResultTable, DataSet ResultDataSet) ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
         {
             OpenConnection();
             SetupCommand(sql, parameters, commandTimeout, commandType);
             _command.Transaction = _transaction;
-            DataTable dt = new DataTable();
-            dt.Load(_command.ExecuteReader());
+            DataSet resultDataSet = new DataSet();
+            DataTable resultTable;
+            using (var reader = _command.ExecuteReader())
+            {
+                // First result set: DataTable.Load preserves exact backward-compatible behaviour
+                // (schema inference, PrimaryKey, constraints, LoadOption merging).
+                // Load internally calls reader.NextResult() after consuming the rows, and calls
+                // reader.Close() when NextResult() returns false, so IsClosed is reliable here.
+                var firstTable = new DataTable();
+                firstTable.Load(reader);
+                resultDataSet.Tables.Add(firstTable);
+
+                // Subsequent result sets: manual loop because Load already advanced the reader.
+                // reader.NextResult() is the authoritative termination signal.
+                int resultSetCount = 1;
+                while (!reader.IsClosed && resultSetCount < MaxResultSets)
+                {
+                    resultDataSet.Tables.Add(ReadResultSet(reader));
+                    resultSetCount++;
+
+                    if (!reader.NextResult())
+                        break;
+                }
+
+                resultTable = resultDataSet.Tables[0];
+            }
             foreach (var param in _command.Parameters)
             {
                 var dbParam = param as DbParameter;
@@ -80,7 +108,7 @@ namespace UiPath.Database
                     Direction = WokflowParameterDirectionToDbParameter(dbParam.Direction)
                 };
             }
-            return dt;
+            return (resultTable, resultDataSet);
         }
 
         public virtual int Execute(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
@@ -226,6 +254,47 @@ namespace UiPath.Database
                 }
             }
         }
+        // Reads the current result set from reader into a new DataTable.
+        // Deduplicates column names and falls back gracefully for unmapped provider types.
+        // Does NOT call NextResult — the caller owns result-set advancement.
+        private static DataTable ReadResultSet(DbDataReader reader)
+        {
+            var table = new DataTable();
+            var columnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                string name;
+                try { name = reader.GetName(i); } catch { name = null; }
+                if (string.IsNullOrEmpty(name))
+                    name = $"Column{i}";
+                string uniqueName = name;
+                int suffix = 1;
+                while (!columnNames.Add(uniqueName))
+                    uniqueName = $"{name}{suffix++}";
+
+                Type fieldType;
+                try { fieldType = reader.GetFieldType(i); } catch { fieldType = null; }
+                table.Columns.Add(uniqueName, fieldType ?? typeof(object));
+            }
+
+            var values = new object[reader.FieldCount];
+            table.BeginLoadData();
+            try
+            {
+                while (reader.Read())
+                {
+                    reader.GetValues(values);
+                    table.Rows.Add(values);
+                }
+            }
+            finally
+            {
+                table.EndLoadData();
+            }
+
+            return table;
+        }
+
         private DbProviderFactory GetCurrentFactory()
         {
             if (DbProviderFactories.GetFactory(_connection) == null)


### PR DESCRIPTION
###   Implementation Summary

  This PR adds DataSet output support to the ExecuteQuery database activity (STUD-77624). Previously, ExecuteQuery
  returned only a single DataTable (the first result set). Now it also returns a DataSet containing all result sets from
   queries that produce multiple result sets (e.g., stored procedures with multiple SELECTs).

  Changes:
  1. DatabaseConnection.ExecuteQuery — Return type changed from DataTable to (DataTable, DataSet). Uses a do/while loop
  with DataTable.Load(reader) to populate all result sets into a DataSet, then returns the first table as the legacy
  DataTable output.
  2. ExecuteQuery activity — New OutArgument<DataSet> DataSet property with [DefaultValue(null)]. The
  DBExecuteQueryResult inner class carries the DataSet through, and it's set on the activity context in the completion
  callback.
  3. ExecuteQueryViewModel — New DesignOutArgument<DataSet> DataSet property with display name, tooltip, category, and
  widget configuration. Also adds explicit DisplayName assignments to existing properties.
  4. Localization — New .resx entries for DataSet name and description.
  5. DatabaseExecute base class — Adds [DefaultValue(null)] to ContinueOnError and TimeoutMS (pre-existing properties
  that were missing it).
  6. Test — Adds mock setup for IsClosed/Close() on the DbDataReader to support the new do/while loop.