### PR TITLE
fix: extract merged branch name via regex capture group only

### DIFF
--- a/Activities/Tools/Patch-Nuspecs.ps1
+++ b/Activities/Tools/Patch-Nuspecs.ps1
@@ -102,7 +102,7 @@ function Get-PrereleaseTag([string] $prereleaseTag, [string] $commitSha)
     $commitMessagePattern = "Merge branch '(.+)'.*";
     if($commitMessage -match $commitMessagePattern) 
     {
-        $mergedBranchName = $commitMessage -replace $commitMessagePattern, "`$1";
+        $mergedBranchName = $Matches[1];
         Write-Host "This is a merge from a release branch. Branch name '$mergedBranchName'";
         $parts = $mergedBranchName.Split('/');
         $lastPart = $parts[$parts.Length - 1];


### PR DESCRIPTION
  Fix a regex bug in `Activities/Tools/Patch-Nuspecs.ps1` that dropped the `-preview` suffix from `masters/*` builds
  when the merge commit message contained `# Conflicts:` lines.

  ## Root cause

  `Get-PrereleaseTag` used `-replace` on the full commit message to extract the merged branch name. PowerShell's `.` is
  single-line by default, so trailing `# Conflicts:` lines survived the replace. The subsequent `Split('/')` then picked
   a conflict file path's last token (e.g. `ActivitiesMetadataWindows.json`) instead of `v3.1.0-preview`, so the
  version-tag check failed and the function returned `final` — leaving `<VersionSuffix>` un-patched.

  Result: `masters/Database` (clean merge) produced `Database.2.1.0-preview` ✅, but `masters/FTP` (merge with
  conflicts) produced `FTP.3.1.0` ❌.

  ## Fix

  Use `$Matches[1]` from the preceding `-match` instead of `-replace` on the full message. The capture group can never
  contain unmatched trailing lines.

  ```diff
  - $mergedBranchName = $commitMessage -replace $commitMessagePattern, "`$1";
  + $mergedBranchName = $Matches[1];
```

  ## Test plan

  - [x] Re-run masters/FTP build, confirm output is FTP.3.1.0-preview.
  - [x] Confirm masters/Database still produces Database.<x.y.z>-preview.