### PR TITLE
fix(credentials): tag activity displayName resx entries with "activity name" [STUD-80091]

### DIFF
--- a/Activities/Credentials/UiPath.Credentials.Activities/Properties/UiPath.Credentials.Activities.resx
+++ b/Activities/Credentials/UiPath.Credentials.Activities/Properties/UiPath.Credentials.Activities.resx
@@ -122,7 +122,7 @@
   </data>
   <data name="Activity_AddCredential_Property_AddCredentialDisplayName_Name" xml:space="preserve">
     <value>Add Credentials</value>
-    <comment>Attribute Name</comment>
+    <comment>activity name</comment>
   </data>
   <data name="Activity_AddCredential_Property_CredentialType_Description" xml:space="preserve">
     <value>Credential Type - The only supported values for Credential Type are 'Generic' or 'DomainPassword'</value>
@@ -135,7 +135,7 @@
   </data>
   <data name="Activity_DeleteCredential_Property_DeleteCredentialDisplayName_Name" xml:space="preserve">
     <value>Delete Credentials</value>
-    <comment>Attribute Name</comment>
+    <comment>activity name</comment>
   </data>
   <data name="Activity_GetCredential_Property_CredentialType_Description" xml:space="preserve">
     <value>Credential Type</value>
@@ -154,14 +154,14 @@
   </data>
   <data name="Activity_GetSecureCredential_Property_GetSecureCredentialDisplayName_Name" xml:space="preserve">
     <value>Get Secure Credentials</value>
-    <comment>Attribute Name</comment>
+    <comment>activity name</comment>
   </data>
   <data name="Activity_RequestCredential_Property_RequestCredentialDescription_Description" xml:space="preserve">
     <value>Request Credentials</value>
   </data>
   <data name="Activity_RequestCredential_Property_RequestCredentialDisplayName_Name" xml:space="preserve">
     <value>Request Credentials</value>
-    <comment>Attribute Name</comment>
+    <comment>activity name</comment>
   </data>
   <data name="CategoryCredentials" xml:space="preserve">
     <value>Credentials</value>


### PR DESCRIPTION
## Summary

- The four activity-level `displayName` entries in `UiPath.Credentials.Activities.resx` (`AddCredential`, `DeleteCredential`, `GetSecureCredential`, `RequestCredential`) carried `<comment>Attribute Name</comment>`, which the UiPath localization pipeline reads as a property-level tag. Translators and tooling that filter by comment would misclassify these strings.
- Change the comment to the canonical `activity name` tag so the entries are correctly identified as activity display names.
- No behavior or value changes; localized resx variants don't carry comments and were not touched.

JIRA: [STUD-80091](https://uipath.atlassian.net/browse/STUD-80091)

## Test plan

- [ ] Localization pipeline correctly classifies the four updated entries as activity display names.
- [ ] No functional regression — only resx `<comment>` text changed; values and keys unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STUD-80091]: https://uipath.atlassian.net/browse/STUD-80091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ