### PR TITLE
FTP: Sftp improvements [STUD-79812] [STUD-72320]

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -1465,7 +1465,7 @@ namespace UiPath.FTP.Activities.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password.
+        ///   Looks up a localized string similar to No valid authentication method found: You need to supply either Private Key file (and optionally passphrase) or Password.
         /// </summary>
         public static string NoValidAuthenticationMethod {
             get {

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -220,7 +220,7 @@
     <value>Path to the Private key in PKCS #1 PEM format</value>
   </data>
   <data name="NoValidAuthenticationMethod" xml:space="preserve">
-    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password</value>
+    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphrase) or Password</value>
   </data>
   <data name="NewPath" xml:space="preserve">
     <value>New remote path</value>

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -250,8 +250,7 @@ namespace UiPath.FTP.Activities
                         throw new ArgumentNullException(Resources.EmptyUsernameException);
                     }
 
-                    if (string.IsNullOrWhiteSpace(ftpConfiguration.Password) && string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath)
-                        && !UseSftp)
+                    if (string.IsNullOrWhiteSpace(ftpConfiguration.Password) && string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath))
                     {
                         throw new ArgumentNullException(Resources.NoValidAuthenticationMethod);
                     }

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -250,7 +250,8 @@ namespace UiPath.FTP.Activities
                         throw new ArgumentNullException(Resources.EmptyUsernameException);
                     }
 
-                    if (string.IsNullOrWhiteSpace(ftpConfiguration.Password) && string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath))
+                    if (string.IsNullOrWhiteSpace(ftpConfiguration.Password) && string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath)
+                        && !UseSftp)
                     {
                         throw new ArgumentNullException(Resources.NoValidAuthenticationMethod);
                     }

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/DirectoryExistsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/DirectoryExistsTests.cs
@@ -1,57 +1,15 @@
 using Moq;
 using System;
 using System.Activities;
-using System.Activities.Statements;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.FTP.Activities;
-using Xunit;
 
 namespace UiPath.FTP.Tests.ActivitiesTests
 {
-    public class DirectoryExistsTests
+    public class DirectoryExistsTests : ExistsActivityTestsBase
     {
-        [Fact]
-        public void DirectoryExists_SetsExistsTrue_WhenSessionReturnsTrue()
-        {
-            var session = CreateSessionMock(exists: true);
-            bool result = RunActivity(session, "/remote/dir");
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void DirectoryExists_SetsExistsFalse_WhenSessionReturnsFalse()
-        {
-            var session = CreateSessionMock(exists: false);
-            bool result = RunActivity(session, "/remote/dir");
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void DirectoryExists_CallsDirectoryExistsAsync_WithCorrectPath()
-        {
-            var session = CreateSessionMock(exists: false);
-            RunActivity(session, "/expected/path");
-            session.Verify(
-                s => s.DirectoryExistsAsync("/expected/path", It.IsAny<CancellationToken>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public void DirectoryExists_PropagatesException_WhenSessionThrows()
-        {
-            var session = new Mock<IFtpSession>();
-            session
-                .Setup(s => s.DirectoryExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new InvalidOperationException("session error"));
-
-            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/dir"));
-            Assert.Contains(TestsHelper.Flatten(ex), e => e is InvalidOperationException);
-        }
-
-        // --- Helpers ---
-
-        private static Mock<IFtpSession> CreateSessionMock(bool exists)
+        protected override Mock<IFtpSession> CreateSessionMock(bool exists)
         {
             var session = new Mock<IFtpSession>();
             session
@@ -60,39 +18,25 @@ namespace UiPath.FTP.Tests.ActivitiesTests
             return session;
         }
 
-        private static bool RunActivity(Mock<IFtpSession> session, string remotePath)
+        protected override Mock<IFtpSession> CreateThrowingSessionMock(Exception exception)
         {
-            var result = new bool[1];
-            var resultVariable = new Variable<bool>("exists");
-            var activity = new WithFtpSession(session.Object)
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.DirectoryExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(exception);
+            return session;
+        }
+
+        protected override Activity CreateExistsActivity(string remotePath, OutArgument<bool> exists)
+            => new DirectoryExists
             {
-                Host = new InArgument<string>("NonUsed"),
-                Username = new InArgument<string>("NonUsed"),
-                Password = new InArgument<string>("NonUsed"),
+                RemotePath = new InArgument<string>(remotePath),
+                Exists = exists
             };
 
-            if (activity.Body.Handler is Sequence seq)
-            {
-                seq.Variables.Add(resultVariable);
-                seq.Activities.Add(new DirectoryExists
-                {
-                    RemotePath = new InArgument<string>(remotePath),
-                    Exists = new OutArgument<bool>(resultVariable)
-                });
-                seq.Activities.Add(new InvokeMethod
-                {
-                    TargetType = typeof(TestsHelper),
-                    MethodName = nameof(TestsHelper.CopyBool),
-                    Parameters =
-                    {
-                        new InArgument<bool>(ctx => resultVariable.Get(ctx)),
-                        new InArgument<bool[]>(ctx => result)
-                    }
-                });
-            }
-
-            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
-            return result[0];
-        }
+        protected override void VerifySessionCall(Mock<IFtpSession> session, string expectedPath)
+            => session.Verify(
+                s => s.DirectoryExistsAsync(expectedPath, It.IsAny<CancellationToken>()),
+                Moq.Times.Once);
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/DirectoryExistsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/DirectoryExistsTests.cs
@@ -1,0 +1,98 @@
+using Moq;
+using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Threading;
+using System.Threading.Tasks;
+using UiPath.FTP.Activities;
+using Xunit;
+
+namespace UiPath.FTP.Tests.ActivitiesTests
+{
+    public class DirectoryExistsTests
+    {
+        [Fact]
+        public void DirectoryExists_SetsExistsTrue_WhenSessionReturnsTrue()
+        {
+            var session = CreateSessionMock(exists: true);
+            bool result = RunActivity(session, "/remote/dir");
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void DirectoryExists_SetsExistsFalse_WhenSessionReturnsFalse()
+        {
+            var session = CreateSessionMock(exists: false);
+            bool result = RunActivity(session, "/remote/dir");
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void DirectoryExists_CallsDirectoryExistsAsync_WithCorrectPath()
+        {
+            var session = CreateSessionMock(exists: false);
+            RunActivity(session, "/expected/path");
+            session.Verify(
+                s => s.DirectoryExistsAsync("/expected/path", It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public void DirectoryExists_PropagatesException_WhenSessionThrows()
+        {
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.DirectoryExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("session error"));
+
+            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/dir"));
+            Assert.Contains(TestsHelper.Flatten(ex), e => e is InvalidOperationException);
+        }
+
+        // --- Helpers ---
+
+        private static Mock<IFtpSession> CreateSessionMock(bool exists)
+        {
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.DirectoryExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(exists));
+            return session;
+        }
+
+        private static bool RunActivity(Mock<IFtpSession> session, string remotePath)
+        {
+            var result = new bool[1];
+            var resultVariable = new Variable<bool>("exists");
+            var activity = new WithFtpSession(session.Object)
+            {
+                Host = new InArgument<string>("NonUsed"),
+                Username = new InArgument<string>("NonUsed"),
+                Password = new InArgument<string>("NonUsed"),
+            };
+
+            if (activity.Body.Handler is Sequence seq)
+            {
+                seq.Variables.Add(resultVariable);
+                seq.Activities.Add(new DirectoryExists
+                {
+                    RemotePath = new InArgument<string>(remotePath),
+                    Exists = new OutArgument<bool>(resultVariable)
+                });
+                seq.Activities.Add(new InvokeMethod
+                {
+                    TargetType = typeof(TestsHelper),
+                    MethodName = nameof(TestsHelper.CopyBool),
+                    Parameters =
+                    {
+                        new InArgument<bool>(ctx => resultVariable.Get(ctx)),
+                        new InArgument<bool[]>(ctx => result)
+                    }
+                });
+            }
+
+            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
+            return result[0];
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/ExistsActivityTestsBase.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/ExistsActivityTestsBase.cs
@@ -1,0 +1,107 @@
+using Moq;
+using Renci.SshNet.Common;
+using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Threading;
+using System.Threading.Tasks;
+using UiPath.FTP.Activities;
+using Xunit;
+
+namespace UiPath.FTP.Tests.ActivitiesTests
+{
+    /// <summary>
+    /// Shared test logic for activity-level "exists" tests (directory and file).
+    /// Concrete subclasses supply the three things that differ: session mock setup,
+    /// activity construction, and the method-level verify call.
+    /// </summary>
+    public abstract class ExistsActivityTestsBase
+    {
+        // --- Abstract seams ---
+
+        protected abstract Mock<IFtpSession> CreateSessionMock(bool exists);
+
+        protected abstract Mock<IFtpSession> CreateThrowingSessionMock(Exception exception);
+
+        protected abstract Activity CreateExistsActivity(string remotePath, OutArgument<bool> exists);
+
+        protected abstract void VerifySessionCall(Mock<IFtpSession> session, string expectedPath);
+
+        // --- Shared tests (inherited by every concrete subclass) ---
+
+        [Fact]
+        public void Exists_ReturnsTrue_WhenSessionReturnsTrue()
+        {
+            var session = CreateSessionMock(exists: true);
+            Assert.True(RunActivity(session, "/remote/path"));
+        }
+
+        [Fact]
+        public void Exists_ReturnsFalse_WhenSessionReturnsFalse()
+        {
+            var session = CreateSessionMock(exists: false);
+            Assert.False(RunActivity(session, "/remote/path"));
+        }
+
+        [Fact]
+        public void Exists_CallsSession_WithCorrectPath()
+        {
+            var session = CreateSessionMock(exists: false);
+            RunActivity(session, "/expected/path");
+            VerifySessionCall(session, "/expected/path");
+        }
+
+        [Fact]
+        public void Exists_PropagatesException_WhenSessionThrows()
+        {
+            var session = CreateThrowingSessionMock(new InvalidOperationException("session error"));
+
+            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/path"));
+            Assert.Contains(TestsHelper.Flatten(ex), e => e is InvalidOperationException);
+        }
+
+        [Fact]
+        public void Exists_PropagatesSftpPathNotFoundException_WhenSessionThrows()
+        {
+            var session = CreateThrowingSessionMock(new SftpPathNotFoundException("No such file"));
+
+            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/path"));
+            Assert.Contains(TestsHelper.Flatten(ex), e => e is SftpPathNotFoundException);
+        }
+
+        // --- Shared helper ---
+
+        protected bool RunActivity(Mock<IFtpSession> session, string remotePath)
+        {
+            var result = new bool[1];
+            var resultVariable = new Variable<bool>("exists");
+            var activity = new WithFtpSession(session.Object)
+            {
+                Host = new InArgument<string>("NonUsed"),
+                Username = new InArgument<string>("NonUsed"),
+                Password = new InArgument<string>("NonUsed"),
+            };
+
+            Assert.True(
+                activity.Body.Handler is Sequence,
+                "WithFtpSession.Body.Handler is no longer a Sequence; update the test scaffolding.");
+            var seq = (Sequence)activity.Body.Handler;
+
+            seq.Variables.Add(resultVariable);
+            seq.Activities.Add(CreateExistsActivity(remotePath, new OutArgument<bool>(resultVariable)));
+            seq.Activities.Add(new InvokeMethod
+            {
+                TargetType = typeof(TestsHelper),
+                MethodName = nameof(TestsHelper.CopyBool),
+                Parameters =
+                {
+                    new InArgument<bool>(ctx => resultVariable.Get(ctx)),
+                    new InArgument<bool[]>(ctx => result)
+                }
+            });
+
+            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
+            return result[0];
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/FileExistsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/FileExistsTests.cs
@@ -1,0 +1,98 @@
+using Moq;
+using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Threading;
+using System.Threading.Tasks;
+using UiPath.FTP.Activities;
+using Xunit;
+
+namespace UiPath.FTP.Tests.ActivitiesTests
+{
+    public class FileExistsTests
+    {
+        [Fact]
+        public void FileExists_SetsExistsTrue_WhenSessionReturnsTrue()
+        {
+            var session = CreateSessionMock(exists: true);
+            bool result = RunActivity(session, "/remote/file.txt");
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FileExists_SetsExistsFalse_WhenSessionReturnsFalse()
+        {
+            var session = CreateSessionMock(exists: false);
+            bool result = RunActivity(session, "/remote/file.txt");
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FileExists_CallsFileExistsAsync_WithCorrectPath()
+        {
+            var session = CreateSessionMock(exists: false);
+            RunActivity(session, "/expected/file.txt");
+            session.Verify(
+                s => s.FileExistsAsync("/expected/file.txt", It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public void FileExists_PropagatesException_WhenSessionThrows()
+        {
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.FileExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("session error"));
+
+            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/file.txt"));
+            Assert.Contains(TestsHelper.Flatten(ex), e => e is InvalidOperationException);
+        }
+
+        // --- Helpers ---
+
+        private static Mock<IFtpSession> CreateSessionMock(bool exists)
+        {
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.FileExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(exists));
+            return session;
+        }
+
+        private static bool RunActivity(Mock<IFtpSession> session, string remotePath)
+        {
+            var result = new bool[1];
+            var resultVariable = new Variable<bool>("exists");
+            var activity = new WithFtpSession(session.Object)
+            {
+                Host = new InArgument<string>("NonUsed"),
+                Username = new InArgument<string>("NonUsed"),
+                Password = new InArgument<string>("NonUsed"),
+            };
+
+            if (activity.Body.Handler is Sequence seq)
+            {
+                seq.Variables.Add(resultVariable);
+                seq.Activities.Add(new FileExists
+                {
+                    RemotePath = new InArgument<string>(remotePath),
+                    Exists = new OutArgument<bool>(resultVariable)
+                });
+                seq.Activities.Add(new InvokeMethod
+                {
+                    TargetType = typeof(TestsHelper),
+                    MethodName = nameof(TestsHelper.CopyBool),
+                    Parameters =
+                    {
+                        new InArgument<bool>(ctx => resultVariable.Get(ctx)),
+                        new InArgument<bool[]>(ctx => result)
+                    }
+                });
+            }
+
+            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
+            return result[0];
+        }
+    }
+}

--- a/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/FileExistsTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/ActivitiesTests/FileExistsTests.cs
@@ -1,57 +1,15 @@
 using Moq;
 using System;
 using System.Activities;
-using System.Activities.Statements;
 using System.Threading;
 using System.Threading.Tasks;
 using UiPath.FTP.Activities;
-using Xunit;
 
 namespace UiPath.FTP.Tests.ActivitiesTests
 {
-    public class FileExistsTests
+    public class FileExistsTests : ExistsActivityTestsBase
     {
-        [Fact]
-        public void FileExists_SetsExistsTrue_WhenSessionReturnsTrue()
-        {
-            var session = CreateSessionMock(exists: true);
-            bool result = RunActivity(session, "/remote/file.txt");
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void FileExists_SetsExistsFalse_WhenSessionReturnsFalse()
-        {
-            var session = CreateSessionMock(exists: false);
-            bool result = RunActivity(session, "/remote/file.txt");
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void FileExists_CallsFileExistsAsync_WithCorrectPath()
-        {
-            var session = CreateSessionMock(exists: false);
-            RunActivity(session, "/expected/file.txt");
-            session.Verify(
-                s => s.FileExistsAsync("/expected/file.txt", It.IsAny<CancellationToken>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public void FileExists_PropagatesException_WhenSessionThrows()
-        {
-            var session = new Mock<IFtpSession>();
-            session
-                .Setup(s => s.FileExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new InvalidOperationException("session error"));
-
-            var ex = Assert.ThrowsAny<Exception>(() => RunActivity(session, "/remote/file.txt"));
-            Assert.Contains(TestsHelper.Flatten(ex), e => e is InvalidOperationException);
-        }
-
-        // --- Helpers ---
-
-        private static Mock<IFtpSession> CreateSessionMock(bool exists)
+        protected override Mock<IFtpSession> CreateSessionMock(bool exists)
         {
             var session = new Mock<IFtpSession>();
             session
@@ -60,39 +18,25 @@ namespace UiPath.FTP.Tests.ActivitiesTests
             return session;
         }
 
-        private static bool RunActivity(Mock<IFtpSession> session, string remotePath)
+        protected override Mock<IFtpSession> CreateThrowingSessionMock(Exception exception)
         {
-            var result = new bool[1];
-            var resultVariable = new Variable<bool>("exists");
-            var activity = new WithFtpSession(session.Object)
+            var session = new Mock<IFtpSession>();
+            session
+                .Setup(s => s.FileExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(exception);
+            return session;
+        }
+
+        protected override Activity CreateExistsActivity(string remotePath, OutArgument<bool> exists)
+            => new FileExists
             {
-                Host = new InArgument<string>("NonUsed"),
-                Username = new InArgument<string>("NonUsed"),
-                Password = new InArgument<string>("NonUsed"),
+                RemotePath = new InArgument<string>(remotePath),
+                Exists = exists
             };
 
-            if (activity.Body.Handler is Sequence seq)
-            {
-                seq.Variables.Add(resultVariable);
-                seq.Activities.Add(new FileExists
-                {
-                    RemotePath = new InArgument<string>(remotePath),
-                    Exists = new OutArgument<bool>(resultVariable)
-                });
-                seq.Activities.Add(new InvokeMethod
-                {
-                    TargetType = typeof(TestsHelper),
-                    MethodName = nameof(TestsHelper.CopyBool),
-                    Parameters =
-                    {
-                        new InArgument<bool>(ctx => resultVariable.Get(ctx)),
-                        new InArgument<bool[]>(ctx => result)
-                    }
-                });
-            }
-
-            WorkflowInvoker.Invoke(activity, TimeSpan.FromSeconds(5));
-            return result[0];
-        }
+        protected override void VerifySessionCall(Mock<IFtpSession> session, string expectedPath)
+            => session.Verify(
+                s => s.FileExistsAsync(expectedPath, It.IsAny<CancellationToken>()),
+                Moq.Times.Once);
     }
 }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -1,5 +1,11 @@
 using Renci.SshNet;
+using Renci.SshNet.Common;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace UiPath.FTP.Tests
@@ -44,12 +50,186 @@ namespace UiPath.FTP.Tests
             Assert.Equal(defaultSftpClient.OperationTimeout, sftpClient.OperationTimeout);
         }
 
-        private static FtpConfiguration CreateTestConfig(int? timeout = null)
+        [Fact]
+        public void SFTP_KeyboardInteractiveMethod_IsAlwaysRegistered()
+        {
+            var config = CreateTestConfig();
+            using var session = new SftpSession(config);
+
+            var authMethods = session.Client.ConnectionInfo.AuthenticationMethods;
+
+            Assert.Contains(authMethods, m => m is KeyboardInteractiveAuthenticationMethod);
+        }
+
+        [Fact]
+        public void SFTP_KeyboardInteractiveMethod_RespondsWithPasswordForNonEchoPrompt()
+        {
+            const string password = "s3cr3t"; // NOSONAR - dummy test credentials
+            var config = CreateTestConfig(password: password);
+            using var session = new SftpSession(config);
+
+            var kbiMethod = session.Client.ConnectionInfo.AuthenticationMethods
+                .OfType<KeyboardInteractiveAuthenticationMethod>()
+                .Single();
+
+            var prompt = new AuthenticationPrompt(0, false, "Password: ");
+            RaiseAuthenticationPrompt(kbiMethod, new[] { prompt });
+
+            Assert.Equal(password, prompt.Response);
+        }
+
+        [Fact]
+        public void SFTP_KeyboardInteractiveMethod_LeavesEchoPromptEmpty()
+        {
+            var config = CreateTestConfig(password: "s3cr3t"); // NOSONAR - dummy test credentials
+            using var session = new SftpSession(config);
+
+            var kbiMethod = session.Client.ConnectionInfo.AuthenticationMethods
+                .OfType<KeyboardInteractiveAuthenticationMethod>()
+                .Single();
+
+            var prompt = new AuthenticationPrompt(0, true, "Username: ");
+            RaiseAuthenticationPrompt(kbiMethod, new[] { prompt });
+
+            Assert.Null(prompt.Response);
+        }
+
+        [Fact]
+        public void SFTP_KeyboardInteractiveMethod_RespondsWithEmptyStringWhenPasswordIsNull()
+        {
+            var config = new FtpConfiguration("localhost")
+            {
+                Username = "testUser",
+                Password = null
+            };
+            using var session = new SftpSession(config);
+
+            var kbiMethod = session.Client.ConnectionInfo.AuthenticationMethods
+                .OfType<KeyboardInteractiveAuthenticationMethod>()
+                .Single();
+
+            var prompt = new AuthenticationPrompt(0, false, "Password: ");
+            RaiseAuthenticationPrompt(kbiMethod, new[] { prompt });
+
+            Assert.Equal(string.Empty, prompt.Response);
+        }
+
+        // --- SafeExists / SshException swallowing ---
+
+        [Fact]
+        public async Task SFTP_DirectoryExistsAsync_ReturnsFalse_WhenClientExistsThrowsBareSshException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SshException("SSH_FX_FAILURE"));
+
+            bool result = await ((IFtpSession)session).DirectoryExistsAsync("/some/path", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task SFTP_FileExistsAsync_ReturnsFalse_WhenClientExistsThrowsBareSshException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SshException("SSH_FX_FAILURE"));
+
+            bool result = await ((IFtpSession)session).FileExistsAsync("/some/file.txt", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task SFTP_DirectoryExistsAsync_Rethrows_WhenClientExistsThrowsSshConnectionException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SshConnectionException("dropped"));
+
+            await Assert.ThrowsAsync<SshConnectionException>(
+                () => ((IFtpSession)session).DirectoryExistsAsync("/some/path", CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task SFTP_FileExistsAsync_Rethrows_WhenClientExistsThrowsSshConnectionException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SshConnectionException("dropped"));
+
+            await Assert.ThrowsAsync<SshConnectionException>(
+                () => ((IFtpSession)session).FileExistsAsync("/some/file.txt", CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task SFTP_DirectoryExistsAsync_ReturnsFalse_WhenClientExistsReturnsFalse()
+        {
+            using var session = new SftpSessionWithFakeExists(CreateTestConfig(), () => false);
+
+            bool result = await ((IFtpSession)session).DirectoryExistsAsync("/some/path", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task SFTP_FileExistsAsync_ReturnsFalse_WhenClientExistsReturnsFalse()
+        {
+            using var session = new SftpSessionWithFakeExists(CreateTestConfig(), () => false);
+
+            bool result = await ((IFtpSession)session).FileExistsAsync("/some/file.txt", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        // --- Helpers ---
+
+        /// <summary>
+        /// Subclass of <see cref="SftpSession"/> that overrides <see cref="SftpSession.ClientExists"/>
+        /// so tests can inject arbitrary behaviour without needing to override the sealed
+        /// <c>SftpClient.Exists</c> method.
+        /// </summary>
+        private sealed class SftpSessionWithFakeExists : SftpSession
+        {
+            private readonly Func<bool> _existsBehaviour;
+
+            public SftpSessionWithFakeExists(FtpConfiguration config, Func<bool> existsBehaviour)
+                : base(config)
+            {
+                _existsBehaviour = existsBehaviour;
+            }
+
+            protected internal override bool ClientExists(string path) => _existsBehaviour();
+        }
+
+        /// <summary>
+        /// Fires the <see cref="KeyboardInteractiveAuthenticationMethod.AuthenticationPrompt"/> event
+        /// by invoking its backing delegate directly. SSH.NET does not expose a raise method, so
+        /// reflection is used here purely as a test seam.
+        /// </summary>
+        private static void RaiseAuthenticationPrompt(
+            KeyboardInteractiveAuthenticationMethod method,
+            IEnumerable<AuthenticationPrompt> prompts)
+        {
+            var eventArgs = new AuthenticationPromptEventArgs("testUser", string.Empty, string.Empty, prompts.ToList().AsReadOnly());
+
+            var field = typeof(KeyboardInteractiveAuthenticationMethod)
+                .GetField("AuthenticationPrompt", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? typeof(KeyboardInteractiveAuthenticationMethod)
+                    .GetField("_authenticationPrompt", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field); // SSH.NET renamed the backing field; update the lookup above.
+
+            var handler = field.GetValue(method) as EventHandler<AuthenticationPromptEventArgs>;
+            Assert.NotNull(handler); // SftpSession did not subscribe to AuthenticationPrompt.
+            handler.Invoke(method, eventArgs);
+        }
+
+        private static FtpConfiguration CreateTestConfig(int? timeout = null, string password = "notUsed")
         {
             return new FtpConfiguration("localhost")
             {
                 Username = "testUser",
-                Password = "notUsed", // NOSONAR - dummy test credentials, never connect to any server
+                Password = password, // NOSONAR - dummy test credentials, never connect to any server
                 Timeout = timeout
             };
         }

--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -12,6 +12,8 @@ namespace UiPath.FTP.Tests
 {
     public class SftpSessionTests
     {
+        private const string TestUsername = "testUser"; // NOSONAR - dummy test credentials
+
         [Fact]
         public void SFTP_TestConnect()
         {
@@ -42,8 +44,8 @@ namespace UiPath.FTP.Tests
             // When no timeout is set, SSH.NET defaults should be preserved
             var defaultConnectionInfo = new ConnectionInfo(
                 "localhost",
-                "testUser",
-                new PasswordAuthenticationMethod("testUser", "notUsed")); // NOSONAR - dummy test credentials
+                TestUsername,
+                new PasswordAuthenticationMethod(TestUsername, "notUsed")); // NOSONAR - dummy test credentials
             using var defaultSftpClient = new SftpClient(defaultConnectionInfo);
 
             Assert.Equal(defaultConnectionInfo.Timeout, sftpClient.ConnectionInfo.Timeout);
@@ -51,14 +53,25 @@ namespace UiPath.FTP.Tests
         }
 
         [Fact]
-        public void SFTP_KeyboardInteractiveMethod_IsAlwaysRegistered()
+        public void SFTP_KeyboardInteractiveMethod_IsRegistered_WhenPasswordIsConfigured()
         {
-            var config = CreateTestConfig();
+            var config = CreateTestConfig(password: "s3cr3t"); // NOSONAR - dummy test credentials
             using var session = new SftpSession(config);
 
-            var authMethods = session.Client.ConnectionInfo.AuthenticationMethods;
+            Assert.Contains(
+                session.Client.ConnectionInfo.AuthenticationMethods,
+                m => m is KeyboardInteractiveAuthenticationMethod);
+        }
 
-            Assert.Contains(authMethods, m => m is KeyboardInteractiveAuthenticationMethod);
+        [Fact]
+        public void SFTP_KeyboardInteractiveMethod_IsNotRegistered_WhenPasswordIsNullOrEmpty()
+        {
+            // With no password and no certificate, no auth methods are added and the
+            // constructor throws. This confirms kbi is not registered as a fallback
+            // when there is no password to respond with.
+            var config = new FtpConfiguration("localhost") { Username = TestUsername, Password = null };
+
+            Assert.Throws<ArgumentNullException>(() => new SftpSession(config));
         }
 
         [Fact]
@@ -94,26 +107,6 @@ namespace UiPath.FTP.Tests
             Assert.Null(prompt.Response);
         }
 
-        [Fact]
-        public void SFTP_KeyboardInteractiveMethod_RespondsWithEmptyStringWhenPasswordIsNull()
-        {
-            var config = new FtpConfiguration("localhost")
-            {
-                Username = "testUser",
-                Password = null
-            };
-            using var session = new SftpSession(config);
-
-            var kbiMethod = session.Client.ConnectionInfo.AuthenticationMethods
-                .OfType<KeyboardInteractiveAuthenticationMethod>()
-                .Single();
-
-            var prompt = new AuthenticationPrompt(0, false, "Password: ");
-            RaiseAuthenticationPrompt(kbiMethod, new[] { prompt });
-
-            Assert.Equal(string.Empty, prompt.Response);
-        }
-
         // --- SafeExists / SshException swallowing ---
 
         [Fact]
@@ -139,6 +132,31 @@ namespace UiPath.FTP.Tests
 
             Assert.False(result);
         }
+
+        [Fact]
+        public async Task SFTP_DirectoryExistsAsync_ReturnsFalse_WhenClientExistsThrowsSftpPathNotFoundException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SftpPathNotFoundException("No such file"));
+
+            bool result = await ((IFtpSession)session).DirectoryExistsAsync("/some/path", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task SFTP_FileExistsAsync_ReturnsFalse_WhenClientExistsThrowsSftpPathNotFoundException()
+        {
+            using var session = new SftpSessionWithFakeExists(
+                CreateTestConfig(),
+                () => throw new SftpPathNotFoundException("No such file"));
+
+            bool result = await ((IFtpSession)session).FileExistsAsync("/some/file.txt", CancellationToken.None);
+
+            Assert.False(result);
+        }
+
 
         [Fact]
         public async Task SFTP_DirectoryExistsAsync_Rethrows_WhenClientExistsThrowsSshConnectionException()
@@ -206,18 +224,19 @@ namespace UiPath.FTP.Tests
         /// Fires the <see cref="KeyboardInteractiveAuthenticationMethod.AuthenticationPrompt"/> event
         /// by invoking its backing delegate directly. SSH.NET does not expose a raise method, so
         /// reflection is used here purely as a test seam.
+        /// The backing field is located by type rather than by name so that SSH.NET version upgrades
+        /// that rename the field do not silently break the lookup.
         /// </summary>
         private static void RaiseAuthenticationPrompt(
             KeyboardInteractiveAuthenticationMethod method,
             IEnumerable<AuthenticationPrompt> prompts)
         {
-            var eventArgs = new AuthenticationPromptEventArgs("testUser", string.Empty, string.Empty, prompts.ToList().AsReadOnly());
+            var eventArgs = new AuthenticationPromptEventArgs(TestUsername, string.Empty, string.Empty, prompts.ToList().AsReadOnly());
 
             var field = typeof(KeyboardInteractiveAuthenticationMethod)
-                .GetField("AuthenticationPrompt", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?? typeof(KeyboardInteractiveAuthenticationMethod)
-                    .GetField("_authenticationPrompt", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(field); // SSH.NET renamed the backing field; update the lookup above.
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(f => f.FieldType == typeof(EventHandler<AuthenticationPromptEventArgs>));
+            Assert.NotNull(field); // SSH.NET no longer uses EventHandler<AuthenticationPromptEventArgs> for this event; update the test seam.
 
             var handler = field.GetValue(method) as EventHandler<AuthenticationPromptEventArgs>;
             Assert.NotNull(handler); // SftpSession did not subscribe to AuthenticationPrompt.
@@ -228,7 +247,7 @@ namespace UiPath.FTP.Tests
         {
             return new FtpConfiguration("localhost")
             {
-                Username = "testUser",
+                Username = TestUsername,
                 Password = password, // NOSONAR - dummy test credentials, never connect to any server
                 Timeout = timeout
             };

--- a/Activities/FTP/UiPath.FTP.Tests/TestsHelper.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/TestsHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace UiPath.FTP.Tests
 {
@@ -10,6 +11,31 @@ namespace UiPath.FTP.Tests
             newObjects.Clear();
             foreach (var obj in lstObjects)
                 newObjects.Add(obj);
+        }
+
+        // Used to capture a bool OutArgument value out of a WorkflowInvoker run.
+        // The result array must have at least one element; result[0] is set to value.
+        public static void CopyBool(bool value, bool[] result)
+        {
+            result[0] = value;
+        }
+
+        // Walks InnerException / AggregateException.InnerExceptions so callers can assert
+        // on the original exception type even after WorkflowInvoker / async wrapping.
+        public static IEnumerable<Exception> Flatten(Exception ex)
+        {
+            while (ex != null)
+            {
+                yield return ex;
+                if (ex is AggregateException agg)
+                {
+                    foreach (var inner in agg.InnerExceptions)
+                        foreach (var e in Flatten(inner))
+                            yield return e;
+                    yield break;
+                }
+                ex = ex.InnerException;
+            }
         }
     }
 }

--- a/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.Designer.cs
+++ b/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.Designer.cs
@@ -79,7 +79,7 @@ namespace UiPath.FTP.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password.
+        ///   Looks up a localized string similar to No valid authentication method found: You need to supply either Private Key file (and optionally passphrase) or Password.
         /// </summary>
         internal static string NoValidAuthenticationMethod {
             get {

--- a/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.resx
+++ b/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.resx
@@ -130,7 +130,7 @@
     <value>Unsupported object type encountered.</value>
   </data>
   <data name="NoValidAuthenticationMethod" xml:space="preserve">
-    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password</value>
+    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphrase) or Password</value>
   </data>
   <data name="DirectoryExistsException" xml:space="preserve">
     <value>The destination directory already exists</value>

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -46,23 +46,27 @@ namespace UiPath.FTP
                 authMethods.Add(new PrivateKeyAuthenticationMethod(ftpConfiguration.Username, keyFiles));
             }
 
-            // Always register keyboard-interactive so that servers which advertise only
-            // keyboard-interactive (OpenSSH with ChallengeResponseAuthentication/PAM) can
-            // authenticate using the configured password. The handler responds with the
-            // password for every non-echo prompt; echo prompts are left empty because the
-            // SSH username is already supplied at the transport layer.
-            var kbiMethod = new KeyboardInteractiveAuthenticationMethod(ftpConfiguration.Username);
-            kbiMethod.AuthenticationPrompt += (sender, e) =>
+            // Register keyboard-interactive when a password is configured, mirroring the
+            // PasswordAuthenticationMethod guard above. Servers that advertise only kbi
+            // (OpenSSH with ChallengeResponseAuthentication/PAM) can then authenticate
+            // using the configured password. Skipping kbi when there is no password avoids
+            // a redundant failed auth round-trip on certificate-only connections.
+            if (!String.IsNullOrEmpty(ftpConfiguration.Password))
             {
-                foreach (var prompt in e.Prompts)
+                var kbiMethod = new KeyboardInteractiveAuthenticationMethod(ftpConfiguration.Username);
+                var kbiPassword = ftpConfiguration.Password;
+                kbiMethod.AuthenticationPrompt += (sender, e) =>
                 {
-                    if (!prompt.IsEchoed)
+                    foreach (var prompt in e.Prompts)
                     {
-                        prompt.Response = ftpConfiguration.Password ?? string.Empty;
+                        if (!prompt.IsEchoed)
+                        {
+                            prompt.Response = kbiPassword;
+                        }
                     }
-                }
-            };
-            authMethods.Add(kbiMethod);
+                };
+                authMethods.Add(kbiMethod);
+            }
 
             //Throw an error if we ended up with no authentication method
             if (authMethods.Count == 0)
@@ -337,7 +341,7 @@ namespace UiPath.FTP
             {
                 return ClientExists(path);
             }
-            catch (SshException ex) when (ex.GetType() == typeof(SshException))
+            catch (SshException ex) when (ex is SftpPathNotFoundException || ex.GetType() == typeof(SshException))
             {
                 Trace.TraceWarning(
                     "SftpSession.SafeExists: bare SshException treated as 'not found' for path '{0}': {1}",

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -1,4 +1,5 @@
 ﻿using Renci.SshNet;
+using Renci.SshNet.Common;
 using Renci.SshNet.Sftp;
 using System;
 using System.Collections.Generic;
@@ -44,6 +45,24 @@ namespace UiPath.FTP
                 var keyFiles = new[] { keyFile };
                 authMethods.Add(new PrivateKeyAuthenticationMethod(ftpConfiguration.Username, keyFiles));
             }
+
+            // Always register keyboard-interactive so that servers which advertise only
+            // keyboard-interactive (OpenSSH with ChallengeResponseAuthentication/PAM) can
+            // authenticate using the configured password. The handler responds with the
+            // password for every non-echo prompt; echo prompts are left empty because the
+            // SSH username is already supplied at the transport layer.
+            var kbiMethod = new KeyboardInteractiveAuthenticationMethod(ftpConfiguration.Username);
+            kbiMethod.AuthenticationPrompt += (sender, e) =>
+            {
+                foreach (var prompt in e.Prompts)
+                {
+                    if (!prompt.IsEchoed)
+                    {
+                        prompt.Response = ftpConfiguration.Password ?? string.Empty;
+                    }
+                }
+            };
+            authMethods.Add(kbiMethod);
 
             //Throw an error if we ended up with no authentication method
             if (authMethods.Count == 0)
@@ -297,7 +316,39 @@ namespace UiPath.FTP
             return missingDirectories;
         }
 
+        /// <summary>
+        /// Calls <see cref="SftpClient.Exists"/> on the underlying client.
+        /// Extracted as a <c>protected internal virtual</c> method so that tests can subclass
+        /// <see cref="SftpSession"/> and override this single call without needing to mock the
+        /// sealed <c>SftpClient.Exists</c> method directly.
+        /// </summary>
+        protected internal virtual bool ClientExists(string path) => _sftpClient.Exists(path);
+
+        /// <summary>
+        /// Wraps <see cref="ClientExists"/> and returns <c>false</c> for bare
+        /// <see cref="SshException"/> (SSH_FX_FAILURE) thrown by some SFTP server
+        /// implementations when a path does not exist, while letting typed subclasses
+        /// (e.g. <see cref="SshConnectionException"/>, <see cref="SshOperationTimeoutException"/>)
+        /// propagate so that real connection/timeout failures are not silently swallowed.
+        /// </summary>
+        private bool SafeExists(string path)
+        {
+            try
+            {
+                return ClientExists(path);
+            }
+            catch (SshException ex) when (ex.GetType() == typeof(SshException))
+            {
+                Trace.TraceWarning(
+                    "SftpSession.SafeExists: bare SshException treated as 'not found' for path '{0}': {1}",
+                    path,
+                    ex.Message);
+                return false;
+            }
+        }
+
         #region IFtpSession members
+
         bool IFtpSession.IsConnected()
         {
             return _sftpClient.IsConnected;
@@ -389,7 +440,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.Directory;
+            return SafeExists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.Directory;
         }
 
         async Task<bool> IFtpSession.DirectoryExistsAsync(string path, CancellationToken cancellationToken)
@@ -399,7 +450,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (_sftpClient.Exists(path))
+            if (SafeExists(path))
             {
                 return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == UiPath.FTP.FtpObjectType.Directory;
             }
@@ -532,7 +583,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return _sftpClient.Exists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.File;
+            return SafeExists(path) && ((IFtpSession)this).GetObjectType(path) == UiPath.FTP.FtpObjectType.File;
         }
 
         async Task<bool> IFtpSession.FileExistsAsync(string path, CancellationToken cancellationToken)
@@ -542,7 +593,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (_sftpClient.Exists(path))
+            if (SafeExists(path))
             {
                 return await ((IFtpSession)this).GetObjectTypeAsync(path, cancellationToken) == UiPath.FTP.FtpObjectType.File;
             }
@@ -559,7 +610,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (!_sftpClient.Exists(path))
+            if (!SafeExists(path))
             {
                 throw new ArgumentException(string.Format(Resources.PathNotFoundException, path), nameof(path));
             }
@@ -574,7 +625,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (!_sftpClient.Exists(path))
+            if (!SafeExists(path))
             {
                 throw new ArgumentException(string.Format(Resources.PathNotFoundException, path), nameof(path));
             }
@@ -613,25 +664,25 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(newPath));
             }
 
-            if (!_sftpClient.Exists(remotePath))
+            if (!SafeExists(remotePath))
             {
                 throw new IOException(string.Format(Resources.PathNotFoundException, remotePath));
             }
 
-            if (_sftpClient.Exists(newPath) && _sftpClient.Get(newPath).IsRegularFile &&  !overwrite)
+            if (SafeExists(newPath) && _sftpClient.Get(newPath).IsRegularFile &&  !overwrite)
             {
                 throw new IOException(Resources.FileExistsException);
             }
 
             var file = _sftpClient.Get(remotePath);
 
-            if(_sftpClient.Exists(newPath) && file.IsRegularFile)
+            if(SafeExists(newPath) && file.IsRegularFile)
             {
                 var movePath = _sftpClient.Get(newPath);
                 if (movePath.IsDirectory)
                 {
                     var newFP = string.Format("{0}/{1}", movePath.FullName, file.Name);
-                    if (_sftpClient.Exists(newFP) && _sftpClient.Get(newFP).IsRegularFile)
+                    if (SafeExists(newFP) && _sftpClient.Get(newFP).IsRegularFile)
                     {
                         if (overwrite)
                             _sftpClient.DeleteFile(newFP);
@@ -668,7 +719,7 @@ namespace UiPath.FTP
                 foreach (Tuple<string, string> pair in listing)
                 {
                     string directoryPath = FtpConfiguration.GetDirectoryPath(pair.Item2);
-                    if (!_sftpClient.Exists(directoryPath))
+                    if (!SafeExists(directoryPath))
                     {
                         _sftpClient.CreateDirectory(directoryPath);
                     }
@@ -683,7 +734,7 @@ namespace UiPath.FTP
             {
                 if (File.Exists(localPath))
                 {
-                    if (_sftpClient.Exists(remotePath) && !overwrite)
+                    if (SafeExists(remotePath) && !overwrite)
                     {
                         throw new IOException(Resources.FileExistsException);
                     }
@@ -720,7 +771,7 @@ namespace UiPath.FTP
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string directoryPath = FtpConfiguration.GetDirectoryPath(pair.Item2);
-                    if (!_sftpClient.Exists(directoryPath))
+                    if (!SafeExists(directoryPath))
                     {
                         _sftpClient.CreateDirectory(directoryPath);
                     }
@@ -735,7 +786,7 @@ namespace UiPath.FTP
             {
                 if (File.Exists(localPath))
                 {
-                    if (_sftpClient.Exists(remotePath) && !overwrite)
+                    if (SafeExists(remotePath) && !overwrite)
                     {
                         throw new IOException(Resources.FileExistsException);
                     }


### PR DESCRIPTION
In certain scenrios, if SshException is thrown swallow it 
Add support for keyboard interactive authentification 
Add unittests

https://uipath.atlassian.net/browse/STUD-72320
https://uipath.atlassian.net/browse/STUD-79812

Simple support is added for keyboard interactive authentication. The password or SecuredPassword from the card will be used for authentication. Custom prompts or 2FA Auth are not supported at the moment.

For testing purposes: the following scenario should be used: have a server that has supports only publickey and keyboard-interactive. If the password is correct, with previous version of the package it will fail to connect;with the new version it will connect.
