### PR TITLE
Database: Timeout support [STUD-77059]

### DIFF
--- a/Activities/Community.Activities.sln
+++ b/Activities/Community.Activities.sln
@@ -80,7 +80,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UiPath.Java.Test", "Java\Ui
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Python", "Python", "{913E6ED1-5915-4C4C-85BE-94E8CEE315FF}"
 	ProjectSection(SolutionItems) = preProject
-		Python\Python.build.props = Python\Python.build.props
+		Python\Directory.build.props = Python\Directory.build.props
+		Python\Directory.build.targets = Python\Directory.build.targets
 	EndProjectSection
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared.Service", "Shared\UiPath.Shared.Service\UiPath.Shared.Service.shproj", "{A6A27646-4889-4F95-A0DF-DD78D287388F}"

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkInsert.md
@@ -13,10 +13,11 @@ Updates a database table via Bulk operations of the specific database driver. Fa
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `ExistingDbConnection` | Existing connection | Property | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
 | `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be inserted into the Table. The DataTable columns' name and description must match the ones from the database table. |
 | `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
-| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+| `TimeoutMS` | Timeout | Property | `int` |  |  |  | Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown. If not set, the connection-level timeout is used; if no connection-level timeout is configured, defaults to 30 seconds. Must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `bool` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/BulkUpdate.md
@@ -13,12 +13,13 @@ Updates a compatible DataTable in an existing database table. The activity also 
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `ExistingDbConnection` | Existing connection | Property | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
 | `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be used to update the database table. The DataTable columns' name and description must match the columns from the database table and be a subset of them. |
 | `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be updated. |
 | `BulkUpdateFlag` | Bulk/batch update | Property | `bool` |  |  |  | Check this box to enable the creation of a temp table using Bulk insert and to update using join between tables. Otherwise, bulk updates are issued in batch. |
 | `ColumnNames` | Columns used for matching rows | InArgument | `string[]` | Yes |  | Column names used for row matching | The collection of column names used for row matching. These column names will not be changed by the Bulk Update activity. |
-| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+| `TimeoutMS` | Timeout | Property | `int` |  |  |  | Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown. If not set, the connection-level timeout is used; if no connection-level timeout is configured, defaults to 30 seconds. Must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `bool` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteNonQuery.md
@@ -13,12 +13,12 @@ Executes an SQL statement on a database. For UPDATE, INSERT, and DELETE statemen
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
-| `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
+| `ExistingDbConnection` | Existing connection | Property | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `CommandType` | Command type | Property | `CommandType` | Yes |  |  | Specifies how a command string is interpreted |
 | `Sql` | SQL command | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL command to be executed. This property must be completed according to the selection from the Command type property |
-| `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
-| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 milliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
-| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+| `Parameters` | Parameters | Property | `Dictionary<string, Argument>` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
+| `TimeoutMS` | Timeout | Property | `int` |  |  |  | Specifies the amount of time (in milliseconds) to wait for the SQL command to run before an error is thrown. If not set, the connection-level timeout is used; if no connection-level timeout is configured, defaults to 30 seconds. Must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `bool` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/ExecuteQuery.md
@@ -13,12 +13,12 @@ Executes a query on a database and returns the query result as a Data Table and 
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
-| `CommandType` | Command type | Property | `object` | Yes |  |  | Specifies how a command string is interpreted |
+| `ExistingDbConnection` | Existing connection | Property | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `CommandType` | Command type | Property | `CommandType` | Yes |  |  | Specifies how a command string is interpreted |
 | `Sql` | SQL query | InArgument | `string` | Yes |  | Provide an SQL statement that corresponds to the selected command type | An SQL query to be executed. This property must be completed according to the selection from the Command type property |
-| `Parameters` | Parameters | Property | `object` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
-| `TimeoutMS` | Timeout | Property | `object` |  |  | Default is 30000 milliseconds | Specifies the amount of time (in millisecond) to wait for the sql command to run before an error is thrown. The default value is 30000 milliseconds (30 seconds) and must be greater than or equal to 0. |
-| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+| `Parameters` | Parameters | Property | `Dictionary<string, Argument>` |  |  |  | A dictionary of named parameters that are bound to the SQL command. The binding is done by specifying the '@parameterName' statement in the SQL command. At runtime the parameterName will be replaced with its value from the dictionary. |
+| `TimeoutMS` | Timeout | Property | `int` |  |  |  | Specifies the amount of time (in milliseconds) to wait for the SQL command to run before an error is thrown. If not set, the connection-level timeout is used; if no connection-level timeout is configured, defaults to 30 seconds. Must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `bool` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
+++ b/Activities/Database/UiPath.Database.Activities.Packaging/docs/activities/InsertDataTable.md
@@ -13,10 +13,11 @@ Inserts a compatible DataTable in an existing database table. Returns the number
 
 | Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
 |------|-------------|------|------|----------|---------|-------------|-------------|
-| `ExistingDbConnection` | Existing connection | Property | `object` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
+| `ExistingDbConnection` | Existing connection | Property | `DatabaseConnection` | Yes |  | Use the output of the Connect to Database activity | An already opened database connection obtained from the Connect to Database activity. |
 | `DataTable` | Input data table | InArgument | `DataTable` | Yes |  | Provide the DataTable variable | The DataTable variable that will be inserted into the Table. The DataTable columns' name and description must match the ones from the database table. |
 | `TableName` | Target table name | InArgument | `string` | Yes |  | Provide the target database table name | The target database table in which the data is to be inserted |
-| `ContinueOnError` | Continue on error | Property | `object` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
+| `TimeoutMS` | Timeout | Property | `int` |  |  |  | Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown. If not set, the connection-level timeout is used; if no connection-level timeout is configured, defaults to 30 seconds. Must be greater than or equal to 0. |
+| `ContinueOnError` | Continue on error | Property | `bool` |  |  |  | Specifies if the automation should continue even when the activity throws an error. |
 
 ### Output
 

--- a/Activities/Database/UiPath.Database.Activities/BulkInsert.cs
+++ b/Activities/Database/UiPath.Database.Activities/BulkInsert.cs
@@ -56,8 +56,8 @@ namespace UiPath.Database.Activities
                 long affectedRecords = 0;
                 IExecutorRuntime executorRuntime = null;
                 var continueOnError = ContinueOnError.Get(context);
-                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
-                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                int? commandTimeoutMs = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeoutMs.HasValue && commandTimeoutMs.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
@@ -80,9 +80,9 @@ namespace UiPath.Database.Activities
                             return 0;
                         }
                         if (executorRuntime != null && executorRuntime.HasFeature(ExecutorFeatureKeys.LogMessage))
-                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeout, executorRuntime);
+                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeoutMs, executorRuntime);
                         else
-                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeout);
+                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeoutMs);
 
                     });
                 }

--- a/Activities/Database/UiPath.Database.Activities/BulkInsert.cs
+++ b/Activities/Database/UiPath.Database.Activities/BulkInsert.cs
@@ -56,6 +56,11 @@ namespace UiPath.Database.Activities
                 long affectedRecords = 0;
                 IExecutorRuntime executorRuntime = null;
                 var continueOnError = ContinueOnError.Get(context);
+                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                {
+                    throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
+                }
                 try
                 {
                     existingConnection = DbConnection = ExistingDbConnection.Get(context);
@@ -75,9 +80,9 @@ namespace UiPath.Database.Activities
                             return 0;
                         }
                         if (executorRuntime != null && executorRuntime.HasFeature(ExecutorFeatureKeys.LogMessage))
-                            return DbConnection.BulkInsertDataTable(tableName, dataTable, executorRuntime);
+                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeout, executorRuntime);
                         else
-                            return DbConnection.BulkInsertDataTable(tableName, dataTable);
+                            return DbConnection.BulkInsertDataTable(tableName, dataTable, commandTimeout);
 
                     });
                 }

--- a/Activities/Database/UiPath.Database.Activities/BulkUpdate.cs
+++ b/Activities/Database/UiPath.Database.Activities/BulkUpdate.cs
@@ -70,6 +70,11 @@ namespace UiPath.Database.Activities
                 long affectedRecords = 0;
                 IExecutorRuntime executorRuntime = null;
                 var continueOnError = ContinueOnError.Get(context);
+                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                {
+                    throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
+                }
                 try
                 {
                     existingConnection = DbConnection = ExistingDbConnection.Get(context);
@@ -89,9 +94,9 @@ namespace UiPath.Database.Activities
                             return 0;
                         }
                         if (executorRuntime != null && executorRuntime.HasFeature(ExecutorFeatureKeys.LogMessage))
-                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, executorRuntime);
+                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeout, executorRuntime);
                         else
-                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames);
+                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeout);
                     });
                 }
                 catch (Exception ex)

--- a/Activities/Database/UiPath.Database.Activities/BulkUpdate.cs
+++ b/Activities/Database/UiPath.Database.Activities/BulkUpdate.cs
@@ -70,8 +70,8 @@ namespace UiPath.Database.Activities
                 long affectedRecords = 0;
                 IExecutorRuntime executorRuntime = null;
                 var continueOnError = ContinueOnError.Get(context);
-                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
-                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                int? commandTimeoutMs = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeoutMs.HasValue && commandTimeoutMs.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
@@ -94,9 +94,9 @@ namespace UiPath.Database.Activities
                             return 0;
                         }
                         if (executorRuntime != null && executorRuntime.HasFeature(ExecutorFeatureKeys.LogMessage))
-                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeout, executorRuntime);
+                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeoutMs, executorRuntime);
                         else
-                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeout);
+                            return DbConnection.BulkUpdateDataTable(BulkUpdateFlag, tableName, dataTable, columnNames, commandTimeoutMs);
                     });
                 }
                 catch (Exception ex)

--- a/Activities/Database/UiPath.Database.Activities/ConnectionHelper.cs
+++ b/Activities/Database/UiPath.Database.Activities/ConnectionHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Activities;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Security;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +12,46 @@ namespace UiPath.Database.Activities
 {
     public class ConnectionHelper
     {
+        /// <summary>Rethrows the exception unless continueOnError is true.</summary>
+        public static void HandleException(Exception ex, bool continueOnError)
+        {
+            if (continueOnError) return;
+            throw ex;
+        }
+
+        /// <summary>Resolves activity Parameters into a typed dictionary using the current context.</summary>
+        public static Dictionary<string, ParameterInfo> BuildParameters(Dictionary<string, Argument> activityParameters, AsyncCodeActivityContext context)
+        {
+            if (activityParameters == null) return null;
+            var parameters = new Dictionary<string, ParameterInfo>();
+            foreach (var param in activityParameters)
+            {
+                parameters.Add(param.Key, new ParameterInfo() { Value = param.Value.Get(context), Direction = param.Value.Direction, Type = param.Value.ArgumentType });
+            }
+            return parameters;
+        }
+
+        /// <summary>Writes Out/InOut parameter values back to the activity's argument bindings.</summary>
+        public static void SetOutputParameters(AsyncCodeActivityContext context, Dictionary<string, Argument> activityParameters, Dictionary<string, ParameterInfo> parametersBind)
+        {
+            foreach (var param in parametersBind)
+            {
+                var currentParam = activityParameters[param.Key];
+                if (currentParam.Direction == ArgumentDirection.Out || currentParam.Direction == ArgumentDirection.InOut)
+                {
+                    currentParam.Set(context, param.Value.Value);
+                }
+            }
+        }
+
+        /// <summary>Ensures the DbConnection is initialised, creating one from the connection string if needed.</summary>
+        public static DatabaseConnection EnsureConnection(DatabaseConnection dbConnection, string connString, SecureString connSecureString, string provName)
+        {
+            if (dbConnection != null) return dbConnection;
+            return new DatabaseConnection().Initialize(connString ?? new NetworkCredential("", connSecureString).Password, provName);
+        }
+
+
         public static void ConnectionValidation(DatabaseConnection existingConnection, SecureString connSecureString = null, string connString = null, string provName = null)
         {
             if (existingConnection == null && connString == null && connSecureString == null && provName == null)

--- a/Activities/Database/UiPath.Database.Activities/DatabaseExecute.cs
+++ b/Activities/Database/UiPath.Database.Activities/DatabaseExecute.cs
@@ -14,8 +14,6 @@ namespace UiPath.Database.Activities
 {
     public abstract class DatabaseExecute : AsyncTaskCodeActivity
     {
-        private const int _defaultTimeout = 30000;
-
         protected DatabaseConnection DbConnection = null;
 
         [DefaultValue(null)]
@@ -61,17 +59,6 @@ namespace UiPath.Database.Activities
         [LocalizedDisplayName(nameof(Resources.Activity_DatabaseExecute_Property_TimeoutMS_Name))]
         [LocalizedDescription(nameof(Resources.Activity_DatabaseExecute_Property_TimeoutMS_Description))]
         public InArgument<int> TimeoutMS { get; set; }
-
-        protected sealed override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
-        {
-            if(TimeoutMS.Expression is null)
-            {
-                TimeoutMS.Set(context, _defaultTimeout);
-            }
-
-            return ExecuteInternalAsync(context, cancellationToken);
-        }
-        protected abstract Task<Action<AsyncCodeActivityContext>> ExecuteInternalAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken);
 
         protected override void CacheMetadata(CodeActivityMetadata metadata)
         {

--- a/Activities/Database/UiPath.Database.Activities/DatabaseRowActivity.cs
+++ b/Activities/Database/UiPath.Database.Activities/DatabaseRowActivity.cs
@@ -2,7 +2,6 @@
 using System.Activities;
 using System.Activities.Validation;
 using System.ComponentModel;
-using System.Data;
 using System.Security;
 using UiPath.Database.Activities.Properties;
 using UiPath.Shared.Activities;
@@ -38,6 +37,12 @@ namespace UiPath.Database.Activities
         [LocalizedDisplayName(nameof(Resources.Activity_DatabaseRowActivity_Property_ContinueOnError_Name))]
         [LocalizedDescription(nameof(Resources.Activity_DatabaseRowActivity_Property_ContinueOnError_Description))]
         public InArgument<bool> ContinueOnError { get; set; }
+
+        [LocalizedCategory(nameof(Resources.Common))]
+        [LocalizedDisplayName(nameof(Resources.Activity_DatabaseExecute_Property_TimeoutMS_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_DatabaseExecute_Property_TimeoutMS_Description))]
+        [DefaultValue(null)]
+        public InArgument<int> TimeoutMS { get; set; }
 
         protected static void HandleException(Exception ex, bool continueOnError)
         {

--- a/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
@@ -40,7 +40,7 @@ namespace UiPath.Database.Activities
             throw ex;
         }
 
-        protected async override Task<Action<AsyncCodeActivityContext>> ExecuteInternalAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
+        protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
             ITelemetryOperationWrapper telemetryOperation = null;
 #if ENABLE_DEFAULT_TELEMETRY
@@ -52,10 +52,10 @@ namespace UiPath.Database.Activities
                 SecureString connSecureString = null;
                 string provName = null;
                 string sql = string.Empty;
-                int commandTimeout = TimeoutMS.Get(context);
+                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
                 DatabaseConnection existingConnection = null;
                 DBExecuteCommandResult affectedRecords = null;
-                if (commandTimeout < 0)
+                if (commandTimeout.HasValue && commandTimeout.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, "TimeoutMS");
                 }

--- a/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
@@ -57,7 +57,7 @@ namespace UiPath.Database.Activities
                 DBExecuteCommandResult affectedRecords = null;
                 if (commandTimeout.HasValue && commandTimeout.Value < 0)
                 {
-                    throw new ArgumentException(Resources.TimeoutMSException, "TimeoutMS");
+                    throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
                 Dictionary<string, ParameterInfo> parameters = null;
                 var continueOnError = ContinueOnError.Get(context);

--- a/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteNonQuery.cs
@@ -3,7 +3,6 @@ using System.Activities;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Net;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,12 +33,6 @@ namespace UiPath.Database.Activities
             CommandType = CommandType.Text;
         }
 
-        private void HandleException(Exception ex, bool continueOnError)
-        {
-            if (continueOnError) return;
-            throw ex;
-        }
-
         protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
             ITelemetryOperationWrapper telemetryOperation = null;
@@ -52,10 +45,10 @@ namespace UiPath.Database.Activities
                 SecureString connSecureString = null;
                 string provName = null;
                 string sql = string.Empty;
-                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                int? commandTimeoutMs = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
                 DatabaseConnection existingConnection = null;
                 DBExecuteCommandResult affectedRecords = null;
-                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                if (commandTimeoutMs.HasValue && commandTimeoutMs.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
@@ -69,37 +62,17 @@ namespace UiPath.Database.Activities
                     connSecureString = ConnectionSecureString.Get(context);
                     provName = ProviderName.Get(context);
 
-                    if (Parameters != null)
-                    {
-                        parameters = new Dictionary<string, ParameterInfo>();
-                        foreach (var param in Parameters)
-                        {
-                            parameters.Add(param.Key, new ParameterInfo() { Value = param.Value.Get(context), Direction = param.Value.Direction, Type = param.Value.ArgumentType });
-                        }
-                    }
+                    parameters = ConnectionHelper.BuildParameters(Parameters, context);
                     ConnectionHelper.ConnectionValidation(existingConnection, connSecureString, connString, provName);
                     // create the action for doing the actual work
-                    affectedRecords = await Task.Run(() =>
-                    {
-                        DBExecuteCommandResult executeResult = new DBExecuteCommandResult();
-                        if (DbConnection == null)
-                        {
-                            DbConnection = new DatabaseConnection().Initialize(connString ?? new NetworkCredential("", connSecureString).Password, provName);
-                        }
-                        if (DbConnection == null)
-                        {
-                            return executeResult;
-                        }
-                        executeResult = new DBExecuteCommandResult(DbConnection.Execute(sql, parameters, commandTimeout, CommandType), parameters);
-                        return executeResult;
-                    });
+                    affectedRecords = await Task.Run(() => ExecuteCommand(connString, connSecureString, provName, sql, parameters, commandTimeoutMs));
                 }
                 catch (Exception ex)
                 {
                     // telemetryOperation object is made null in order to avoid double sending.
                     telemetryOperation?.SendWithException(ex);
                     telemetryOperation = null;
-                    HandleException(ex, continueOnError);
+                    ConnectionHelper.HandleException(ex, continueOnError);
                 }
                 finally
                 {
@@ -111,14 +84,7 @@ namespace UiPath.Database.Activities
                 var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
                 {
                     AffectedRecords.Set(asyncCodeActivityContext, affectedRecords.Result);
-                    foreach (var param in affectedRecords.ParametersBind)
-                    {
-                        var currentParam = Parameters[param.Key];
-                        if (currentParam.Direction == ArgumentDirection.Out || currentParam.Direction == ArgumentDirection.InOut)
-                        {
-                            currentParam.Set(asyncCodeActivityContext, param.Value.Value);
-                        }
-                    }
+                    ConnectionHelper.SetOutputParameters(asyncCodeActivityContext, Parameters, affectedRecords.ParametersBind);
                 });
 
                 //if exception was caught and sent to telemetry, avoid sending again
@@ -131,6 +97,16 @@ namespace UiPath.Database.Activities
                 telemetryOperation?.SendWithException(ex);
                 throw;
             }
+        }
+
+        private DBExecuteCommandResult ExecuteCommand(string connString, SecureString connSecureString, string provName, string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeoutMs)
+        {
+            DbConnection = ConnectionHelper.EnsureConnection(DbConnection, connString, connSecureString, provName);
+            if (DbConnection == null)
+            {
+                return new DBExecuteCommandResult();
+            }
+            return new DBExecuteCommandResult(DbConnection.Execute(sql, parameters, commandTimeoutMs, CommandType), parameters);
         }
 
         private class DBExecuteCommandResult

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -63,7 +63,7 @@ namespace UiPath.Database.Activities
                 int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
                 if (commandTimeout.HasValue && commandTimeout.Value < 0)
                 {
-                    throw new ArgumentException(Resources.TimeoutMSException, "TimeoutMS");
+                    throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
                 Dictionary<string, ParameterInfo> parameters = null;
                 var continueOnError = ContinueOnError.Get(context);

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -3,7 +3,6 @@ using System.Activities;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Net;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,12 +39,6 @@ namespace UiPath.Database.Activities
             CommandType = CommandType.Text;
         }
 
-        private void HandleException(Exception ex, bool continueOnError)
-        {
-            if (continueOnError) return;
-            throw ex;
-        }
-
         protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
             ITelemetryOperationWrapper telemetryOperation = null;
@@ -60,8 +53,8 @@ namespace UiPath.Database.Activities
                 string sql = string.Empty;
                 DatabaseConnection existingConnection = null;
                 DBExecuteQueryResult affectedRecords = null;
-                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
-                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                int? commandTimeoutMs = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeoutMs.HasValue && commandTimeoutMs.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
@@ -75,41 +68,17 @@ namespace UiPath.Database.Activities
                     sql = Sql.Get(context);
                     connSecureString = ConnectionSecureString.Get(context);
                     ConnectionHelper.ConnectionValidation(existingConnection, connSecureString, connString, provName);
-                    if (Parameters != null)
-                    {
-                        parameters = new Dictionary<string, ParameterInfo>();
-                        foreach (var param in Parameters)
-                        {
-                            parameters.Add(param.Key, new ParameterInfo()
-                            {
-                                Value = param.Value.Get(context),
-                                Direction = param.Value.Direction,
-                                Type = param.Value.ArgumentType
-                            });
-                        }
-                    }
+                    parameters = ConnectionHelper.BuildParameters(Parameters, context);
 
                     // create the action for doing the actual work
-                    affectedRecords = await Task.Run(() =>
-                    {
-                        if (DbConnection == null)
-                        {
-                            DbConnection = new DatabaseConnection().Initialize(connString != null ? connString : new NetworkCredential("", connSecureString).Password, provName);
-                        }
-                        if (DbConnection == null)
-                        {
-                            return null;
-                        }
-                        var (resultTable, resultDataSet) = DbConnection.ExecuteQuery(sql, parameters, commandTimeout, CommandType);
-                        return new DBExecuteQueryResult(resultTable, resultDataSet, parameters);
-                    });
+                    affectedRecords = await Task.Run(() => ExecuteQueryCommand(connString, connSecureString, provName, sql, parameters, commandTimeoutMs));
                 }
                 catch (Exception ex)
                 {
                     // telemetryOperation object is made null in order to avoid double sending.
                     telemetryOperation?.SendWithException(ex);
                     telemetryOperation = null;
-                    HandleException(ex, continueOnError);
+                    ConnectionHelper.HandleException(ex, continueOnError);
                 }
                 finally
                 {
@@ -121,19 +90,11 @@ namespace UiPath.Database.Activities
 
                 var result = new Action<AsyncCodeActivityContext>(asyncCodeActivityContext =>
                 {
-                    DataTable dt = affectedRecords?.Result;
-                    if (dt == null) return;
+                    if (affectedRecords == null) return;
 
-                    DataTable?.Set(asyncCodeActivityContext, dt);
+                    DataTable?.Set(asyncCodeActivityContext, affectedRecords.Result);
                     DataSet?.Set(asyncCodeActivityContext, affectedRecords.DataSetResult);
-                    foreach (var param in affectedRecords.ParametersBind)
-                    {
-                        var currentParam = Parameters[param.Key];
-                        if (currentParam.Direction == ArgumentDirection.Out || currentParam.Direction == ArgumentDirection.InOut)
-                        {
-                            currentParam.Set(asyncCodeActivityContext, param.Value.Value);
-                        }
-                    }
+                    ConnectionHelper.SetOutputParameters(asyncCodeActivityContext, Parameters, affectedRecords.ParametersBind);
                 });
 
                 //if exception was caught and sent to telemetry, avoid sending again
@@ -146,6 +107,17 @@ namespace UiPath.Database.Activities
                 telemetryOperation?.SendWithException(ex);
                 throw;
             }
+        }
+
+        private DBExecuteQueryResult ExecuteQueryCommand(string connString, SecureString connSecureString, string provName, string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeoutMs)
+        {
+            DbConnection = ConnectionHelper.EnsureConnection(DbConnection, connString, connSecureString, provName);
+            if (DbConnection == null)
+            {
+                return null;
+            }
+            var (resultTable, resultDataSet) = DbConnection.ExecuteQuery(sql, parameters, commandTimeoutMs, CommandType);
+            return new DBExecuteQueryResult(resultTable, resultDataSet, parameters);
         }
 
         private class DBExecuteQueryResult

--- a/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
+++ b/Activities/Database/UiPath.Database.Activities/ExecuteQuery.cs
@@ -46,7 +46,7 @@ namespace UiPath.Database.Activities
             throw ex;
         }
 
-        protected async override Task<Action<AsyncCodeActivityContext>> ExecuteInternalAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
+        protected async override Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
         {
             ITelemetryOperationWrapper telemetryOperation = null;
 #if ENABLE_DEFAULT_TELEMETRY
@@ -60,8 +60,8 @@ namespace UiPath.Database.Activities
                 string sql = string.Empty;
                 DatabaseConnection existingConnection = null;
                 DBExecuteQueryResult affectedRecords = null;
-                int commandTimeout = TimeoutMS.Get(context);
-                if (commandTimeout < 0)
+                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeout.HasValue && commandTimeout.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, "TimeoutMS");
                 }

--- a/Activities/Database/UiPath.Database.Activities/InsertDataTable.cs
+++ b/Activities/Database/UiPath.Database.Activities/InsertDataTable.cs
@@ -54,8 +54,8 @@ namespace UiPath.Database.Activities
                 DatabaseConnection existingConnection = null;
                 int affectedRecords = 0;
                 var continueOnError = ContinueOnError.Get(context);
-                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
-                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                int? commandTimeoutMs = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeoutMs.HasValue && commandTimeoutMs.Value < 0)
                 {
                     throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
                 }
@@ -77,7 +77,7 @@ namespace UiPath.Database.Activities
                         {
                             return 0;
                         }
-                        return DbConnection.InsertDataTable(tableName, dataTable, commandTimeout);
+                        return DbConnection.InsertDataTable(tableName, dataTable, commandTimeoutMs);
                     });
 
                 }

--- a/Activities/Database/UiPath.Database.Activities/InsertDataTable.cs
+++ b/Activities/Database/UiPath.Database.Activities/InsertDataTable.cs
@@ -54,6 +54,11 @@ namespace UiPath.Database.Activities
                 DatabaseConnection existingConnection = null;
                 int affectedRecords = 0;
                 var continueOnError = ContinueOnError.Get(context);
+                int? commandTimeout = TimeoutMS.Expression is null ? (int?)null : TimeoutMS.Get(context);
+                if (commandTimeout.HasValue && commandTimeout.Value < 0)
+                {
+                    throw new ArgumentException(Resources.TimeoutMSException, nameof(TimeoutMS));
+                }
                 try
                 {
                     existingConnection = DbConnection = ExistingDbConnection.Get(context);
@@ -72,7 +77,7 @@ namespace UiPath.Database.Activities
                         {
                             return 0;
                         }
-                        return DbConnection.InsertDataTable(tableName, dataTable);
+                        return DbConnection.InsertDataTable(tableName, dataTable, commandTimeout);
                     });
 
                 }

--- a/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/BulkInsertViewModel.cs
+++ b/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/BulkInsertViewModel.cs
@@ -49,6 +49,11 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
         public DesignInArgument<bool> ContinueOnError { get; set; } = new DesignInArgument<bool>();
 
         /// <summary>
+        /// Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown.
+        /// </summary>
+        public DesignInArgument<int> TimeoutMS { get; set; } = new DesignInArgument<int>();
+
+        /// <summary>
         /// The number of updated rows.
         /// </summary>
         public DesignOutArgument<long> AffectedRecords { get; set; } = new DesignOutArgument<long>();
@@ -74,6 +79,10 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
 
             ContinueOnError.OrderIndex = propertyOrderIndex++;
             ContinueOnError.Widget = new DefaultWidget { Type = ViewModelWidgetType.NullableBoolean };
+
+            TimeoutMS.IsVisible = true;
+            TimeoutMS.OrderIndex = propertyOrderIndex++;
+            TimeoutMS.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
             AffectedRecords.OrderIndex = propertyOrderIndex;
             AffectedRecords.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };

--- a/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/BulkUpdateViewModel.cs
+++ b/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/BulkUpdateViewModel.cs
@@ -54,6 +54,11 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
         public DesignInArgument<bool> ContinueOnError { get; set; } = new DesignInArgument<bool>();
 
         /// <summary>
+        /// Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown.
+        /// </summary>
+        public DesignInArgument<int> TimeoutMS { get; set; } = new DesignInArgument<int>();
+
+        /// <summary>
         /// The number of updated rows.
         /// </summary>
         public DesignOutArgument<long> AffectedRecords { get; set; } = new DesignOutArgument<long>();
@@ -84,7 +89,11 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
 
             ContinueOnError.OrderIndex = propertyOrderIndex++;
             ContinueOnError.Widget = new DefaultWidget { Type = ViewModelWidgetType.NullableBoolean };
-         
+
+            TimeoutMS.IsVisible = true;
+            TimeoutMS.OrderIndex = propertyOrderIndex++;
+            TimeoutMS.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
+
             AffectedRecords.OrderIndex = propertyOrderIndex;
             AffectedRecords.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
         }

--- a/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/InsertDataTableViewModel.cs
+++ b/Activities/Database/UiPath.Database.Activities/NetCore/ViewModels/InsertDataTableViewModel.cs
@@ -48,6 +48,11 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
         public DesignInArgument<bool> ContinueOnError { get; set; } = new DesignInArgument<bool>();
 
         /// <summary>
+        /// Specifies the amount of time (in milliseconds) to wait for the command to run before an error is thrown.
+        /// </summary>
+        public DesignInArgument<int> TimeoutMS { get; set; } = new DesignInArgument<int>();
+
+        /// <summary>
         /// Stores the number of affected rows into an Int32 variable.
         /// </summary>
         public DesignOutArgument<int> AffectedRecords { get; set; } = new DesignOutArgument<int>();
@@ -74,6 +79,10 @@ namespace UiPath.Database.Activities.NetCore.ViewModels
             
             ContinueOnError.OrderIndex = propertyOrderIndex++;
             ContinueOnError.Widget = new DefaultWidget { Type = ViewModelWidgetType.NullableBoolean };
+
+            TimeoutMS.IsVisible = true;
+            TimeoutMS.OrderIndex = propertyOrderIndex++;
+            TimeoutMS.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };
 
             AffectedRecords.OrderIndex = propertyOrderIndex;
             AffectedRecords.Widget = new DefaultWidget { Type = ViewModelWidgetType.Input };

--- a/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
+++ b/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
@@ -283,5 +283,54 @@ namespace UiPath.Database.Tests
 
             Assert.True(executed == true);
         }
+
+        [Fact]
+        public void ExecuteQuery_NullTimeout_NoConnectionTimeout_DefaultsTo30Seconds()
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 0);
+
+            dbConn.ExecuteQuery("SELECT 1", null, null);
+
+            Assert.Equal(30, cmd.Object.CommandTimeout);
+        }
+
+        [Fact]
+        public void ExecuteQuery_NullTimeout_ConnectionTimeoutAlreadySet_KeepsConnectionTimeout()
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 60);
+
+            dbConn.ExecuteQuery("SELECT 1", null, null);
+
+            Assert.Equal(60, cmd.Object.CommandTimeout);
+        }
+
+        [Theory]
+        [InlineData(30000, 30)]
+        [InlineData(60000, 60)]
+        [InlineData(1500,   2)] // ceiling: 1.5s -> 2s
+        public void ExecuteQuery_ExplicitTimeout_ConvertsMillisecondsToSeconds(int timeoutMs, int expectedSeconds)
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 0);
+
+            dbConn.ExecuteQuery("SELECT 1", null, timeoutMs);
+
+            Assert.Equal(expectedSeconds, cmd.Object.CommandTimeout);
+        }
+
+        private (DatabaseConnection, Mock<DbCommand>) CreateMockConnectionForTimeout(int initialCommandTimeout)
+        {
+            var con = new Mock<DbConnection>();
+            var cmd = new Mock<DbCommand>();
+            var dbParameterCollection = new Mock<DbParameterCollection>();
+            var dataReader = new Mock<DbDataReader>();
+
+            con.SetReturnsDefault(cmd.Object);
+            cmd.SetupProperty(c => c.CommandTimeout, initialCommandTimeout);
+            cmd.SetReturnsDefault(dbParameterCollection.Object);
+            cmd.SetReturnsDefault(dataReader.Object);
+            dbParameterCollection.Setup(x => x.GetEnumerator()).Returns(new List<DbParameter>().GetEnumerator());
+
+            return (new DatabaseConnection().Initialize(con.Object), cmd);
+        }
     }
 }

--- a/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
+++ b/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
@@ -317,6 +317,62 @@ namespace UiPath.Database.Tests
             Assert.Equal(expectedSeconds, cmd.Object.CommandTimeout);
         }
 
+        [Fact]
+        public void Execute_NullTimeout_NoConnectionTimeout_DefaultsTo30Seconds()
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 0);
+
+            dbConn.Execute("SELECT 1", new Dictionary<string, ParameterInfo>(), null);
+
+            Assert.Equal(30, cmd.Object.CommandTimeout);
+        }
+
+        [Fact]
+        public void Execute_NullTimeout_ConnectionTimeoutAlreadySet_KeepsConnectionTimeout()
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 60);
+
+            dbConn.Execute("SELECT 1", new Dictionary<string, ParameterInfo>(), null);
+
+            Assert.Equal(60, cmd.Object.CommandTimeout);
+        }
+
+        [Theory]
+        [InlineData(30000, 30)]
+        [InlineData(60000, 60)]
+        [InlineData(1500,   2)] // ceiling: 1.5s -> 2s
+        public void Execute_ExplicitTimeout_ConvertsMillisecondsToSeconds(int timeoutMs, int expectedSeconds)
+        {
+            var (dbConn, cmd) = CreateMockConnectionForTimeout(initialCommandTimeout: 0);
+
+            dbConn.Execute("SELECT 1", new Dictionary<string, ParameterInfo>(), timeoutMs);
+
+            Assert.Equal(expectedSeconds, cmd.Object.CommandTimeout);
+        }
+
+        [Fact]
+        public void BulkUpdateBatchPath_NullTimeout_NoConnectionTimeout_DefaultsTo30Seconds()
+        {
+            var (dbConn, cmd) = CreateMockConnectionForBatchUpdate(initialCommandTimeout: 0);
+
+            dbConn.BulkUpdateDataTable(false, "TestTable", CreateTwoColumnDataTable(), new[] { "Id" }, null);
+
+            Assert.Equal(30, cmd.Object.CommandTimeout);
+        }
+
+        [Theory]
+        [InlineData(30000, 30)]
+        [InlineData(60000, 60)]
+        [InlineData(1500,   2)] // ceiling: 1.5s -> 2s
+        public void BulkUpdateBatchPath_ExplicitTimeout_ConvertsMillisecondsToSeconds(int timeoutMs, int expectedSeconds)
+        {
+            var (dbConn, cmd) = CreateMockConnectionForBatchUpdate(initialCommandTimeout: 0);
+
+            dbConn.BulkUpdateDataTable(false, "TestTable", CreateTwoColumnDataTable(), new[] { "Id" }, timeoutMs);
+
+            Assert.Equal(expectedSeconds, cmd.Object.CommandTimeout);
+        }
+
         private (DatabaseConnection, Mock<DbCommand>) CreateMockConnectionForTimeout(int initialCommandTimeout)
         {
             var con = new Mock<DbConnection>();
@@ -331,6 +387,36 @@ namespace UiPath.Database.Tests
             dbParameterCollection.Setup(x => x.GetEnumerator()).Returns(new List<DbParameter>().GetEnumerator());
 
             return (new DatabaseConnection().Initialize(con.Object), cmd);
+        }
+
+        private (DatabaseConnection, Mock<DbCommand>) CreateMockConnectionForBatchUpdate(int initialCommandTimeout)
+        {
+            var con = new Mock<DbConnection>();
+            var cmd = new Mock<DbCommand>();
+            var dbParameterCollection = new Mock<DbParameterCollection>();
+            var param = new Mock<DbParameter>();
+            param.SetupAllProperties();
+
+            var schema = new DataTable();
+            schema.Columns.Add(DbMetaDataColumnNames.ParameterMarkerFormat, typeof(string));
+            schema.Columns.Add(DbMetaDataColumnNames.ParameterMarkerPattern, typeof(string));
+            schema.Rows.Add("{0}", "@param");
+
+            con.SetReturnsDefault(cmd.Object);
+            con.Setup(c => c.GetSchema(DbMetaDataCollectionNames.DataSourceInformation)).Returns(schema);
+            cmd.SetupProperty(c => c.CommandTimeout, initialCommandTimeout);
+            cmd.SetReturnsDefault(dbParameterCollection.Object);
+            cmd.SetReturnsDefault(param.Object);
+
+            return (new DatabaseConnection().Initialize(con.Object), cmd);
+        }
+
+        private static DataTable CreateTwoColumnDataTable()
+        {
+            var dataTable = new DataTable();
+            dataTable.Columns.Add("Id", typeof(int));
+            dataTable.Columns.Add("Name", typeof(string));
+            return dataTable;
         }
     }
 }

--- a/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
+++ b/Activities/Database/UiPath.Database.Tests/DatabaseConnectionTests.cs
@@ -389,7 +389,7 @@ namespace UiPath.Database.Tests
             return (new DatabaseConnection().Initialize(con.Object), cmd);
         }
 
-        private (DatabaseConnection, Mock<DbCommand>) CreateMockConnectionForBatchUpdate(int initialCommandTimeout)
+        private static (DatabaseConnection, Mock<DbCommand>) CreateMockConnectionForBatchUpdate(int initialCommandTimeout)
         {
             var con = new Mock<DbConnection>();
             var cmd = new Mock<DbCommand>();

--- a/Activities/Database/UiPath.Database/BulkOps/IBulkOperations.cs
+++ b/Activities/Database/UiPath.Database/BulkOps/IBulkOperations.cs
@@ -10,7 +10,7 @@ namespace UiPath.Database.BulkOps
         string TableName { get; set; }
         Type BulkCopyType { get; set; }
 
-        void WriteToServer(DataTable dataTable);
+        void WriteToServer(DataTable dataTable, int? commandTimeoutMs = null);
     }
 
     public class BulkOperationsFactory

--- a/Activities/Database/UiPath.Database/BulkOps/OracleBulkOperations.cs
+++ b/Activities/Database/UiPath.Database/BulkOps/OracleBulkOperations.cs
@@ -11,11 +11,15 @@ namespace UiPath.Database.BulkOps
         public string TableName { get; set; }
         public Type BulkCopyType { get; set; }
 
-        public void WriteToServer(DataTable dataTable)
+        public void WriteToServer(DataTable dataTable, int? commandTimeoutMs = null)
         {
-
-            //dynamic bulkCopy = Activator.CreateInstance(BulkCopyType, new object[] { Connection });
             OracleBulkCopy bulkCopy = new OracleBulkCopy((OracleConnection)Connection);
+            if (commandTimeoutMs.HasValue)
+            {
+                var seconds = (int)Math.Ceiling((double)commandTimeoutMs.Value / 1000);
+                if (seconds != 0)
+                    bulkCopy.BulkCopyTimeout = seconds;
+            }
             bulkCopy.DestinationTableName = TableName;
             bulkCopy.WriteToServer(dataTable);
         }

--- a/Activities/Database/UiPath.Database/BulkOps/SQLBulkOperations.cs
+++ b/Activities/Database/UiPath.Database/BulkOps/SQLBulkOperations.cs
@@ -11,11 +11,17 @@ namespace UiPath.Database.BulkOps
         public string TableName { get; set; }
         public Type BulkCopyType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-        public void WriteToServer(DataTable dataTable)
+        public void WriteToServer(DataTable dataTable, int? commandTimeoutMs = null)
         {
             // Set up the bulk copy object
             using (SqlBulkCopy bulkCopy = new SqlBulkCopy((SqlConnection)Connection))
             {
+                if (commandTimeoutMs.HasValue)
+                {
+                    var seconds = (int)Math.Ceiling((double)commandTimeoutMs.Value / 1000);
+                    if (seconds != 0)
+                        bulkCopy.BulkCopyTimeout = seconds;
+                }
                 bulkCopy.DestinationTableName = TableName;
                 bulkCopy.WriteToServer(dataTable);
             }

--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -212,7 +212,7 @@ namespace UiPath.Database
             IBulkOperations bulkOps = BulkOperationsFactory.Create(_connection);
             bulkOps.Connection = _connection;
             bulkOps.TableName = tableName;
-            ValidateDatabaseTableStructure(tableName, dataTable);
+            ValidateDatabaseTableStructure(tableName, dataTable, commandTimeoutMs);
             var countStart = CountRowsInTable(tableName, commandTimeoutMs);
             bulkOps.WriteToServer(dataTable, commandTimeoutMs);
             var countEnd = CountRowsInTable(tableName, commandTimeoutMs);
@@ -305,7 +305,7 @@ namespace UiPath.Database
             return DbProviderFactories.GetFactory(_connection);
         }
 
-        private void ValidateDatabaseTableStructure(string tableName, DataTable dataTable)
+        private void ValidateDatabaseTableStructure(string tableName, DataTable dataTable, int? commandTimeoutMs = null)
         {
             if (_connection == null)
                 return;
@@ -314,6 +314,7 @@ namespace UiPath.Database
             dbDA.SelectCommand.Transaction = _transaction;
             dbDA.SelectCommand.CommandType = CommandType.Text;
             dbDA.SelectCommand.CommandText = string.Format("select * from {0}", tableName);
+            ApplyCommandTimeout(dbDA.SelectCommand, commandTimeoutMs);
 
             var ds = new DataSet();
             dbDA.FillSchema(ds, SchemaType.Source);

--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -23,9 +23,9 @@ namespace UiPath.Database
         private DbCommand _command;
         private DbTransaction _transaction;
         private string _providerName;
-        
+
         private bool _isWindows = true;
-        
+
         public ConnectionState? State => _connection?.State;
 
         public DatabaseConnection()
@@ -46,7 +46,7 @@ namespace UiPath.Database
             _providerName = providerName;
 
             DatabaseHelper.RegisterFactories(_isWindows);
-            
+
             if (providerName.Equals(DatabaseConstants.SqlServerProvider, StringComparison.OrdinalIgnoreCase))
                 _connection = new SqlConnection();
             else if (providerName.Equals(DatabaseConstants.OracleProvider, StringComparison.OrdinalIgnoreCase))
@@ -68,7 +68,7 @@ namespace UiPath.Database
         // Prevents unbounded iteration when a command returns an unexpected number of result sets.
         private const int MaxResultSets = 100;
 
-        public virtual (DataTable ResultTable, DataSet ResultDataSet) ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
+        public virtual (DataTable ResultTable, DataSet ResultDataSet) ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
         {
             OpenConnection();
             SetupCommand(sql, parameters, commandTimeout, commandType);
@@ -111,7 +111,7 @@ namespace UiPath.Database
             return (resultTable, resultDataSet);
         }
 
-        public virtual int Execute(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
+        public virtual int Execute(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
         {
             OpenConnection();
             SetupCommand(sql, parameters, commandTimeout, commandType);
@@ -130,14 +130,14 @@ namespace UiPath.Database
         }
 
 
-        public virtual int InsertDataTable(string tableName, DataTable dataTable)
+        public virtual int InsertDataTable(string tableName, DataTable dataTable, int? commandTimeout = null)
         {
             // the select command text should be different depending on the provider
             // in this iteration we will try both formats for an insert operation, but a proper matching must be implemented
             Exception firstException, secondException;
             try
             {
-                return InsertDataTableInternal(tableName, dataTable, true);
+                return InsertDataTableInternal(tableName, dataTable, true, commandTimeout);
             }
             catch (Exception e)
             {
@@ -145,7 +145,7 @@ namespace UiPath.Database
             }
             try
             {
-                return InsertDataTableInternal(tableName, dataTable, false);
+                return InsertDataTableInternal(tableName, dataTable, false, commandTimeout);
             }
             catch (Exception e)
             {
@@ -156,7 +156,7 @@ namespace UiPath.Database
             throw new AggregateException(firstException, secondException);
         }
 
-        private int InsertDataTableInternal(string tableName, DataTable dataTable, bool removeBrackets)
+        private int InsertDataTableInternal(string tableName, DataTable dataTable, bool removeBrackets, int? commandTimeout = null)
         {
             DbDataAdapter dbDA = GetCurrentFactory().CreateDataAdapter();
             DbCommandBuilder cmdb = GetCurrentFactory().CreateCommandBuilder();
@@ -166,12 +166,14 @@ namespace UiPath.Database
             dbDA.SelectCommand = _connection.CreateCommand();
             dbDA.SelectCommand.Transaction = _transaction;
             dbDA.SelectCommand.CommandType = CommandType.Text;
+            ApplyCommandTimeout(dbDA.SelectCommand, commandTimeout);
 
             dbDA.SelectCommand.CommandText = string.Format("select {0} from {1}", GetColumnNames(dataTable, removeBrackets), tableName);
             dbDA.InsertCommand = cmdb.GetInsertCommand();
 
             dbDA.InsertCommand.Connection = _connection;
             dbDA.InsertCommand.Transaction = _transaction;
+            ApplyCommandTimeout(dbDA.InsertCommand, commandTimeout);
 
             foreach (DataRow row in dataTable.Rows)
             {
@@ -189,7 +191,7 @@ namespace UiPath.Database
             return false;
         }
 
-        public long BulkInsertDataTable(string tableName, DataTable dataTable, IExecutorRuntime executorRuntime = null)
+        public long BulkInsertDataTable(string tableName, DataTable dataTable, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
         {
             if (SupportsBulk())
                 return DoBulkInsert(tableName, dataTable);
@@ -201,7 +203,7 @@ namespace UiPath.Database
                 {
                     LogWarningMessage(executorRuntime);
                 }
-                return InsertDataTable(tableName, dataTable);
+                return InsertDataTable(tableName, dataTable, commandTimeout);
             }
         }
 
@@ -333,15 +335,15 @@ namespace UiPath.Database
             return tempTableName;
         }
 
-        public long BulkUpdateDataTable(bool bulkBatch, string tableName, DataTable dataTable, string[] columnNames, IExecutorRuntime executorRuntime = null)
+        public long BulkUpdateDataTable(bool bulkBatch, string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
         {
             if (bulkBatch && SupportsBulk())
-                return DoBulkUpdate(tableName, dataTable, columnNames, executorRuntime);
+                return DoBulkUpdate(tableName, dataTable, columnNames, commandTimeout, executorRuntime);
             else
-                return DoBatchUpdate(tableName, dataTable, columnNames);
+                return DoBatchUpdate(tableName, dataTable, columnNames, commandTimeout);
         }
 
-        private int DoBatchUpdate(string tableName, DataTable dataTable, string[] columnNames)
+        private int DoBatchUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null)
         {
             if (_connection == null)
                 return -1;
@@ -351,6 +353,7 @@ namespace UiPath.Database
                 sqlCommand.Connection = _connection;
                 sqlCommand.Transaction = _transaction;
                 sqlCommand.CommandType = CommandType.Text;
+                ApplyCommandTimeout(sqlCommand, commandTimeout);
             }
             var dbSchema = _connection?.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
             string markerFormat = (string)dbSchema.Rows[0][DbMetaDataColumnNames.ParameterMarkerFormat];
@@ -380,7 +383,7 @@ namespace UiPath.Database
             return rows;
         }
 
-        private int DoBulkUpdate(string tableName, DataTable dataTable, string[] columnNames, IExecutorRuntime executorRuntime)
+        private int DoBulkUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
         {
             if (_connection == null)
                 return -1;
@@ -391,11 +394,12 @@ namespace UiPath.Database
                 sqlCommand.Connection = _connection;
                 sqlCommand.Transaction = _transaction;
                 sqlCommand.CommandType = CommandType.Text;
+                ApplyCommandTimeout(sqlCommand, commandTimeout);
             }
             try
             {
                 tblName = CreateTempTableForUpdate(dataTable, tableName, sqlCommand);
-                BulkInsertDataTable(tblName, dataTable, executorRuntime);
+                BulkInsertDataTable(tblName, dataTable, commandTimeout, executorRuntime);
 
                 sqlCommand.CommandText = string.Format("MERGE INTO {0} t USING (SELECT * FROM {1})s on ({3}) WHEN MATCHED THEN UPDATE SET {2}", tableName, tblName,
                     string.Join(",", dataTable.Columns.Cast<DataColumn>()
@@ -498,7 +502,7 @@ namespace UiPath.Database
             }
         }
 
-        private void SetupCommand(string sql, Dictionary<string, ParameterInfo> parameters, int commandTimeout, CommandType commandType = CommandType.Text)
+        private void SetupCommand(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
         {
             if (_connection == null)
             {
@@ -507,12 +511,7 @@ namespace UiPath.Database
 
             _command = _command ?? _connection.CreateCommand();
 
-            var ceilVal = (int)Math.Ceiling((double)commandTimeout / 1000);
-
-            if (ceilVal != 0)
-            {
-                _command.CommandTimeout = ceilVal;
-            }
+            ApplyCommandTimeout(_command, commandTimeout);
 
             _command.CommandType = commandType;
             _command.CommandText = sql;
@@ -537,6 +536,20 @@ namespace UiPath.Database
                 UpdateDbParamType(dbParameter, param.Value);
 
                 _command.Parameters.Add(dbParameter);
+            }
+        }
+
+        private static void ApplyCommandTimeout(DbCommand command, int? commandTimeout)
+        {
+            if (commandTimeout.HasValue)
+            {
+                var seconds = (int)Math.Ceiling((double)commandTimeout.Value / 1000);
+                if (seconds != 0)
+                    command.CommandTimeout = seconds;
+            }
+            else if (command.CommandTimeout == 0)
+            {
+                command.CommandTimeout = 30;
             }
         }
 

--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -68,10 +68,10 @@ namespace UiPath.Database
         // Prevents unbounded iteration when a command returns an unexpected number of result sets.
         private const int MaxResultSets = 100;
 
-        public virtual (DataTable ResultTable, DataSet ResultDataSet) ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
+        public virtual (DataTable ResultTable, DataSet ResultDataSet) ExecuteQuery(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeoutMs, CommandType commandType = CommandType.Text)
         {
             OpenConnection();
-            SetupCommand(sql, parameters, commandTimeout, commandType);
+            SetupCommand(sql, parameters, commandTimeoutMs, commandType);
             _command.Transaction = _transaction;
             DataSet resultDataSet = new DataSet();
             DataTable resultTable;
@@ -111,10 +111,10 @@ namespace UiPath.Database
             return (resultTable, resultDataSet);
         }
 
-        public virtual int Execute(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
+        public virtual int Execute(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeoutMs, CommandType commandType = CommandType.Text)
         {
             OpenConnection();
-            SetupCommand(sql, parameters, commandTimeout, commandType);
+            SetupCommand(sql, parameters, commandTimeoutMs, commandType);
             _command.Transaction = _transaction;
             var result = _command.ExecuteNonQuery();
             foreach (var param in _command.Parameters)
@@ -130,14 +130,14 @@ namespace UiPath.Database
         }
 
 
-        public virtual int InsertDataTable(string tableName, DataTable dataTable, int? commandTimeout = null)
+        public virtual int InsertDataTable(string tableName, DataTable dataTable, int? commandTimeoutMs = null)
         {
             // the select command text should be different depending on the provider
             // in this iteration we will try both formats for an insert operation, but a proper matching must be implemented
             Exception firstException, secondException;
             try
             {
-                return InsertDataTableInternal(tableName, dataTable, true, commandTimeout);
+                return InsertDataTableInternal(tableName, dataTable, true, commandTimeoutMs);
             }
             catch (Exception e)
             {
@@ -145,7 +145,7 @@ namespace UiPath.Database
             }
             try
             {
-                return InsertDataTableInternal(tableName, dataTable, false, commandTimeout);
+                return InsertDataTableInternal(tableName, dataTable, false, commandTimeoutMs);
             }
             catch (Exception e)
             {
@@ -156,7 +156,7 @@ namespace UiPath.Database
             throw new AggregateException(firstException, secondException);
         }
 
-        private int InsertDataTableInternal(string tableName, DataTable dataTable, bool removeBrackets, int? commandTimeout = null)
+        private int InsertDataTableInternal(string tableName, DataTable dataTable, bool removeBrackets, int? commandTimeoutMs = null)
         {
             DbDataAdapter dbDA = GetCurrentFactory().CreateDataAdapter();
             DbCommandBuilder cmdb = GetCurrentFactory().CreateCommandBuilder();
@@ -166,14 +166,14 @@ namespace UiPath.Database
             dbDA.SelectCommand = _connection.CreateCommand();
             dbDA.SelectCommand.Transaction = _transaction;
             dbDA.SelectCommand.CommandType = CommandType.Text;
-            ApplyCommandTimeout(dbDA.SelectCommand, commandTimeout);
+            ApplyCommandTimeout(dbDA.SelectCommand, commandTimeoutMs);
 
             dbDA.SelectCommand.CommandText = string.Format("select {0} from {1}", GetColumnNames(dataTable, removeBrackets), tableName);
             dbDA.InsertCommand = cmdb.GetInsertCommand();
 
             dbDA.InsertCommand.Connection = _connection;
             dbDA.InsertCommand.Transaction = _transaction;
-            ApplyCommandTimeout(dbDA.InsertCommand, commandTimeout);
+            ApplyCommandTimeout(dbDA.InsertCommand, commandTimeoutMs);
 
             foreach (DataRow row in dataTable.Rows)
             {
@@ -191,10 +191,10 @@ namespace UiPath.Database
             return false;
         }
 
-        public long BulkInsertDataTable(string tableName, DataTable dataTable, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
+        public long BulkInsertDataTable(string tableName, DataTable dataTable, int? commandTimeoutMs = null, IExecutorRuntime executorRuntime = null)
         {
             if (SupportsBulk())
-                return DoBulkInsert(tableName, dataTable);
+                return DoBulkInsert(tableName, dataTable, commandTimeoutMs);
             else
             {
                 //if no bulk insert possible, fallback to insert data table with warning message
@@ -203,23 +203,23 @@ namespace UiPath.Database
                 {
                     LogWarningMessage(executorRuntime);
                 }
-                return InsertDataTable(tableName, dataTable, commandTimeout);
+                return InsertDataTable(tableName, dataTable, commandTimeoutMs);
             }
         }
 
-        private long DoBulkInsert(string tableName, DataTable dataTable)
+        private long DoBulkInsert(string tableName, DataTable dataTable, int? commandTimeoutMs = null)
         {
             IBulkOperations bulkOps = BulkOperationsFactory.Create(_connection);
             bulkOps.Connection = _connection;
             bulkOps.TableName = tableName;
             ValidateDatabaseTableStructure(tableName, dataTable);
-            var countStart = CountRowsInTable(tableName);
-            bulkOps.WriteToServer(dataTable);
-            var countEnd = CountRowsInTable(tableName);
+            var countStart = CountRowsInTable(tableName, commandTimeoutMs);
+            bulkOps.WriteToServer(dataTable, commandTimeoutMs);
+            var countEnd = CountRowsInTable(tableName, commandTimeoutMs);
             return countEnd - countStart;
         }
 
-        private long CountRowsInTable(string tableName)
+        private long CountRowsInTable(string tableName, int? commandTimeoutMs = null)
         {
             var commandRowCount = _connection.CreateCommand();
             // Perform an initial count on the destination table.
@@ -227,6 +227,7 @@ namespace UiPath.Database
             commandRowCount.Transaction = _transaction;
             commandRowCount.CommandType = CommandType.Text;
             commandRowCount.CommandText = countQuery;
+            ApplyCommandTimeout(commandRowCount, commandTimeoutMs);
 
             return Convert.ToInt32(commandRowCount.ExecuteScalar());
         }
@@ -335,15 +336,15 @@ namespace UiPath.Database
             return tempTableName;
         }
 
-        public long BulkUpdateDataTable(bool bulkBatch, string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
+        public long BulkUpdateDataTable(bool bulkBatch, string tableName, DataTable dataTable, string[] columnNames, int? commandTimeoutMs = null, IExecutorRuntime executorRuntime = null)
         {
             if (bulkBatch && SupportsBulk())
-                return DoBulkUpdate(tableName, dataTable, columnNames, commandTimeout, executorRuntime);
+                return DoBulkUpdate(tableName, dataTable, columnNames, commandTimeoutMs, executorRuntime);
             else
-                return DoBatchUpdate(tableName, dataTable, columnNames, commandTimeout);
+                return DoBatchUpdate(tableName, dataTable, columnNames, commandTimeoutMs);
         }
 
-        private int DoBatchUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null)
+        private int DoBatchUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeoutMs = null)
         {
             if (_connection == null)
                 return -1;
@@ -353,7 +354,7 @@ namespace UiPath.Database
                 sqlCommand.Connection = _connection;
                 sqlCommand.Transaction = _transaction;
                 sqlCommand.CommandType = CommandType.Text;
-                ApplyCommandTimeout(sqlCommand, commandTimeout);
+                ApplyCommandTimeout(sqlCommand, commandTimeoutMs);
             }
             var dbSchema = _connection?.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
             string markerFormat = (string)dbSchema.Rows[0][DbMetaDataColumnNames.ParameterMarkerFormat];
@@ -383,7 +384,7 @@ namespace UiPath.Database
             return rows;
         }
 
-        private int DoBulkUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeout = null, IExecutorRuntime executorRuntime = null)
+        private int DoBulkUpdate(string tableName, DataTable dataTable, string[] columnNames, int? commandTimeoutMs = null, IExecutorRuntime executorRuntime = null)
         {
             if (_connection == null)
                 return -1;
@@ -394,12 +395,12 @@ namespace UiPath.Database
                 sqlCommand.Connection = _connection;
                 sqlCommand.Transaction = _transaction;
                 sqlCommand.CommandType = CommandType.Text;
-                ApplyCommandTimeout(sqlCommand, commandTimeout);
+                ApplyCommandTimeout(sqlCommand, commandTimeoutMs);
             }
             try
             {
                 tblName = CreateTempTableForUpdate(dataTable, tableName, sqlCommand);
-                BulkInsertDataTable(tblName, dataTable, commandTimeout, executorRuntime);
+                BulkInsertDataTable(tblName, dataTable, commandTimeoutMs, executorRuntime);
 
                 sqlCommand.CommandText = string.Format("MERGE INTO {0} t USING (SELECT * FROM {1})s on ({3}) WHEN MATCHED THEN UPDATE SET {2}", tableName, tblName,
                     string.Join(",", dataTable.Columns.Cast<DataColumn>()
@@ -502,7 +503,7 @@ namespace UiPath.Database
             }
         }
 
-        private void SetupCommand(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeout, CommandType commandType = CommandType.Text)
+        private void SetupCommand(string sql, Dictionary<string, ParameterInfo> parameters, int? commandTimeoutMs, CommandType commandType = CommandType.Text)
         {
             if (_connection == null)
             {
@@ -511,7 +512,7 @@ namespace UiPath.Database
 
             _command = _command ?? _connection.CreateCommand();
 
-            ApplyCommandTimeout(_command, commandTimeout);
+            ApplyCommandTimeout(_command, commandTimeoutMs);
 
             _command.CommandType = commandType;
             _command.CommandText = sql;
@@ -539,11 +540,11 @@ namespace UiPath.Database
             }
         }
 
-        private static void ApplyCommandTimeout(DbCommand command, int? commandTimeout)
+        private static void ApplyCommandTimeout(DbCommand command, int? commandTimeoutMs)
         {
-            if (commandTimeout.HasValue)
+            if (commandTimeoutMs.HasValue)
             {
-                var seconds = (int)Math.Ceiling((double)commandTimeout.Value / 1000);
+                var seconds = (int)Math.Ceiling((double)commandTimeoutMs.Value / 1000);
                 if (seconds != 0)
                     command.CommandTimeout = seconds;
             }


### PR DESCRIPTION
Add timeout support for BulkInsert, BulkUpdate and InsertDataTable 
When timeout not specified on the activity, default to 30s only if timeout not already set by connection 
Update md files
Update unittests