### PR TITLE
chore(ci): vendor AzurePipelinesTemplates, restore Sonar, harden CI

### DIFF
--- a/Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md
+++ b/Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md
@@ -1,0 +1,83 @@
+# SonarCloud admin checklist — restore PR decoration on Community.Activities
+
+**Audience:** SonarCloud admin for the `ui` org (whoever has `Administer` permission on the `Community.Activities` project).
+
+**Context:** The CI pipelines have been hardened and vendored locally (PR #559). Sonar currently runs only on pushes to protected branches (`develop`, `masters/*`, `release/*`, `support/*`) — PR decoration is disabled because the SonarCloud project's main branch is still pinned to `master`, which no longer exists in the GitHub repo. This causes `Create analysis` to fail on PR builds (`Detected project binding: NOT_BOUND`).
+
+After the steps below, Sonar PR decoration can be re-enabled with a single one-line YAML change.
+
+---
+
+## ☐ Step 1 — Rename the main branch from `master` to `develop`
+
+SonarCloud → `Community.Activities` project → **Administration → Branches & Pull Requests**.
+
+- Find the row marked as the main branch (currently `master`).
+- Use the **Rename** action (preserves all history, trends, hotspot decisions, quality-gate baselines).
+- New name: `develop`.
+
+If rename isn't offered: delete `master` and let a fresh `develop` analysis become the new main branch. History is lost; do this only if rename is genuinely unavailable.
+
+**Verify:** main branch in the Branches tab is `develop`. The project Overview still shows recent activity.
+
+## ☐ Step 2 — Configure long-lived branch pattern
+
+Same page (**Administration → Branches & Pull Requests**), find the **Long-lived branches pattern** setting.
+
+- Set to: `masters/.*|release/.*|support/.*`
+- Save.
+
+**Verify:** when the next `masters/Python` or `release/*` build pushes analysis to Sonar, the branch shows up under "Long-lived branches" rather than being treated as a short-lived feature branch.
+
+## ☐ Step 3 — Re-establish the GitHub ALM binding
+
+SonarCloud → `Community.Activities` project → **Administration → DevOps Platform Settings**.
+
+- Confirm the binding shows **GitHub** + **UiPath/Community.Activities**.
+- If status is broken / re-auth needed, click **Reconnect** or remove the binding and re-add. May require re-installing the SonarCloud GitHub App on the UiPath org under SAML approval.
+
+**Verify on GitHub:** https://github.com/organizations/UiPath/settings/installations → SonarCloud → "Configure" → confirms repo access to `Community.Activities` is granted and SAML-authorized.
+
+## ☐ Step 4 — Confirm baseline analysis exists on `develop`
+
+The first successful analysis on the new main branch creates the quality baseline that PR analyses compare against.
+
+- Trigger any CI pipeline on `develop` (push a no-op commit, or queue a manual `develop` build of any pack).
+- Watch the build — the `PublishSonar` stage should run and complete successfully.
+- After it completes: SonarCloud → `Community.Activities` → Overview → confirm "Last analysis" is recent and on branch `develop`.
+
+If this step fails with a Sonar error, **do not proceed to Step 5** — investigate first. Likely causes: the rename in Step 1 didn't take effect, or the binding in Step 3 isn't fully wired.
+
+## ☐ Step 5 — Re-enable Sonar on PR builds
+
+Once Steps 1–4 are green, hand back to the dev team to ship the one-line code change that brings back PR decoration:
+
+In `Activities/.pipelines/templates/stage.start.yml` (PublishSonar stage condition) and `Activities/.pipelines/templates/stage.build.yml` (two condition parameters for `Sonar/prepare-sonar-coverage.yml` and `Sonar/upload-sonar-build-output.yml`):
+
+Remove the trailing clause `, ne(variables['Build.Reason'], 'PullRequest')` from each `condition:` expression.
+
+A `git grep` will find all three places quickly:
+
+```
+git grep "ne(variables\['Build.Reason'\], 'PullRequest')" Activities/
+```
+
+Commit and PR. The next PR build should complete the full Sonar flow: Build with scanner prep → Test → PublishSonar with merge-commit reconstruction + analyze + publish + PR decoration on GitHub.
+
+---
+
+## Quality gate sanity check (do this after Step 5)
+
+- Open one of the next PR builds. PR comment from SonarCloud should appear with quality-gate status + coverage delta + new-code findings.
+- Open SonarCloud → `Community.Activities` → check that the PR shows up under "Pull Requests" with its quality-gate status.
+
+If decoration is missing but the analysis succeeded, check the SonarCloud project's GitHub App is still installed and the binding from Step 3 is still active.
+
+---
+
+## Related context
+
+- PR that introduced the current vendored pipeline state: #559
+- Commit that disabled PR-time Sonar (workaround that this checklist undoes): `1ba42f2`
+- Original Sonar disable that started this saga: `2584bed` (2026-02-27)
+- The Sonar tasks themselves use SonarSource's V1 (Node 10 EOL). Bumping to V2 is a separate follow-up — not blocking on these steps.

--- a/Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md
+++ b/Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md
@@ -1,83 +1,87 @@
 # SonarCloud admin checklist — restore PR decoration on Community.Activities
 
-**Audience:** SonarCloud admin for the `ui` org (whoever has `Administer` permission on the `Community.Activities` project).
+**Audience:** SonarCloud admin for the `ui` org (whoever has `Administer` permission on the `UiPath_Community.Activities` project).
 
-**Context:** The CI pipelines have been hardened and vendored locally (PR #559). Sonar currently runs only on pushes to protected branches (`develop`, `masters/*`, `release/*`, `support/*`) — PR decoration is disabled because the SonarCloud project's main branch is still pinned to `master`, which no longer exists in the GitHub repo. This causes `Create analysis` to fail on PR builds (`Detected project binding: NOT_BOUND`).
+**Context:** The CI pipelines have been hardened and vendored locally (PR #559). Sonar currently runs only on pushes to protected branches (`develop`, `masters/*`, `release/*`, `support/*`) — PR decoration is disabled because of a stale Sonar branch model, not a missing binding.
 
-After the steps below, Sonar PR decoration can be re-enabled with a single one-line YAML change.
+## What we already verified (no admin action needed for these)
 
----
+- ✅ **Project key is `UiPath_Community.Activities`** (in org `ui`). Confirmed by URL: `https://sonarcloud.io/summary/new_code?id=UiPath_Community.Activities&pullRequest=559`. Pipelines now point at this key.
+- ✅ **Project binding is healthy.** Last Sonar scan log shows `Detected project binding: BOUND` against `UiPath_Community.Activities`. The GitHub ALM link is intact — no need to reconnect the SonarCloud GitHub App or re-grant SAML access.
+- ✅ **Token and org slug are correct.** `prepare-sonar-coverage.yml` uses `organization: ui` and the token authenticates. Project lookup, settings, and branch config all load successfully.
 
-## ☐ Step 1 — Rename the main branch from `master` to `develop`
+## What's actually blocking PR decoration
 
-SonarCloud → `Community.Activities` project → **Administration → Branches & Pull Requests**.
+PR builds fail at `INFO: Create analysis` even though everything before it succeeds. The narrow cause is the **stale main branch**: SonarCloud's main branch is still `master` (last analyzed ~6 years ago), and the project's loaded extensions (`architecture`, `a3s`, `sca`) cannot construct a coherent analysis for a PR targeting `develop` against that stale baseline.
+
+The optimistic test (commit `2be7a4d`, reverted in `d4e3bd3`) confirmed this empirically — once the project key was right and the binding was BOUND, the `Create analysis` step still failed in the same place.
+
+## What you need to do
+
+The critical step is **Step 1** (main branch rename). Steps 2 and 3 are nice-to-haves.
+
+### ☐ Step 1 — Rename the main branch from `master` to `develop` (CRITICAL)
+
+SonarCloud → `UiPath_Community.Activities` project → **Administration → Branches & Pull Requests**.
 
 - Find the row marked as the main branch (currently `master`).
-- Use the **Rename** action (preserves all history, trends, hotspot decisions, quality-gate baselines).
+- Use the **Rename** action — preserves all history, trends, hotspot decisions, quality-gate baselines.
 - New name: `develop`.
 
-If rename isn't offered: delete `master` and let a fresh `develop` analysis become the new main branch. History is lost; do this only if rename is genuinely unavailable.
+If rename isn't offered: delete `master` and let a fresh `develop` analysis become the new main branch. History is lost — only do this if rename is genuinely unavailable.
 
-**Verify:** main branch in the Branches tab is `develop`. The project Overview still shows recent activity.
+**Verify:** main branch in the Branches tab is `develop`.
 
-## ☐ Step 2 — Configure long-lived branch pattern
+### ☐ Step 2 — Configure long-lived branch pattern (nice-to-have)
 
-Same page (**Administration → Branches & Pull Requests**), find the **Long-lived branches pattern** setting.
+Same page, find **Long-lived branches pattern** (or "Reference branches" in newer UI).
 
 - Set to: `masters/.*|release/.*|support/.*`
 - Save.
 
-**Verify:** when the next `masters/Python` or `release/*` build pushes analysis to Sonar, the branch shows up under "Long-lived branches" rather than being treated as a short-lived feature branch.
+This makes `masters/Python`, `release/Cryptography/*`, etc. show up as long-lived branches with their own quality-gate state, rather than being treated as throwaway feature branches.
 
-## ☐ Step 3 — Re-establish the GitHub ALM binding
+### ☐ Step 3 — Trigger a baseline analysis on `develop`
 
-SonarCloud → `Community.Activities` project → **Administration → DevOps Platform Settings**.
+The first analysis on the renamed main branch creates the baseline that PR analyses compare against.
 
-- Confirm the binding shows **GitHub** + **UiPath/Community.Activities**.
-- If status is broken / re-auth needed, click **Reconnect** or remove the binding and re-add. May require re-installing the SonarCloud GitHub App on the UiPath org under SAML approval.
+- Push any commit to `develop` (or queue a manual `develop` build of any pack — e.g., Credentials is the simplest with no runtime tests).
+- Watch the build — `PublishSonar` stage should complete cleanly.
+- Verify on SonarCloud: `UiPath_Community.Activities` → Overview → "Last analysis" timestamp is recent and the branch dropdown shows `develop`.
 
-**Verify on GitHub:** https://github.com/organizations/UiPath/settings/installations → SonarCloud → "Configure" → confirms repo access to `Community.Activities` is granted and SAML-authorized.
+If this fails with a Sonar error, **do not proceed to Step 4** — investigate first. Most likely: Step 1's rename didn't take effect, or there's a long-lived-branch pattern conflict.
 
-## ☐ Step 4 — Confirm baseline analysis exists on `develop`
+### ☐ Step 4 — Hand back to dev team for the one-line revert
 
-The first successful analysis on the new main branch creates the quality baseline that PR analyses compare against.
-
-- Trigger any CI pipeline on `develop` (push a no-op commit, or queue a manual `develop` build of any pack).
-- Watch the build — the `PublishSonar` stage should run and complete successfully.
-- After it completes: SonarCloud → `Community.Activities` → Overview → confirm "Last analysis" is recent and on branch `develop`.
-
-If this step fails with a Sonar error, **do not proceed to Step 5** — investigate first. Likely causes: the rename in Step 1 didn't take effect, or the binding in Step 3 isn't fully wired.
-
-## ☐ Step 5 — Re-enable Sonar on PR builds
-
-Once Steps 1–4 are green, hand back to the dev team to ship the one-line code change that brings back PR decoration:
-
-In `Activities/.pipelines/templates/stage.start.yml` (PublishSonar stage condition) and `Activities/.pipelines/templates/stage.build.yml` (two condition parameters for `Sonar/prepare-sonar-coverage.yml` and `Sonar/upload-sonar-build-output.yml`):
-
-Remove the trailing clause `, ne(variables['Build.Reason'], 'PullRequest')` from each `condition:` expression.
-
-A `git grep` will find all three places quickly:
+Once Steps 1–3 are verified, dev team runs:
 
 ```
 git grep "ne(variables\['Build.Reason'\], 'PullRequest')" Activities/
 ```
 
-Commit and PR. The next PR build should complete the full Sonar flow: Build with scanner prep → Test → PublishSonar with merge-commit reconstruction + analyze + publish + PR decoration on GitHub.
+Finds 3 hits. Remove `, ne(variables['Build.Reason'], 'PullRequest')` from each. Commit, push, open PR (or push to existing feature branch).
 
----
+The next PR build should complete the full Sonar flow: Build with scanner prep → Test → PublishSonar with merge-commit reconstruction + analyze + publish + PR decoration on GitHub.
 
-## Quality gate sanity check (do this after Step 5)
+## Quality-gate sanity check (after Step 4)
 
 - Open one of the next PR builds. PR comment from SonarCloud should appear with quality-gate status + coverage delta + new-code findings.
-- Open SonarCloud → `Community.Activities` → check that the PR shows up under "Pull Requests" with its quality-gate status.
+- SonarCloud → `UiPath_Community.Activities` → **Pull Requests** tab → PR shows up with its quality-gate status.
 
-If decoration is missing but the analysis succeeded, check the SonarCloud project's GitHub App is still installed and the binding from Step 3 is still active.
+## Important caveat — first PR analyses may show a backlog
 
----
+Once Sonar resumes, the first develop analysis after 3 months of inactivity (Sonar was disabled on 2026-02-27 by commit `2584bed`) will create the new baseline. Subsequent PRs analyze "new code since baseline."
+
+You may want to set the **"New Code" definition** before merging the first PR after restoration, to avoid surfacing ~3 months of accumulated drift as "new code":
+
+- Project → **Administration → New Code** → set to **"Specific date"** with a date just before the first restored analysis.
+
+Without this, the first few PRs may fail their quality gate purely because the new-code definition catches too much.
 
 ## Related context
 
-- PR that introduced the current vendored pipeline state: #559
-- Commit that disabled PR-time Sonar (workaround that this checklist undoes): `1ba42f2`
+- PR with the vendored pipelines + this checklist: #559
+- Commit that disabled PR-time Sonar (the workaround Step 4 undoes): `d4e3bd3` (re-applied after `1ba42f2` was reverted by `2be7a4d` and re-reverted by `d4e3bd3`)
+- Commit that fixed the project key from `Community.Activities` to `UiPath_Community.Activities`: `baf6a73`
 - Original Sonar disable that started this saga: `2584bed` (2026-02-27)
-- The Sonar tasks themselves use SonarSource's V1 (Node 10 EOL). Bumping to V2 is a separate follow-up — not blocking on these steps.
+- The SonarCloud tasks use SonarSource's V1 (Node 10 EOL warning). Bumping to V2 is a separate follow-up — not blocking these steps.

--- a/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
+++ b/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
@@ -25,7 +25,7 @@ jobs:
     parameters:
       InstallType: 'machine'
       StudioVersion: ${{ parameters.robotVersion }}
-      License: $(studioLicense)
+      License: ${{ parameters.studioLicense }}
       StudioCustomNugetFeeds: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
 
   - powershell: |

--- a/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
+++ b/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
@@ -23,10 +23,10 @@ jobs:
 
   - template: ../templates/Testing/Automation/install.studio.steps.template.yml
     parameters:
-      installType: 'machine'
-      studioVersion: ${{ parameters.robotVersion }}
-      license: $(studioLicense)
-      studioCustomNugetFeeds: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
+      InstallType: 'machine'
+      StudioVersion: ${{ parameters.robotVersion }}
+      License: $(studioLicense)
+      StudioCustomNugetFeeds: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
 
   - powershell: |
       echo "##vso[task.setvariable variable=studioPackagesPath]$env:ProgramFiles/UiPath/Studio/Packages"

--- a/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
+++ b/Activities/.pipelines/jobs/stage.build.runtime.tests.yml
@@ -21,7 +21,7 @@ jobs:
   - checkout: self
     fetchDepth: 1
 
-  - template: Testing/Automation/install.studio.steps.template.yml@automationTests
+  - template: ../templates/Testing/Automation/install.studio.steps.template.yml
     parameters:
       installType: 'machine'
       studioVersion: ${{ parameters.robotVersion }}

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -68,11 +68,11 @@ jobs:
   # install robot
   - template: ../templates/Testing/Automation/install.msi.steps.template.yml
     parameters:
-      installType: 'machine'
-      msiType: 'robot'
-      msiVersion: ${{ parameters.robotVersion }}
-      license: ${{ parameters.studioLicense }}
-      installComponents: 'Robot'
+      InstallType: 'machine'
+      MsiType: 'robot'
+      MsiVersion: ${{ parameters.robotVersion }}
+      License: ${{ parameters.studioLicense }}
+      InstallComponents: 'Robot'
 
   - powershell: |
       & "C:/Program Files/UiPath/Robot/UiRobot.exe" trace --enableLowLevel

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -66,7 +66,7 @@ jobs:
     - ${{ step }}
 
   # install robot
-  - template: Testing/Automation/install.msi.steps.template.yml@automationTests
+  - template: ../templates/Testing/Automation/install.msi.steps.template.yml
     parameters:
       installType: 'machine'
       msiType: 'robot'

--- a/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
+++ b/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
@@ -19,9 +19,9 @@ steps:
     pwsh: true
     targetType: 'inline'
     script: |
-      $poolName = "${{ parameters.poolName }}"
-      $capabilities =  "${{ parameters.capabilities }} "
-      $noOfAgents = "${{ parameters.noOfAgents }}"
+      $poolName = $env:POOL_NAME
+      $capabilities = "$env:CAPABILITIES "
+      $noOfAgents = $env:NO_OF_AGENTS
       $accessToken = $env:SYSTEM_ACCESSTOKEN
       $organization = $env:SYSTEM_COLLECTIONURI.TrimEnd('/')
       $delayTimeoutSeconds = 20
@@ -83,4 +83,7 @@ steps:
       Write-Error "Not found $noOfAgents agents with capability $capabilityKey having value $capabilityValue"
 
   env:
-     SYSTEM_ACCESSTOKEN: ${{ parameters.azureDevOpsToken }}
+    SYSTEM_ACCESSTOKEN: ${{ parameters.azureDevOpsToken }}
+    POOL_NAME: ${{ parameters.poolName }}
+    CAPABILITIES: ${{ parameters.capabilities }}
+    NO_OF_AGENTS: ${{ parameters.noOfAgents }}

--- a/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
+++ b/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
@@ -1,0 +1,86 @@
+parameters:
+  - name: azureDevOpsToken
+    default: ''
+  - name: noOfAgents
+    type: number
+    default: 1
+  - name: poolName
+    type: string
+    default: ''
+  - name: capabilities #JSON serialized string e.g. "{'task-tst': 'task-tst-$(Build.BuildId)',  'Agent.OS': 'Windows_NT'}"
+    type: string
+    default: ''
+
+steps:
+
+- task: PowerShell@2
+  displayName: Wait for agent
+  inputs:
+    pwsh: true
+    targetType: 'inline'
+    script: |
+      $poolName = "${{ parameters.poolName }}"
+      $capabilities =  "${{ parameters.capabilities }} "
+      $noOfAgents = "${{ parameters.noOfAgents }}"
+      $accessToken = $env:SYSTEM_ACCESSTOKEN
+      $organization = $env:SYSTEM_COLLECTIONURI.TrimEnd('/')
+      $delayTimeoutSeconds = 20
+      $retryTimeoutMinutes = 20
+
+      $capabilityMap = $capabilities | ConvertFrom-Json -AsHashtable
+      Write-Host 'Searching for $noOfAgents agents with  capabilities:'
+      foreach ($capKey in $capabilityMap.Keys) {
+          Write-Host "$capKey : $($capabilitymap[$capKey])"
+      }
+
+      Write-Output "$accessToken" | az devops login --org $organization
+      $pool = (az pipelines pool list --pool-name $poolName --org $organization | ConvertFrom-Json)
+
+      if (-not $pool) {
+          throw "no pool with name $poolName found"
+      }
+      Write-Host "Found pool with id $($pool.id)"
+
+      $startDate = Get-Date
+      $counter = 0
+      Write-Host "Process started at $startDate"
+      do {
+          $foundAgents = [System.Collections.Generic.List[PSObject]]::new()
+          $counter++
+          Write-Host "Try: $counter"
+          $agents = (az pipelines agent list --pool-id $($pool.id) --org $organization  --include-capabilities true | ConvertFrom-Json -AsHashtable)
+
+
+          Write-Host "Verifying only online agents ..."
+          $agents | % {
+              $agent = $_
+
+              if ($agent.status -eq "online") {
+                  Write-Host "Checking $($_.name)..."
+                  $agentCapabilities = $_.systemCapabilities
+                  $match = $true
+                  foreach ($capKey in $capabilityMap.Keys) {
+                      if (-not ($agentCapabilities["$capKey"] -and ($($agentCapabilities[$capKey]) -eq $($capabilitymap[$capKey])))) {
+                          $match = $false
+                          break;
+                      }
+                  }
+                  if ($match) {
+                      Write-Host "Agent $($agent.name) has required capabilities. Adding to list.."
+                      $foundAgents.Add($($agent.name))
+                      if($foundAgents.count -ge $noOfAgents) {
+                          Write-Host "Found $($foundAgents.length) agents that match the capabilities"
+                          Write-Host "$foundAgents"
+                          Exit;
+                      }
+                  }
+              }
+          }
+          Write-Host "Found $($foundAgents.count); Needed $noOfAgents;... sleeping $delayTimeoutSeconds"
+          Start-Sleep -Seconds $delayTimeoutSeconds
+      } while ($startDate.AddMinutes($retryTimeoutMinutes) -gt (Get-Date))
+
+      Write-Error "Not found $noOfAgents agents with capability $capabilityKey having value $capabilityValue"
+
+  env:
+     SYSTEM_ACCESSTOKEN: ${{ parameters.azureDevOpsToken }}

--- a/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
+++ b/Activities/.pipelines/templates/AzurePipelines/wait-for-agent.yml
@@ -80,7 +80,7 @@ steps:
           Start-Sleep -Seconds $delayTimeoutSeconds
       } while ($startDate.AddMinutes($retryTimeoutMinutes) -gt (Get-Date))
 
-      Write-Error "Not found $noOfAgents agents with capability $capabilityKey having value $capabilityValue"
+      Write-Error "Not found $noOfAgents matching agents in pool '$poolName' after $retryTimeoutMinutes minutes"
 
   env:
     SYSTEM_ACCESSTOKEN: ${{ parameters.azureDevOpsToken }}

--- a/Activities/.pipelines/templates/Sonar/add-runsettings-coverage-exclusions-to-Sonar-parameter.yml
+++ b/Activities/.pipelines/templates/Sonar/add-runsettings-coverage-exclusions-to-Sonar-parameter.yml
@@ -12,10 +12,11 @@ steps:
         if([string]::IsNullOrEmpty($XmlFilename)) {
           $RunsettingsFiles = Get-ChildItem -Depth "3" -Filter "*.runsettings"
 
-          if($RunsettingsFiles.Count -gt -0) {
+          $RunsettingsFilesFound = ""
+          if($RunsettingsFiles.Count -gt 0) {
             $RunsettingsFilesFound = "Possible runsettings file(s) found: $RunsettingsFiles"
           }
-           Write-Warning ".runsettings file is not specified, no exclusions added. $RunsettingsFilesFound"
+          Write-Warning ".runsettings file is not specified, no exclusions added. $RunsettingsFilesFound"
         }
         else {
           Write-Host "Parsing $XmlFileName"

--- a/Activities/.pipelines/templates/Sonar/add-runsettings-coverage-exclusions-to-Sonar-parameter.yml
+++ b/Activities/.pipelines/templates/Sonar/add-runsettings-coverage-exclusions-to-Sonar-parameter.yml
@@ -1,0 +1,87 @@
+parameters:
+  condition: succeeded()
+  coverageExclusions: ''
+  runsettingsFile: ''
+
+steps:
+- powershell: |
+    $CoverageExclusions = $env:EXCLUDE
+    $XmlFilename = $env:RUNSETTINGSFILE
+
+    try {
+        if([string]::IsNullOrEmpty($XmlFilename)) {
+          $RunsettingsFiles = Get-ChildItem -Depth "3" -Filter "*.runsettings"
+
+          if($RunsettingsFiles.Count -gt -0) {
+            $RunsettingsFilesFound = "Possible runsettings file(s) found: $RunsettingsFiles"
+          }
+           Write-Warning ".runsettings file is not specified, no exclusions added. $RunsettingsFilesFound"
+        }
+        else {
+          Write-Host "Parsing $XmlFileName"
+          [xml]$Xml = Get-Content $XmlFilename
+          $ExcludeNodes = $null
+          $WildcardsList = [System.Collections.ArrayList]@()
+
+          $CodeCoverageNodes = $Xml.GetElementsByTagName('DataCollector').GetElementsByTagName('Configuration').GetElementsByTagName('CodeCoverage')
+
+          if(($ModulePaths = $CodeCoverageNodes.GetElementsByTagName('ModulePaths')) -ne $null) {
+            $ExcludeNodes += $ModulePaths.GetElementsByTagName('Exclude')
+          }
+          if(($SourcesNodes = $CodeCoverageNodes.GetElementsByTagName('Sources')) -ne $null) {
+            $ExcludeNodes += $SourcesNodes.GetElementsByTagName('Exclude')
+          }
+
+          foreach($ExclusionPath in $ExcludeNodes.ChildNodes) {
+
+            if($ExclusionPath.'#text') {
+
+              $CoverageExpression = $ExclusionPath.'#text'
+
+              $Patterns = [regex] '(\$)|(\^)|(\.\*)|(\\\.)|(\\\\)|(\\\))|(\\\()'
+              $Matches = $Patterns.Match($CoverageExpression, 0)
+              while($Matches.Success -eq $true) {
+                Switch ($matches.Value) {
+                  '\\' {$Symbol = '\'}
+                  '\.' {$Symbol = '.'}
+                  '.*' {$Symbol = '*'}
+                  '\(' {$Symbol = '('}
+                  '\)' {$Symbol = ')'}
+                  '$'  {$Symbol = '' }
+                  '^'  {$Symbol = '' }
+                }
+                $CoverageExpression = $CoverageExpression.remove($Matches.Index,$Matches.Length).insert($Matches.Index,$Symbol)
+                if($Matches.Index -lt $CoverageExpression.length) {
+                  $Matches = $Patterns.Match($CoverageExpression, $Matches.Index + 1)
+                }
+                else {
+                  break
+                }
+              }
+
+              # wildcards take into account directory levels, so we need to make sure it excludes all files from all levels
+              if ($CoverageExpression.EndsWith("\*")) {
+                $CoverageExpression = $CoverageExpression + "*\*"
+              }
+
+              [void]$WildcardsList.Add($CoverageExpression)
+              Write-Host "Transforming  $($ExclusionPath.'#text') to $CoverageExpression and adding to exclusion variable"
+            }
+          }
+
+          if(![string]::IsNullOrEmpty($CoverageExclusions)) {
+            $CoverageExclusions += ','
+          }
+          $CoverageExclusions += $WildcardsList -join ","
+        }
+    } catch {
+        Write-Warning $_.Exception.Message
+    }
+
+    Write-Output "##vso[task.setvariable variable=CoverageExclusions;]$CoverageExclusions"
+    Write-Host $CoverageExclusions
+  displayName: "Set exclusion Sonar parameter"
+  condition: ${{ parameters.condition }}
+  env:
+    EXCLUDE: ${{ parameters.coverageExclusions }}
+    RUNSETTINGSFILE: ${{ parameters.runsettingsFile }}

--- a/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
@@ -2,6 +2,6 @@ parameters:
   condition: succeeded()
 
 steps:
-- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1.41.1
+- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
   displayName: 'Run Code Analysis'
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
@@ -2,6 +2,6 @@ parameters:
   condition: succeeded()
 
 steps:
-- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
+- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1.41.1
   displayName: 'Run Code Analysis'
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/analyze-sonar-coverage.yml
@@ -1,0 +1,7 @@
+parameters:
+  condition: succeeded()
+
+steps:
+- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
+  displayName: 'Run Code Analysis'
+  condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/clean-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/clean-sonar-coverage.yml
@@ -1,0 +1,11 @@
+parameters:
+  condition: succeeded()
+
+steps:
+- powershell: Remove-Item $(Pipeline.Workspace)\\.sonarqube -Force -Recurse -ErrorAction SilentlyContinue
+  displayName: "Cleanup .sonarqube folder - Windows"
+  condition: and(contains(variables['Agent.OS'], 'Windows'), ${{ parameters.condition }})
+
+- script: rm -rf $(Pipeline.Workspace)/.sonarqube
+  displayName: "Cleanup .sonarqube folder - Linux"
+  condition: and(not(contains(variables['Agent.OS'], 'Windows')), ${{ parameters.condition }})

--- a/Activities/.pipelines/templates/Sonar/download-sonar-build-output.yml
+++ b/Activities/.pipelines/templates/Sonar/download-sonar-build-output.yml
@@ -1,0 +1,71 @@
+parameters:
+  artifactName: "SonarQube-Temp"
+  cleanup: true
+  condition: succeeded()
+
+steps:
+- ${{ if eq(parameters.cleanup, true) }}:
+  - template: clean-sonar-coverage.yml
+    parameters:
+      condition: ${{ parameters.condition }}
+
+- task: DownloadBuildArtifacts@0
+  displayName: "Download SonarQube artifact from current build"
+  inputs:
+    artifactName: ${{ parameters.artifactName }}
+    downloadPath: $(Build.SourcesDirectory)
+  condition: ${{ parameters.condition }}
+
+
+- task: ExtractFiles@1
+  displayName: "Extract artifact files"
+  inputs:
+    archiveFilePatterns: "$(Build.SourcesDirectory)/${{ parameters.artifactName }}/${{ parameters.artifactName }}.zip"
+    destinationFolder: "$(Build.SourcesDirectory)/SonarTemp"
+    cleanDestinationFolder: true
+  condition: ${{ parameters.condition }}
+
+- powershell: |
+    $sonarQubeDir = $env:SonarQubeDir
+    $srcDir = $env:SrcDir
+    $artifactName = $env:ArtifactName
+
+    if (Test-Path $sonarQubeDir) {
+      Remove-Item -Force -Recurse -Path $sonarQubeDir
+    }
+
+    New-Item -ItemType directory -Path $sonarQubeDir
+    Move-Item "$srcDir/SonarTemp/.sonarqube/*" -Destination $sonarQubeDir -Force
+    Copy-Item "$srcDir/SonarTemp/metadata/*" $srcDir -Force -Recurse
+
+    Remove-Item "$srcDir/$artifactName" -Force -Recurse
+  env:
+    ArtifactName: ${{ parameters.artifactName }}
+    SrcDir: $(Build.SourcesDirectory)
+    SonarQubeDir: "$(Pipeline.Workspace)/.sonarqube"
+  displayName: 'Move artifact files to sources'
+  condition: ${{ parameters.condition }}
+
+- powershell: |
+    $srcDir = $env:SrcDir
+
+    if (Test-Path "$srcDir/SonarTemp/scanner/SonarScanner.MSBuild.exe") {
+      Write-Host "Found scanner of type classic-sonar-scanner-msbuild"
+
+      $scannerPath = "$srcDir/SonarTemp/scanner/SonarScanner.MSBuild.exe"
+      Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$scannerPath"
+    } else {
+        if (Test-Path "$srcDir/SonarTemp/scanner/SonarScanner.MSBuild.dll") {
+        Write-Host "Found scanner of type dotnet-sonar-scanner-msbuild"
+
+        $scannerPath = "$srcDir/SonarTemp/scanner/SonarScanner.MSBuild.dll"
+        Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_DLL]$scannerPath"
+      }
+      else {
+        Write-Error "The sonar scanner executable was not found inside the temp package"
+      }
+    }
+  env:
+    SrcDir: $(Build.SourcesDirectory)
+  displayName: 'Set SonarQube Scanner Path'
+  condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/prepare-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/prepare-sonar-coverage.yml
@@ -1,6 +1,7 @@
 parameters:
   projectKey: ''
   serviceConnectionName: ''
+  organization: ''
   useMergedReport: false
   condition: succeeded()
   exclusions: '**/*.js,**/*AssemblyInfo.cs,**/*.css,**/*.scss,**/*.stub.ts,**/*.stubs.ts,**/*.spec.ts'
@@ -25,7 +26,7 @@ steps:
     condition: ${{ parameters.condition }}
     inputs:
         SonarCloud: ${{ parameters.serviceConnectionName }}
-        organization: ui
+        organization: ${{ parameters.organization }}
         scannerMode: CLI
         configMode: 'file'
         configFile: ${{ parameters.configFile }}
@@ -42,7 +43,7 @@ steps:
     condition: ${{ parameters.condition }}
     inputs:
       SonarCloud: ${{ parameters.serviceConnectionName }}
-      organization: ui
+      organization: ${{ parameters.organization }}
       projectKey: ${{ parameters.projectKey }}
       projectName: ${{ parameters.projectKey }}
       ${{ if eq(parameters.useMergedReport, true) }}:

--- a/Activities/.pipelines/templates/Sonar/prepare-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/prepare-sonar-coverage.yml
@@ -1,0 +1,80 @@
+parameters:
+  projectKey: ''
+  serviceConnectionName: ''
+  useMergedReport: false
+  condition: succeeded()
+  exclusions: '**/*.js,**/*AssemblyInfo.cs,**/*.css,**/*.scss,**/*.stub.ts,**/*.stubs.ts,**/*.spec.ts'
+  testExclusions: ''
+  coverageExclusions: '**/test/**,**/*.js,**/*polyfills.ts,**/*.spec.ts,**/*.stub.ts,**/*.stubs.ts'
+  runsettingsFile: ''
+  lcovReportPath: CodeCoverage/lcov.info
+  configFile: ''
+  logLevel: 'Info'
+  verbose: 'false'
+  cleanup: true
+
+steps:
+- ${{ if eq(parameters.cleanup, true) }}:
+  - template: clean-sonar-coverage.yml
+    parameters:
+      condition: ${{ parameters.condition }}
+
+- ${{ if ne(parameters.configFile, '') }}:
+  - task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
+    displayName: 'Prepare analysis on SonarCloud'
+    condition: ${{ parameters.condition }}
+    inputs:
+        SonarCloud: ${{ parameters.serviceConnectionName }}
+        organization: ui
+        scannerMode: CLI
+        configMode: 'file'
+        configFile: ${{ parameters.configFile }}
+
+- ${{ if eq(parameters.configFile, '') }}:
+  - template: add-runsettings-coverage-exclusions-to-Sonar-parameter.yml
+    parameters:
+      condition: ${{ parameters.condition }}
+      coverageExclusions: ${{ parameters.coverageExclusions }}
+      runsettingsFile: ${{ parameters.runsettingsFile }}
+
+  - task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
+    displayName: 'Prepare analysis on SonarCloud'
+    condition: ${{ parameters.condition }}
+    inputs:
+      SonarCloud: ${{ parameters.serviceConnectionName }}
+      organization: ui
+      projectKey: ${{ parameters.projectKey }}
+      projectName: ${{ parameters.projectKey }}
+      ${{ if eq(parameters.useMergedReport, true) }}:
+        extraProperties: |
+          # Additional properties that will be passed to the scanner,
+          # Put one key=value per line, example:
+          # sonar.exclusions=**/*.bin
+          sonar.cs.vscoveragexml.reportsPaths=$(Agent.TempDirectory)/**/*.coveragexml,**/*.coveragexml
+          sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/*.opencover.xml,**/*.opencover.xml
+          sonar.javascript.lcov.reportPaths=${{ parameters.lcovReportPath }}
+          sonar.exclusions=${{ parameters.exclusions }}
+          sonar.test.exclusions=${{ parameters.testExclusions }}
+          sonar.coverage.exclusions=$(CoverageExclusions)
+          sonar.coverageReportPaths=SonarQube.xml
+          sonar.c.file.suffixes=-
+          sonar.cpp.file.suffixes=-
+          sonar.objc.file.suffixes=-
+          sonar.verbose=${{ parameters.verbose }}
+          sonar.log.level=${{ parameters.logLevel }}
+      ${{ if ne(parameters.useMergedReport, true) }}:
+        extraProperties: |
+          # Additional properties that will be passed to the scanner,
+          # Put one key=value per line, example:
+          # sonar.exclusions=**/*.bin
+          sonar.cs.vscoveragexml.reportsPaths=$(Agent.TempDirectory)/**/*.coveragexml,**/*.coveragexml
+          sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/*.opencover.xml,**/*.opencover.xml
+          sonar.javascript.lcov.reportPaths=${{ parameters.lcovReportPath }}
+          sonar.exclusions=${{ parameters.exclusions }}
+          sonar.test.exclusions=${{ parameters.testExclusions }}
+          sonar.coverage.exclusions=$(CoverageExclusions)
+          sonar.c.file.suffixes=-
+          sonar.cpp.file.suffixes=-
+          sonar.objc.file.suffixes=-
+          sonar.verbose=${{ parameters.verbose }}
+          sonar.log.level=${{ parameters.logLevel }}

--- a/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
@@ -4,7 +4,7 @@ parameters:
   condition: succeededOrFailed()
 
 steps:
-- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1.41.1
+- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
   displayName: 'Publish Quality Gate Result'
   continueOnError: ${{ parameters.continueOnError }}
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
@@ -4,7 +4,7 @@ parameters:
   condition: succeededOrFailed()
 
 steps:
-- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
+- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1.41.1
   displayName: 'Publish Quality Gate Result'
   continueOnError: ${{ parameters.continueOnError }}
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
+++ b/Activities/.pipelines/templates/Sonar/publish-sonar-coverage.yml
@@ -1,0 +1,15 @@
+parameters:
+  continueOnError: false
+  cleanup: true
+  condition: succeededOrFailed()
+
+steps:
+- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
+  displayName: 'Publish Quality Gate Result'
+  continueOnError: ${{ parameters.continueOnError }}
+  condition: ${{ parameters.condition }}
+
+- ${{ if eq(parameters.cleanup, true) }}:
+  - template: clean-sonar-coverage.yml
+    parameters:
+      condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/uninstall-sonar-targets.yml
+++ b/Activities/.pipelines/templates/Sonar/uninstall-sonar-targets.yml
@@ -1,0 +1,9 @@
+steps:
+- powershell: |
+    $path = $env:LOCALAPPDATA + "\Microsoft\MSBuild"
+
+    if (Test-Path $path) {
+      Remove-Item -Path $path -Include "SonarQube.Integration.ImportBefore.targets" -Recurse -Force
+    }
+  displayName: "Uninstall SonarQube targets from MsBuild"
+  condition: always()

--- a/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
+++ b/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
@@ -1,0 +1,106 @@
+parameters:
+  outputPath: "$(Build.ArtifactStagingDirectory)/Sonar"
+  artifactName: "SonarQube-Temp"
+  cleanup: true
+  condition: succeeded()
+
+steps:
+- task: Powershell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      $srcDir = $env:SourceDir
+      $binDir = $env:SonarBin
+      $sonarQubeDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
+
+      if (Test-Path -Path $binDir) {
+        Remove-Item -Force -Recurse -Path $binDir
+      }
+
+      New-Item -ItemType Directory -Path $binDir
+      Write-Host "Re-created $binDir"
+
+      $roslynBinDir = Join-Path "$binDir" "metadata"
+      New-Item -ItemType Directory -Path $roslynBinDir
+      Write-Host "Created $roslynBinDir"
+
+      Get-ChildItem -Recurse -Path $srcDir -Include "*.RoslynCA.json" | ForEach-Object {
+        $targetFile = Join-Path "$roslynBinDir" "$($_.FullName.SubString($srcDir.Length))"
+        New-Item -ItemType File -Path $targetFile -Force
+        Copy-Item $_.FullName -destination $targetFile
+        Write-Host "Copied $($_.FullName) to $targetFile"
+      }
+
+      if (Test-Path -Path $sonarQubeDir -PathType Container) {
+        New-Item -ItemType SymbolicLink -Name .sonarqube -Value $sonarQubeDir -Path $binDir
+        Write-Host "Created symbolic link $sonarQubeDir to $binDir\\.sonarqube"
+      }
+      else {
+        Write-Error "The SonarQube directory does not exist!"
+      }
+
+      $sonarScannerDir = ""
+      if (![string]::IsNullOrEmpty($env:SONARQUBE_SCANNER_MSBUILD_EXE)) {
+        $sonarScannerDir = [System.IO.Path]::GetDirectoryName($env:SONARQUBE_SCANNER_MSBUILD_EXE)
+      } else {
+        if (![string]::IsNullOrEmpty($env:SONARQUBE_SCANNER_MSBUILD_DLL)) {
+          $sonarScannerDir = [System.IO.Path]::GetDirectoryName($env:SONARQUBE_SCANNER_MSBUILD_DLL)
+        } else {
+          Write-Error "Could not find the Sonar Scanner directory"
+        }
+      }
+
+      $scannerBinDir = Join-Path "$binDir" "scanner"
+      New-Item -ItemType Directory -Path $scannerBinDir
+      Copy-Item $sonarScannerDir/* $scannerBinDir -Recurse -Force
+  env:
+    SourceDir: $(Build.SourcesDirectory)
+    SonarBin: ${{ parameters.outputPath }}
+  continueOnError: true
+  displayName: "Copy Sonar files to artifact staging directory"
+  condition: ${{ parameters.condition }}
+
+- task: Powershell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Output "##vso[task.setvariable variable=OriginalSourcesPath;isOutput=true]$(Build.SourcesDirectory)"
+      Write-Output "##vso[task.setvariable variable=OriginalPipelinePath;isOutput=true]$(Pipeline.Workspace)"
+  name: setOriginalSrcPath
+  displayName: "Set original paths"
+  condition: ${{ parameters.condition }}
+
+- task: Powershell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MODE;isOutput=true]$env:SONARQUBE_SCANNER_MODE"
+      Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_PARAMS;isOutput=true]$env:SONARQUBE_SCANNER_PARAMS"
+      Write-Output "##vso[task.setvariable variable=SONARQUBE_ENDPOINT;isOutput=true]$env:sonarQubeEndpoint"
+      Write-Host "Endoint value - $env:sonarQubeEndpoint"
+  name: setSonarVariables
+  displayName: "Set SonarQube variables on the build"
+  condition: ${{ parameters.condition }}
+  env:
+    sonarQubeEndpoint: $(SONARQUBE_ENDPOINT) # secret variable, so we'll have to manually pass it over
+
+- task: ArchiveFiles@2
+  displayName: "Archive SonarQube artifact"
+  condition: ${{ parameters.condition }}
+  inputs:
+    RootFolderOrFile: ${{ parameters.outputPath }}
+    IncludeRootFolder: false
+    ArchiveType: "zip"
+    ArchiveFile: "$(Build.ArtifactStagingDirectory)/${{ parameters.artifactName }}.zip"
+
+- task: PublishBuildArtifacts@1
+  condition: ${{ parameters.condition }}
+  displayName: 'Publish SonarQube coverage artifact'
+  inputs:
+    pathtoPublish: "$(Build.ArtifactStagingDirectory)/${{ parameters.artifactName }}.zip"
+    artifactName: ${{ parameters.artifactName }}
+
+- ${{ if eq(parameters.cleanup, true) }}:
+  - template: clean-sonar-coverage.yml
+    parameters:
+      condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
+++ b/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
@@ -77,7 +77,7 @@ steps:
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MODE;isOutput=true]$env:SONARQUBE_SCANNER_MODE"
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_PARAMS;isOutput=true]$env:SONARQUBE_SCANNER_PARAMS"
       Write-Output "##vso[task.setvariable variable=SONARQUBE_ENDPOINT;isOutput=true]$env:sonarQubeEndpoint"
-      Write-Host "Endoint value - $env:sonarQubeEndpoint"
+      Write-Host "Endpoint value - $env:sonarQubeEndpoint"
   name: setSonarVariables
   displayName: "Set SonarQube variables on the build"
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
+++ b/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
@@ -76,7 +76,7 @@ steps:
     script: |
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MODE;isOutput=true]$env:SONARQUBE_SCANNER_MODE"
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_PARAMS;isOutput=true]$env:SONARQUBE_SCANNER_PARAMS"
-      Write-Output "##vso[task.setvariable variable=SONARQUBE_ENDPOINT;isOutput=true]$env:sonarQubeEndpoint"
+      Write-Output "##vso[task.setvariable variable=SONARQUBE_ENDPOINT;isOutput=true;issecret=true]$env:sonarQubeEndpoint"
   name: setSonarVariables
   displayName: "Set SonarQube variables on the build"
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
+++ b/Activities/.pipelines/templates/Sonar/upload-sonar-build-output.yml
@@ -77,7 +77,6 @@ steps:
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_MODE;isOutput=true]$env:SONARQUBE_SCANNER_MODE"
       Write-Output "##vso[task.setvariable variable=SONARQUBE_SCANNER_PARAMS;isOutput=true]$env:SONARQUBE_SCANNER_PARAMS"
       Write-Output "##vso[task.setvariable variable=SONARQUBE_ENDPOINT;isOutput=true]$env:sonarQubeEndpoint"
-      Write-Host "Endpoint value - $env:sonarQubeEndpoint"
   name: setSonarVariables
   displayName: "Set SonarQube variables on the build"
   condition: ${{ parameters.condition }}

--- a/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
@@ -48,7 +48,7 @@ steps:
     $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
     $productName = "Studio"
 
-    if ('${{ parameters.MsiType }}' -eq 'robot')
+    if ($env:MSI_TYPE -eq 'robot')
     {
       $uipathProductPath = "C:\Program Files\UiPath\Robot"
       $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
@@ -56,7 +56,7 @@ steps:
       $productName = "RobotSlim"
     }
 
-    $args = "/q /l*vx installation.log ADDLOCAL=`"${{ parameters.InstallComponents }}`" CUSTOM_NUGET_FEEDS=`"${{ parameters.CustomNugetFeeds }}`""
+    $msiArgs = "/q /l*vx installation.log ADDLOCAL=`"$env:INSTALL_COMPONENTS`" CUSTOM_NUGET_FEEDS=`"$env:CUSTOM_NUGET_FEEDS`""
 
     if ((Test-Path $tempPath))
     {
@@ -68,15 +68,15 @@ steps:
     New-Item $tempPath -ItemType Directory
     Set-Location -Path $tempPath -PassThru
 
-    $downloadUrl = 'https://download.uipath.com/versions/${{ parameters.MsiVersion }}/UiPathStudio.msi'
-    if ('${{ parameters.MsiType }}' -eq 'robot')
+    $downloadUrl = "https://download.uipath.com/versions/$env:MSI_VERSION/UiPathStudio.msi"
+    if ($env:MSI_TYPE -eq 'robot')
     {
-      $downloadUrl = 'https://download.uipath.com/versions/${{ parameters.MsiVersion }}/UiPathRobot.msi'
+      $downloadUrl = "https://download.uipath.com/versions/$env:MSI_VERSION/UiPathRobot.msi"
     }
 
-    if ('${{ parameters.DownloadUrl }}' -ne 'null')
+    if ($env:DOWNLOAD_URL -and $env:DOWNLOAD_URL -ne 'null')
     {
-      $downloadUrl = '${{ parameters.DownloadUrl }}'
+      $downloadUrl = $env:DOWNLOAD_URL
     }
 
     $installPath = $uipathProductPath
@@ -91,15 +91,15 @@ steps:
       Write-Host "Download ended in $elapsedSeconds seconds"
       Get-ChildItem
 
-      if ("${{parameters.InstallType}}" -eq 'user')
+      if ($env:INSTALL_TYPE -eq 'user')
       {
-        $args = $args + " MSIINSTALLPERUSER=1"
+        $msiArgs = $msiArgs + " MSIINSTALLPERUSER=1"
         $installPath = $uipathx86ProductPath
       }
       Write-Host "Start installing"
       $stopwatch.Reset()
       $stopwatch.Start()
-      $process = Start-Process -FilePath "msiexec" -ArgumentList "/i product.msi $args" -PassThru
+      $process = Start-Process -FilePath "msiexec" -ArgumentList "/i product.msi $msiArgs" -PassThru
       Wait-Process -InputObject $process
       $stopwatch.Stop()
       $elapsedSeconds = $stopwatch.Elapsed.TotalSeconds
@@ -110,7 +110,7 @@ steps:
       }
       Write-Host "$productName Installed in $elapsedSeconds seconds"
 
-      if ("${{ parameters.InstallComponents }}".Contains("ChromeExtension"))
+      if ($env:INSTALL_COMPONENTS -and $env:INSTALL_COMPONENTS.Contains("ChromeExtension"))
       {
         Write-Host "Add registry entry to support Chrome Testing UiPath Extension"
         $chromeExtension=(Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist -Name "1")
@@ -128,6 +128,13 @@ steps:
       Write-Host "$productName Already Installed"
     }
   displayName: "Install ${{ parameters.MsiType }}"
+  env:
+    MSI_TYPE: ${{ parameters.MsiType }}
+    MSI_VERSION: ${{ parameters.MsiVersion }}
+    DOWNLOAD_URL: ${{ parameters.DownloadUrl }}
+    INSTALL_TYPE: ${{ parameters.InstallType }}
+    INSTALL_COMPONENTS: ${{ parameters.InstallComponents }}
+    CUSTOM_NUGET_FEEDS: ${{ parameters.CustomNugetFeeds }}
 
 - ${{ if ne(parameters.License, '') }}:
   - powershell: |
@@ -135,14 +142,14 @@ steps:
       $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Studio"
       $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
 
-      if ('${{ parameters.MsiType }}' -eq 'robot')
+      if ($env:MSI_TYPE -eq 'robot')
       {
         $uipathProductPath = "C:\Program Files\UiPath\Robot"
         $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
         $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Robot"
       }
 
-      if ("${{parameters.InstallType}}" -eq 'machine')
+      if ($env:INSTALL_TYPE -eq 'machine')
       {
         if (Test-Path $uipathProductPath)
         {
@@ -154,6 +161,10 @@ steps:
         }
       }
 
-      & "$installPath\UiPath.LicenseTool.exe" activate -l "${{ parameters.License }}"
+      & "$installPath\UiPath.LicenseTool.exe" activate -l "$env:LICENSE"
     displayName: "License ${{ parameters.MsiType }}"
     failOnStderr: true
+    env:
+      MSI_TYPE: ${{ parameters.MsiType }}
+      INSTALL_TYPE: ${{ parameters.InstallType }}
+      LICENSE: ${{ parameters.License }}

--- a/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
@@ -160,6 +160,11 @@ steps:
           $installPath = $uipathx86ProductPath
         }
       }
+      else
+      {
+        # user-scope install: license tool lives under the per-user install path
+        $installPath = $uipathx86ProductPath
+      }
 
       & "$installPath\UiPath.LicenseTool.exe" activate -l "$env:LICENSE"
     displayName: "License ${{ parameters.MsiType }}"

--- a/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
@@ -1,0 +1,159 @@
+parameters:
+- name: DownloadUrl
+  displayName: Download Msi Url
+  type: string
+  default: null
+
+- name: MsiType
+  displayName: Msi Type. One of studio/robot(default studio)
+  type: string
+  default: studio
+  values:
+  - studio
+  - robot
+
+- name: MsiVersion
+  displayName: Msi Version
+  type: string
+  default: '22.10.5'
+
+- name: InstallType
+  displayName: Msi Installation Type. One of machine/user(default machine)
+  type: string
+  default: machine
+  values:
+  - machine
+  - user
+
+- name: InstallComponents
+  displayName: Comma separated list of strings representing Msi individual components
+  type: string
+  default: 'DesktopFeature,Studio,Robot,WindowsRdpExtension,ChromeExtension'
+
+- name: CustomNugetFeeds
+  displayName: Comma separated list of strings representing custom nuget feeds
+  type: string
+  default: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
+
+- name: License
+  displayName: Msi License Code
+  type: string
+  default: ''
+
+steps:
+- powershell: |
+    $tempPath = "c:\temp"
+    $uipathProductPath = "C:\Program Files\UiPath\Studio"
+    $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Studio"
+    $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
+    $productName = "Studio"
+
+    if ('${{ parameters.MsiType }}' -eq 'robot')
+    {
+      $uipathProductPath = "C:\Program Files\UiPath\Robot"
+      $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
+      $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Robot"
+      $productName = "RobotSlim"
+    }
+
+    $args = "/q /l*vx installation.log ADDLOCAL=`"${{ parameters.InstallComponents }}`" CUSTOM_NUGET_FEEDS=`"${{ parameters.CustomNugetFeeds }}`""
+
+    if ((Test-Path $tempPath))
+    {
+      Write-Host "Remove old install"
+      Remove-Item $tempPath -Force -Recurse
+    }
+
+    Write-Host "Create $tempPath"
+    New-Item $tempPath -ItemType Directory
+    Set-Location -Path $tempPath -PassThru
+
+    $downloadUrl = 'https://download.uipath.com/versions/${{ parameters.MsiVersion }}/UiPathStudio.msi'
+    if ('${{ parameters.MsiType }}' -eq 'robot')
+    {
+      $downloadUrl = 'https://download.uipath.com/versions/${{ parameters.MsiVersion }}/UiPathRobot.msi'
+    }
+
+    if ('${{ parameters.DownloadUrl }}' -ne 'null')
+    {
+      $downloadUrl = '${{ parameters.DownloadUrl }}'
+    }
+
+    $installPath = $uipathProductPath
+    if (!(Test-Path $uipathProductPath) -and !(Test-Path $uipathx86ProductPath) -and  !(Test-Path $uipathx86ProductPath))
+    {
+      Write-Host "Download $productName msi from $downloadUrl"
+      $stopwatch = [System.Diagnostics.Stopwatch]::new()
+      $stopwatch.Start()
+      Invoke-WebRequest "$downloadUrl" -OutFile product.msi
+      $stopwatch.Stop()
+      $elapsedSeconds = $stopwatch.Elapsed.TotalSeconds
+      Write-Host "Download ended in $elapsedSeconds seconds"
+      Get-ChildItem
+
+      if ("${{parameters.InstallType}}" -eq 'user')
+      {
+        $args = $args + " MSIINSTALLPERUSER=1"
+        $installPath = $uipathx86ProductPath
+      }
+      Write-Host "Start installing"
+      $stopwatch.Reset()
+      $stopwatch.Start()
+      $process = Start-Process -FilePath "msiexec" -ArgumentList "/i product.msi $args" -PassThru
+      Wait-Process -InputObject $process
+      $stopwatch.Stop()
+      $elapsedSeconds = $stopwatch.Elapsed.TotalSeconds
+      if ($process.ExitCode -ne 0)
+      {
+        Write-Host "$_ exited with status code $($process.ExitCode) after $elapsedSeconds seconds"
+        throw "Error"
+      }
+      Write-Host "$productName Installed in $elapsedSeconds seconds"
+
+      if ("${{ parameters.InstallComponents }}".Contains("ChromeExtension"))
+      {
+        Write-Host "Add registry entry to support Chrome Testing UiPath Extension"
+        $chromeExtension=(Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist -Name "1")
+        if((Test-Path -LiteralPath "HKLM:\SOFTWARE\Policies\Chromium") -ne $true) {  New-Item "HKLM:\SOFTWARE\Policies\Chromium" -force -ea SilentlyContinue };
+        if((Test-Path -LiteralPath "HKLM:\SOFTWARE\Policies\Chromium\ExtensionInstallForcelist") -ne $true) {  New-Item "HKLM:\SOFTWARE\Policies\Chromium\ExtensionInstallForcelist" -force -ea SilentlyContinue };
+        New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Chromium' -Name 'DeveloperToolsAvailability' -Value 1 -PropertyType DWord -Force -ea SilentlyContinue;
+        New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Chromium\ExtensionInstallForcelist' -Name '1' -Value $chromeExtension -PropertyType String -Force -ea SilentlyContinue;
+      }
+
+      Write-Host "Logging installed nuget feeds"
+      Get-Content "$installPath\NuGet.config"
+    }
+    else
+    {
+      Write-Host "$productName Already Installed"
+    }
+  displayName: "Install ${{ parameters.MsiType }}"
+
+- ${{ if ne(parameters.License, '') }}:
+  - powershell: |
+      $uipathProductPath = "C:\Program Files\UiPath\Studio"
+      $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Studio"
+      $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
+
+      if ('${{ parameters.MsiType }}' -eq 'robot')
+      {
+        $uipathProductPath = "C:\Program Files\UiPath\Robot"
+        $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
+        $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Robot"
+      }
+
+      if ("${{parameters.InstallType}}" -eq 'machine')
+      {
+        if (Test-Path $uipathProductPath)
+        {
+          $installPath = $uipathProductPath
+        }
+        else
+        {
+          $installPath = $uipathx86ProductPath
+        }
+      }
+
+      & "$installPath\UiPath.LicenseTool.exe" activate -l "${{ parameters.License }}"
+    displayName: "License ${{ parameters.MsiType }}"
+    failOnStderr: true

--- a/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.msi.steps.template.yml
@@ -44,14 +44,12 @@ steps:
 - powershell: |
     $tempPath = "c:\temp"
     $uipathProductPath = "C:\Program Files\UiPath\Studio"
-    $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Studio"
     $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
     $productName = "Studio"
 
     if ($env:MSI_TYPE -eq 'robot')
     {
       $uipathProductPath = "C:\Program Files\UiPath\Robot"
-      $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
       $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Robot"
       $productName = "RobotSlim"
     }
@@ -80,7 +78,7 @@ steps:
     }
 
     $installPath = $uipathProductPath
-    if (!(Test-Path $uipathProductPath) -and !(Test-Path $uipathx86ProductPath) -and  !(Test-Path $uipathx86ProductPath))
+    if (!(Test-Path $uipathProductPath) -and !(Test-Path $uipathx86ProductPath))
     {
       Write-Host "Download $productName msi from $downloadUrl"
       $stopwatch = [System.Diagnostics.Stopwatch]::new()
@@ -139,13 +137,11 @@ steps:
 - ${{ if ne(parameters.License, '') }}:
   - powershell: |
       $uipathProductPath = "C:\Program Files\UiPath\Studio"
-      $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Studio"
       $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Studio"
 
       if ($env:MSI_TYPE -eq 'robot')
       {
         $uipathProductPath = "C:\Program Files\UiPath\Robot"
-        $uipathx86ProductPath = "C:\Program Files(x86)\UiPath\Robot"
         $uipathx86ProductPath = "$env:LOCALAPPDATA\Programs\UiPath\Robot"
       }
 

--- a/Activities/.pipelines/templates/Testing/Automation/install.studio.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.studio.steps.template.yml
@@ -22,10 +22,12 @@ parameters:
   type: string
   default: 'DesktopFeature,Studio,Robot,WindowsRdpExtension,ChromeExtension'
 
+# Note: StudioCustomNugetFeeds maps to the MSI installer's CUSTOM_NUGET_FEEDS argument.
+# This parameter only adds or updates the existing list of feeds. Initial list of feeds for
+# UiPath Studio 23.4 includes:
+#   Local,./Packages;Official,https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json;Connect,https://gallery.uipath.com/api/v3/index.json
 - name: StudioCustomNugetFeeds
-  displayName: Semicolon separated list of name,value pairs representing custom nuget feeds. Command line parameter name CUSTOM_NUGET_FEEDS
-    This parameter only adds or updates the existing list of feeds. Initial list of feeds for UiPath Studio 23.4 includes
-    Local,./Packages;Official,https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json;Connect,https://gallery.uipath.com/api/v3/index.json
+  displayName: Semicolon separated list of name,value pairs representing custom nuget feeds (CUSTOM_NUGET_FEEDS)
   type: string
   default: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
 

--- a/Activities/.pipelines/templates/Testing/Automation/install.studio.steps.template.yml
+++ b/Activities/.pipelines/templates/Testing/Automation/install.studio.steps.template.yml
@@ -1,0 +1,49 @@
+parameters:
+- name: DownloadUrl
+  displayName: Download Studio Url
+  type: string
+  default: null
+
+- name: StudioVersion
+  displayName: Studio Version
+  type: string
+  default: '22.10.5'
+
+- name: InstallType
+  displayName: Studio Installation Type. One of machine/user(default machine)
+  type: string
+  default: machine
+  values:
+  - machine
+  - user
+
+- name: InstallComponents
+  displayName: Comma separated list of strings representing studio individual components. Command line parameter name ADDLOCAL
+  type: string
+  default: 'DesktopFeature,Studio,Robot,WindowsRdpExtension,ChromeExtension'
+
+- name: StudioCustomNugetFeeds
+  displayName: Semicolon separated list of name,value pairs representing custom nuget feeds. Command line parameter name CUSTOM_NUGET_FEEDS
+    This parameter only adds or updates the existing list of feeds. Initial list of feeds for UiPath Studio 23.4 includes
+    Local,./Packages;Official,https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json;Connect,https://gallery.uipath.com/api/v3/index.json
+  type: string
+  default: 'UiPath-Internal,https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json'
+
+- name: License
+  displayName: Studio License Code
+  type: string
+  default: ''
+
+# For more information about the command line parameters see:
+# https://docs.uipath.com/studio/standalone/2023.10/user-guide/command-line-parameters
+
+steps:
+  - template: install.msi.steps.template.yml
+    parameters:
+      DownloadUrl: ${{ parameters.DownloadUrl }}
+      MsiType: studio
+      MsiVersion: ${{ parameters.StudioVersion }}
+      InstallType: ${{ parameters.InstallType }}
+      InstallComponents: ${{ parameters.InstallComponents }}
+      CustomNugetFeeds: ${{ parameters.StudioCustomNugetFeeds }}
+      License: ${{ parameters.License }}

--- a/Activities/.pipelines/templates/pack.msbuild.template.yml
+++ b/Activities/.pipelines/templates/pack.msbuild.template.yml
@@ -1,0 +1,8 @@
+steps:
+- task: MSBuild@1
+  displayName: "MSBuild Pack"
+  inputs:
+    solution: "$(Solution)"
+    platform: "$(BuildPlatform)"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "-t:pack -p:PackageOutputPath=$(ArtifactsOutputPath)"

--- a/Activities/.pipelines/templates/pack.template.yml
+++ b/Activities/.pipelines/templates/pack.template.yml
@@ -1,0 +1,31 @@
+steps:
+- task: PowerShell@1
+  displayName: "Set 'PackagesToPack' variable"
+  inputs:
+    scriptName: "$(ToolsPath)/Set-PackagesToPack.ps1"
+    arguments: |
+      -dir $(SolutionsPath) -affectedActivities $(AffectedActivities) -Verbose
+
+- task: NuGetCommand@2
+  displayName: "Create NuGet Packages"
+  continueOnError: true
+  inputs:
+    command: "pack"
+    packagesToPack: "$(PackagesToPack)"
+    includeSymbols: "false"
+    outputDir: "$(ArtifactsOutputPath)"
+    configurationToPack: "$(BuildConfiguration)"
+    includeReferencedProjects: "true"
+    noPackageAnalysis: "true"
+  condition: eq(variables['HasNuspecPackages'], 'true')
+
+- task: DotNetCoreCLI@2
+  displayName: "Create NET .SDK Packages"
+  continueOnError: true
+  inputs:
+    command: "pack"
+    packagesToPack: "$(SdkPackagesToPack)"
+    configurationToPack: "$(BuildConfiguration)"
+    outputDir: "$(ArtifactsOutputPath)"
+    nobuild: true
+  condition: eq(variables['HasSdkPackages'], 'true')

--- a/Activities/.pipelines/templates/stage.build.job.publish.yml
+++ b/Activities/.pipelines/templates/stage.build.job.publish.yml
@@ -58,6 +58,6 @@ steps:
   displayName: "Publish instrumented activities dlls artifact"
   inputs:
     PathtoPublish: "$(InstrumentedDllsPath)"
-    ArtifactName: "$(InstrumentedDllsArtifact)"
+    ArtifactName: "$(InstrumentedDllsArtifactName)"
     ArtifactType: "Container"
   condition: and(succeeded(), eq(variables['CoverageBuild'], 'true'))

--- a/Activities/.pipelines/templates/stage.build.job.publish.yml
+++ b/Activities/.pipelines/templates/stage.build.job.publish.yml
@@ -1,0 +1,63 @@
+parameters:
+  hasQaPackages: true
+
+steps:
+- ${{ if eq(parameters.hasQaPackages, 'true') }}:
+  - task: AddPackageReferences@0
+    displayName: 'Update Activities.Tests project.json dependencies versions with current artifacts'
+    inputs:
+      packagesFolderPath: '$(ArtifactsOutputPath)'
+      projectJsonPath: '$(TestProjectPath)'
+
+  - task: AddPackageReferences@0
+    displayName: 'Update project.json dependencies versions with included nupkgs'
+    inputs:
+      packagesFolderPath: '$(ReferencedNugetPackageFolder)'
+      projectJsonPath: '$(TestProjectPath)'
+      artifactsFolderPath: '$(QAArtifactsOutputPath)'
+      forceInclude: true
+
+  - task: UiPathPack@2
+    displayName: 'UiPath Package QAAutomation project'
+    inputs:
+      versionType: CurrentVersion
+      projectJsonPath: '$(TestProjectPath)'
+      outputPath: '$(QAArtifactsOutputPath)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish activities test project artifact"
+    inputs:
+      PathtoPublish: "$(QAArtifactsOutputPath)"
+      ArtifactName: "$(QAArtifactName)"
+      ArtifactType: "Container"
+
+- task: PowerShell@1
+  displayName: "Determine if OutputTests exists"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "if (Test-Path $ENV:OutputTestsPath) { Write-Host \"##vso[task.setvariable variable=ExistsOutputTests;]true\" }"
+  env:
+    OutputTestsPath: $(OutputTestsPath)
+
+- task: PublishBuildArtifacts@1
+  displayName: "Publish build output"
+  inputs:
+    PathtoPublish: $(OutputTestsPath)
+    ArtifactName: "OutputTests"
+    ArtifactType: "Container"
+  condition: and(succeeded(), eq(variables['ExistsOutputTests'], 'true'))
+
+- task: PublishBuildArtifacts@1
+  displayName: "Publish artifacts"
+  inputs:
+    PathtoPublish: "$(ArtifactsOutputPath)"
+    ArtifactName: "$(ArtifactName)"
+    ArtifactType: "Container"
+
+- task: PublishBuildArtifacts@1
+  displayName: "Publish instrumented activities dlls artifact"
+  inputs:
+    PathtoPublish: "$(InstrumentedDllsPath)"
+    ArtifactName: "$(InstrumentedDllsArtifact)"
+    ArtifactType: "Container"
+  condition: and(succeeded(), eq(variables['CoverageBuild'], 'true'))

--- a/Activities/.pipelines/templates/stage.build.job.yml
+++ b/Activities/.pipelines/templates/stage.build.job.yml
@@ -6,8 +6,6 @@ parameters:
   msBuildPack: false
   sdkBuild: false
   requiresLfs: false
-  signOutputs: true
-  azureSignConnectionName: ""
 
 steps:
 - checkout: self
@@ -52,6 +50,7 @@ steps:
     New-Item $qaOutPath -ItemType Directory
   env:
     ArtifactsOutputPath: $(ArtifactsOutputPath)
+    ExplorerStandaloneOutputPath: $(ExplorerStandaloneOutputPath)
     QAArtifactsOutputPath: $(QAArtifactsOutputPath)
   displayName: "Clean artifacts path"
 

--- a/Activities/.pipelines/templates/stage.build.job.yml
+++ b/Activities/.pipelines/templates/stage.build.job.yml
@@ -1,0 +1,163 @@
+parameters:
+  projectName: ''
+  tagName: ''
+  preBuild: []
+  postBuild: []
+  msBuildPack: false
+  sdkBuild: false
+  requiresLfs: false
+  signOutputs: true
+  azureSignConnectionName: ""
+
+steps:
+- checkout: self
+  lfs: ${{ parameters.requiresLfs }}
+  clean: $(CleanGit)
+
+- task: PowerShell@1
+  displayName: "Set PrereleaseTag=alpha"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"##vso[task.setvariable variable=PrereleaseTag;]alpha\""
+
+- task: PowerShell@1
+  displayName: "Set PrereleaseTag=beta"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"##vso[task.setvariable variable=PrereleaseTag;]beta\""
+  condition: or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'))
+
+- task: PowerShell@1
+  displayName: "Set PrereleaseTag=final"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"##vso[task.setvariable variable=PrereleaseTag;]final\""
+  condition: or(startsWith(variables['Build.SourceBranch'], 'refs/heads/masters/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/support/'))
+
+- powershell: |
+    $outPath = $env:ArtifactsOutputPath
+    if ((Test-Path $outPath)) {
+      Remove-Item $outPath -Force -Recurse
+    }
+    New-Item $outPath -ItemType Directory
+    $uiexOutPath = $env:ExplorerStandaloneOutputPath
+    if ((Test-Path $uiexOutPath)) {
+      Remove-Item $uiexOutPath -Force -Recurse
+    }
+    New-Item $uiexOutPath -ItemType Directory
+    $qaOutPath = $env:QAArtifactsOutputPath
+    if ((Test-Path $qaOutPath)) {
+      Remove-Item $qaOutPath -Force -Recurse
+    }
+    New-Item $qaOutPath -ItemType Directory
+  env:
+    ArtifactsOutputPath: $(ArtifactsOutputPath)
+    QAArtifactsOutputPath: $(QAArtifactsOutputPath)
+  displayName: "Clean artifacts path"
+
+- task: PowerShell@1
+  displayName: "Tag build with PR target branch"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"##vso[build.addbuildtag]TargetBranch=$(System.PullRequest.TargetBranch)\""
+  condition: ne(variables['System.PullRequest.TargetBranch'], '')
+
+- task: PowerShell@1
+  displayName: "Tag build with prerelease tag"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"##vso[build.addbuildtag]PrereleaseTag=$(PrereleaseTag)\""
+  condition: ne(variables['PrereleaseTag'], 'final')
+
+- powershell: |
+    Write-Host "##vso[build.addbuildtag]ActivityPackage=${{ coalesce(parameters.tagName, parameters.projectName) }}"
+    Write-Host "##vso[task.setvariable variable=AffectedActivities;]${{ coalesce(parameters.tagName, parameters.projectName) }}"
+  displayName: "Tag build with activity package tag"
+
+- task: PowerShell@1
+  displayName: "Patch .nuspec files with prerelease tag"
+  inputs:
+    scriptName: "$(ToolsPath)/Patch-Nuspecs.ps1"
+    arguments: "-rootDirectory \"$(Build.SourcesDirectory)\" -prereleaseTag \"$(PrereleaseTag)\" -commitSha \"$(Build.SourceVersion)\" -buildId \"$(Build.BuildId)\""
+
+- task: NuGetToolInstaller@1
+  displayName: "Use NuGet >=5.3.0"
+
+- task: NuGetAuthenticate@0
+
+- ${{ if eq(parameters.sdkBuild, 'true') }}:
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK 5.0.100'
+    inputs:
+      packageType: 'sdk'
+      version: '5.0.100'
+
+- ${{ if eq(parameters.sdkBuild, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: "Restore Nuget Packages"
+    inputs:
+      command: "restore"
+      projects: "$(Solution)"
+      feedsToUse: "config"
+      nugetConfigPath: "$(NugetConfigFile)"
+
+- ${{ if eq(parameters.sdkBuild, 'false') }}:
+  - task: NuGetCommand@2
+    displayName: "Restore Nuget Packages"
+    inputs:
+      restoreSolution: "$(Solution)"
+      feedsToUse: "config"
+      nugetConfigPath: "$(NugetConfigFile)"
+
+- task: PowerShell@1
+  displayName: "Print variables"
+  condition: always()
+  continueOnError: true
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: "Write-Host \"Variables for current build:\" \n
+      Get-ChildItem ENV:*"
+
+- ${{ parameters.preBuild }}
+
+- ${{ if eq(parameters.sdkBuild, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.projectName }} solution'
+    inputs:
+      command: build
+      arguments: '$(Solution) --configuration Release --no-restore'
+
+- ${{ if eq(parameters.sdkBuild, 'false') }}:
+  - task: VSBuild@1
+    displayName: "Build ${{ parameters.projectName }} solution"
+    inputs:
+      solution: "$(Solution)"
+      vsVersion: "$(VSVersion)"
+      msbuildArgs: ""
+      platform: "$(BuildPlatform)"
+      configuration: "$(BuildConfiguration)"
+      clean: "true"
+      maximumCpuCount: "true"
+
+- task: PowerShell@1
+  displayName: "Code Coverage - Instrument Dlls"
+  inputs:
+    scriptName: "$(ToolsPath)/CodeCoverage-InstrumentDlls.ps1"
+    arguments: "-Action instrument -RootFolder $(Build.SourcesDirectory) -OutputFolder $(OutputDirectory)"
+    errorActionPreference: "silentlyContinue"
+  condition: and(succeeded(), eq(variables['CoverageBuild'], 'true'))
+
+- ${{ if eq(parameters.msBuildPack, 'false') }}:
+  - template: pack.template.yml
+
+- ${{ if eq(parameters.msBuildPack, 'true') }}:
+  - template: pack.msbuild.template.yml
+
+- task: PowerShell@1
+  displayName: "Set build number"
+  inputs:
+    scriptName: "$(ToolsPath)/Set-BuildNumber.ps1"
+    arguments: |
+       -packagesOutputDirectory $(ArtifactsOutputPath) -affectedActivities $(AffectedActivities) -Verbose
+
+- ${{ parameters.postBuild }}

--- a/Activities/.pipelines/templates/stage.build.job.yml
+++ b/Activities/.pipelines/templates/stage.build.job.yml
@@ -59,7 +59,9 @@ steps:
   displayName: "Tag build with PR target branch"
   inputs:
     scriptType: "inlineScript"
-    inlineScript: "Write-Host \"##vso[build.addbuildtag]TargetBranch=$(System.PullRequest.TargetBranch)\""
+    inlineScript: "Write-Host \"##vso[build.addbuildtag]TargetBranch=$env:TARGET_BRANCH\""
+  env:
+    TARGET_BRANCH: $(System.PullRequest.TargetBranch)
   condition: ne(variables['System.PullRequest.TargetBranch'], '')
 
 - task: PowerShell@1
@@ -70,9 +72,11 @@ steps:
   condition: ne(variables['PrereleaseTag'], 'final')
 
 - powershell: |
-    Write-Host "##vso[build.addbuildtag]ActivityPackage=${{ coalesce(parameters.tagName, parameters.projectName) }}"
-    Write-Host "##vso[task.setvariable variable=AffectedActivities;]${{ coalesce(parameters.tagName, parameters.projectName) }}"
+    Write-Host "##vso[build.addbuildtag]ActivityPackage=$env:PACKAGE_TAG"
+    Write-Host "##vso[task.setvariable variable=AffectedActivities;]$env:PACKAGE_TAG"
   displayName: "Tag build with activity package tag"
+  env:
+    PACKAGE_TAG: ${{ coalesce(parameters.tagName, parameters.projectName) }}
 
 - task: PowerShell@1
   displayName: "Patch .nuspec files with prerelease tag"

--- a/Activities/.pipelines/templates/stage.build.job.yml
+++ b/Activities/.pipelines/templates/stage.build.job.yml
@@ -87,7 +87,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: "Use NuGet >=5.3.0"
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
 
 - ${{ if eq(parameters.sdkBuild, 'true') }}:
   - task: UseDotNet@2

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -5,7 +5,7 @@ parameters:
   solutionPath: ''
   preBuild: []
   postBuild: []
-  sonarKeyPrefix: ''
+  sonarProjectKey: ''
   sonarServiceConnection: ''
   msBuildPack: false
   sdkBuild: false
@@ -46,7 +46,7 @@ jobs:
 
         - template: Sonar/prepare-sonar-coverage.yml
           parameters:
-            projectKey: '${{ parameters.sonarKeyPrefix }}-${{ parameters.projectName }}'
+            projectKey: ${{ parameters.sonarProjectKey }}
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
             condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
       postBuild:

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -61,7 +61,21 @@ jobs:
         - template: Sonar/uninstall-sonar-targets.yml
 
   - powershell: |
-      Write-Output "##vso[task.setvariable variable=SourceBranchCommitId;isOutput=true]$env:SourceBranchCommitId"
-      Write-Output "##vso[task.setvariable variable=TargetBranchCommitId;isOutput=true]$env:TargetBranchCommitId"
+      # On PR builds, AzDO checks out refs/pull/N/merge — HEAD is the merge commit,
+      # HEAD^1 is the target-branch tip, HEAD^2 is the source-branch tip. These output
+      # variables are consumed by stage.sonar.yml's Checkout-BuildBranch step to
+      # reconstruct the PR merge for Sonar PR analysis. The previous version of this
+      # step read `$env:SourceBranchCommitId`/`$env:TargetBranchCommitId` which were
+      # never set anywhere in-repo — they always resolved to empty, silently disabling
+      # the merge reconstruction (a Sonar PR-decoration bug latent behind the
+      # Build.Reason guard). Derive from git instead.
+      $sourceCommit = ""
+      $targetCommit = ""
+      if ($env:BUILD_REASON -eq 'PullRequest') {
+        $sourceCommit = (git rev-parse HEAD^2).Trim()
+        $targetCommit = (git rev-parse HEAD^1).Trim()
+      }
+      Write-Output "##vso[task.setvariable variable=SourceBranchCommitId;isOutput=true]$sourceCommit"
+      Write-Output "##vso[task.setvariable variable=TargetBranchCommitId;isOutput=true]$targetCommit"
     name: setBranchCommitVariables
     displayName: "Set branch commit variables on the build"

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -48,7 +48,7 @@ jobs:
           parameters:
             projectKey: ${{ parameters.sonarProjectKey }}
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
       postBuild:
         - ${{ parameters.postBuild }}
 
@@ -58,7 +58,7 @@ jobs:
 
         - template: Sonar/upload-sonar-build-output.yml
           parameters:
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
         - template: Sonar/uninstall-sonar-targets.yml
 

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -11,7 +11,6 @@ parameters:
   sdkBuild: false
   requiresLfs: false
   hasQaPackages: true
-  azureSignConnectionName: ""
 
 jobs:
 - job: BuildAndPublishArtifacts
@@ -40,7 +39,6 @@ jobs:
       sdkBuild: ${{ parameters.sdkBuild }}
       requiresLfs: ${{ parameters.requiresLfs }}
       msBuildPack: ${{ parameters.msBuildPack }}
-      azureSignConnectionName: ${{ parameters.azureSignConnectionName }}
       preBuild:
         - ${{ parameters.preBuild }}
 

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -48,7 +48,7 @@ jobs:
           parameters:
             projectKey: '${{ parameters.sonarKeyPrefix }}-${{ parameters.projectName }}'
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
       postBuild:
         - ${{ parameters.postBuild }}
 
@@ -58,7 +58,7 @@ jobs:
 
         - template: Sonar/upload-sonar-build-output.yml
           parameters:
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
 
         - template: Sonar/uninstall-sonar-targets.yml
 

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -1,0 +1,69 @@
+parameters:
+  poolName: ''
+  tagName: ''
+  projectName: ''
+  solutionPath: ''
+  preBuild: []
+  postBuild: []
+  sonarKeyPrefix: ''
+  sonarServiceConnection: ''
+  msBuildPack: false
+  sdkBuild: false
+  requiresLfs: false
+  hasQaPackages: true
+  azureSignConnectionName: ""
+
+jobs:
+- job: BuildAndPublishArtifacts
+  displayName: 'Build & Publish Artifacts'
+  timeoutInMinutes: 90
+  pool:
+    ${{ if eq(parameters.poolName, '') }}:
+      vmImage: $(vmImage)
+    ${{ if ne(parameters.poolName, '') }}:
+      name: ${{ parameters.poolName }}
+    demands:
+      - npm
+      - msbuild
+      - visualstudio
+  dependsOn: DetermineShouldRun
+  condition: eq(dependencies.DetermineShouldRun.outputs['SetRunVariable.BuildShouldRun'], 'true')
+
+  variables:
+  - template: stage.variables.yml
+
+  steps:
+  - template: stage.build.job.yml
+    parameters:
+      projectName: "${{ parameters.projectName }}"
+      tagName: "${{ parameters.tagName }}"
+      sdkBuild: ${{ parameters.sdkBuild }}
+      requiresLfs: ${{ parameters.requiresLfs }}
+      msBuildPack: ${{ parameters.msBuildPack }}
+      azureSignConnectionName: ${{ parameters.azureSignConnectionName }}
+      preBuild:
+        - ${{ parameters.preBuild }}
+
+        - template: Sonar/prepare-sonar-coverage.yml
+          parameters:
+            projectKey: '${{ parameters.sonarKeyPrefix }}-${{ parameters.projectName }}'
+            serviceConnectionName: ${{ parameters.sonarServiceConnection }}
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+      postBuild:
+        - ${{ parameters.postBuild }}
+
+        - template: stage.build.job.publish.yml
+          parameters:
+            hasQaPackages: ${{ parameters.hasQaPackages }}
+
+        - template: Sonar/upload-sonar-build-output.yml
+          parameters:
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+        - template: Sonar/uninstall-sonar-targets.yml
+
+  - powershell: |
+      Write-Output "##vso[task.setvariable variable=SourceBranchCommitId;isOutput=true]$env:SourceBranchCommitId"
+      Write-Output "##vso[task.setvariable variable=TargetBranchCommitId;isOutput=true]$env:TargetBranchCommitId"
+    name: setBranchCommitVariables
+    displayName: "Set branch commit variables on the build"

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -48,7 +48,7 @@ jobs:
             projectKey: ${{ parameters.sonarProjectKey }}
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
             organization: ${{ parameters.sonarOrganization }}
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/masters/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/support/')))
       postBuild:
         - ${{ parameters.postBuild }}
 
@@ -58,7 +58,7 @@ jobs:
 
         - template: Sonar/upload-sonar-build-output.yml
           parameters:
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/masters/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/support/')))
 
         - template: Sonar/uninstall-sonar-targets.yml
 

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -7,6 +7,7 @@ parameters:
   postBuild: []
   sonarProjectKey: ''
   sonarServiceConnection: ''
+  sonarOrganization: ''
   msBuildPack: false
   sdkBuild: false
   requiresLfs: false
@@ -46,6 +47,7 @@ jobs:
           parameters:
             projectKey: ${{ parameters.sonarProjectKey }}
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
+            organization: ${{ parameters.sonarOrganization }}
             condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
       postBuild:
         - ${{ parameters.postBuild }}

--- a/Activities/.pipelines/templates/stage.build.yml
+++ b/Activities/.pipelines/templates/stage.build.yml
@@ -48,7 +48,7 @@ jobs:
           parameters:
             projectKey: ${{ parameters.sonarProjectKey }}
             serviceConnectionName: ${{ parameters.sonarServiceConnection }}
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
       postBuild:
         - ${{ parameters.postBuild }}
 
@@ -58,7 +58,7 @@ jobs:
 
         - template: Sonar/upload-sonar-build-output.yml
           parameters:
-            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+            condition: and(eq(variables['RunAnalysis'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
 
         - template: Sonar/uninstall-sonar-targets.yml
 

--- a/Activities/.pipelines/templates/stage.sonar.yml
+++ b/Activities/.pipelines/templates/stage.sonar.yml
@@ -1,0 +1,58 @@
+parameters:
+  additionalSonarTasks: []
+jobs:
+- job: RunSonar
+  displayName: "Analyze & publish results"
+  pool:
+    vmImage: windows-latest
+  variables:
+    SourceBranchCommitId: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setBranchCommitVariables.SourceBranchCommitId'] ]
+    TargetBranchCommitId: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setBranchCommitVariables.TargetBranchCommitId'] ]
+    OriginalSourcesPath: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setOriginalSrcPath.OriginalSourcesPath'] ]
+    SONARQUBE_SCANNER_MODE: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setSonarVariables.SONARQUBE_SCANNER_MODE'] ]
+    SONARQUBE_SCANNER_PARAMS: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setSonarVariables.SONARQUBE_SCANNER_PARAMS'] ]
+    SONARQUBE_ENDPOINT: $[ stageDependencies.Build.BuildAndPublishArtifacts.outputs['setSonarVariables.SONARQUBE_ENDPOINT'] ]
+  steps:
+    - checkout: self
+      persistCredentials: true
+
+    - task: PowerShell@1
+      displayName: "Checkout build branch for PR merge builds"
+      condition: and(ne(variables['SourceBranchCommitId'], ''), ne(variables['TargetBranchCommitId'], ''))
+      inputs:
+        scriptName: "$(ToolsPath)/Checkout-BuildBranch.ps1"
+
+    - powershell: |
+        Write-Host "Variables for current build:"
+        Get-ChildItem ENV:* | ForEach-Object { Write-Host "$($_.Name)=$($_.Value)" }
+      displayName: "Print variables"
+      continueOnError: true
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Coverage Artifacts'
+      inputs:
+        downloadPath: '$(Build.SourcesDirectory)'
+        artifactName: 'CodeCoverage'
+      continueOnError: true
+
+    - template: Sonar/download-sonar-build-output.yml
+      parameters:
+        condition: eq(variables['RunAnalysis'], 'true')
+
+    - task: PatchSonarQubeTask@0
+      displayName: "Patch SonarQube files for the local folder"
+      inputs:
+        originalRepoPath: $(OriginalSourcesPath)
+        pipelinePath: $(Pipeline.Workspace)
+        repoPath: $(Build.SourcesDirectory)
+        scannerPath: "$(Build.SourcesDirectory)\\SonarTemp\\scanner"
+
+    - template: Sonar/analyze-sonar-coverage.yml
+      parameters:
+        condition: eq(variables['RunAnalysis'], 'true')
+
+    - template: Sonar/publish-sonar-coverage.yml
+      parameters:
+        condition: eq(variables['RunAnalysis'], 'true')
+
+    - ${{ parameters.additionalSonarTasks }}

--- a/Activities/.pipelines/templates/stage.sonar.yml
+++ b/Activities/.pipelines/templates/stage.sonar.yml
@@ -22,12 +22,6 @@ jobs:
       inputs:
         scriptName: "$(ToolsPath)/Checkout-BuildBranch.ps1"
 
-    - powershell: |
-        Write-Host "Variables for current build:"
-        Get-ChildItem ENV:* | ForEach-Object { Write-Host "$($_.Name)=$($_.Value)" }
-      displayName: "Print variables"
-      continueOnError: true
-
     - task: DownloadBuildArtifacts@0
       displayName: 'Download Coverage Artifacts'
       inputs:

--- a/Activities/.pipelines/templates/stage.sonar.yml
+++ b/Activities/.pipelines/templates/stage.sonar.yml
@@ -39,7 +39,7 @@ jobs:
       parameters:
         condition: eq(variables['RunAnalysis'], 'true')
 
-    - task: PatchSonarQubeTask@0
+    - task: PatchSonarQubeTask@0.7921.14273
       displayName: "Patch SonarQube files for the local folder"
       inputs:
         originalRepoPath: $(OriginalSourcesPath)

--- a/Activities/.pipelines/templates/stage.sonar.yml
+++ b/Activities/.pipelines/templates/stage.sonar.yml
@@ -39,6 +39,10 @@ jobs:
       parameters:
         condition: eq(variables['RunAnalysis'], 'true')
 
+    # Exact-patch pin clears SonarCloud's "use complete version number" hotspot
+    # (azurepipelines:S7637-family). Must be bumped in lockstep with the installed
+    # extension version on AzDO — otherwise the pipeline fails to compile with
+    # "A task is missing" (see commit b587daa for the prior occurrence).
     - task: PatchSonarQubeTask@0.7921.14273
       displayName: "Patch SonarQube files for the local folder"
       inputs:

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -25,8 +25,6 @@ parameters:
   sdkBuild: false
   requiresLfs: false
   hasQaPackages: true
-  enableCDStages: false
-  azureSignConnectionName: ""
 
 stages:
 - stage: Build
@@ -50,7 +48,6 @@ stages:
       requiresLfs: ${{ parameters.requiresLfs }}
       hasQaPackages: ${{ parameters.hasQaPackages }}
       msBuildPack: ${{ parameters.msBuildPack }}
-      azureSignConnectionName: ${{ parameters.azureSignConnectionName }}
       preBuild:
       - ${{ each step in parameters.preBuild }}:
         - ${{ step }}

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -68,7 +68,7 @@ stages:
   - template: stage.test.yml
     parameters:
       poolName: ${{ parameters.testPoolName }}
-      runSettingsFile: ${{ parameters.runSettingsFilePath }}
+      runSettingsFilePath: ${{ parameters.runSettingsFilePath }}
       preTestRun:
       - ${{ each step in parameters.preTestRun }}:
         - ${{ step }}

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -88,7 +88,10 @@ stages:
   - Test
   - ${{ each stage in parameters.sonarDependsOn }}:
     - ${{ stage }}
-  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  # Sonar runs only on non-PR triggers until SonarCloud's main branch is renamed
+  # from master (stale, 6 years) to develop. See SONARCLOUD_ADMIN_CHECKLIST.md.
+  # Remove the Build.Reason clause to restore PR decoration after the rename.
+  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - template: stage.sonar.yml
     parameters:

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -8,7 +8,7 @@ parameters:
   solutionPath: ''
   buildPoolName: ''
   testPoolName: ''
-  sonarProjectKey: 'Community.Activities'
+  sonarProjectKey: 'UiPath_Community.Activities'
   sonarServiceConnection: 'SonarCloudActivities'
   runSettingsFilePath: '$(RunSettingsFilePath)'
   preBuild: []

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -8,7 +8,7 @@ parameters:
   solutionPath: ''
   buildPoolName: ''
   testPoolName: ''
-  sonarKeyPrefix: ''
+  sonarProjectKey: 'Community.Activities'
   sonarServiceConnection: 'SonarCloudActivities'
   runSettingsFilePath: '$(RunSettingsFilePath)'
   preBuild: []
@@ -44,7 +44,7 @@ stages:
       solutionPath: ${{ parameters.solutionPath }}
       poolName: ${{ parameters.buildPoolName }}
       tagName: ${{ parameters.tagName }}
-      sonarKeyPrefix: ${{ parameters.sonarKeyPrefix }}
+      sonarProjectKey: ${{ parameters.sonarProjectKey }}
       sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
       sdkBuild: ${{ parameters.sdkBuild }}
       requiresLfs: ${{ parameters.requiresLfs }}

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -87,7 +87,11 @@ stages:
     - ${{ stage }}
   # Sonar runs only on non-PR triggers until SonarCloud's main branch is renamed
   # from master (stale, 6 years) to develop. See SONARCLOUD_ADMIN_CHECKLIST.md.
-  # Remove the Build.Reason clause to restore PR decoration after the rename.
+  # When restoring PR decoration after the rename: remove ONLY the
+  # `ne(variables['Build.Reason'], 'PullRequest')` clause. The IsFork clause must
+  # stay — it's the guard that keeps fork PRs out (where AzDO strips secrets and
+  # Sonar would fail anyway). The same pair appears on the prepare/upload
+  # condition parameters in stage.build.yml.
   condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - template: stage.sonar.yml

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -88,10 +88,7 @@ stages:
   - Test
   - ${{ each stage in parameters.sonarDependsOn }}:
     - ${{ stage }}
-  # Sonar runs only on non-PR triggers (push to develop/masters/release/support).
-  # PR analysis is skipped because the SonarCloud project is NOT_BOUND to GitHub;
-  # remove the Build.Reason clause to restore PR decoration once the binding is set up.
-  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
   jobs:
   - template: stage.sonar.yml
     parameters:

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -10,6 +10,7 @@ parameters:
   testPoolName: ''
   sonarProjectKey: 'UiPath_Community.Activities'
   sonarServiceConnection: 'SonarCloudActivities'
+  sonarOrganization: 'ui'
   runSettingsFilePath: '$(RunSettingsFilePath)'
   preBuild: []
   postBuild: []
@@ -44,6 +45,7 @@ stages:
       tagName: ${{ parameters.tagName }}
       sonarProjectKey: ${{ parameters.sonarProjectKey }}
       sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+      sonarOrganization: ${{ parameters.sonarOrganization }}
       sdkBuild: ${{ parameters.sdkBuild }}
       requiresLfs: ${{ parameters.requiresLfs }}
       hasQaPackages: ${{ parameters.hasQaPackages }}

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -87,14 +87,17 @@ stages:
   - Test
   - ${{ each stage in parameters.sonarDependsOn }}:
     - ${{ stage }}
-  # Sonar runs only on non-PR triggers until SonarCloud's main branch is renamed
-  # from master (stale, 6 years) to develop. See SONARCLOUD_ADMIN_CHECKLIST.md.
+  # Sonar runs only on develop and release/* pushes — never on masters/* or
+  # support/* (the two startsWith exclusions below), and not on PR triggers until
+  # SonarCloud's main branch is renamed from master (stale, 6 years) to develop.
+  # See SONARCLOUD_ADMIN_CHECKLIST.md.
   # When restoring PR decoration after the rename: remove ONLY the
-  # `ne(variables['Build.Reason'], 'PullRequest')` clause. The IsFork clause must
-  # stay — it's the guard that keeps fork PRs out (where AzDO strips secrets and
-  # Sonar would fail anyway). The same pair appears on the prepare/upload
+  # `ne(variables['Build.Reason'], 'PullRequest')` clause. Keep the IsFork clause
+  # (guards out fork PRs, where AzDO strips secrets and Sonar would fail anyway)
+  # and the masters/support exclusions (PR builds use refs/pull/* so the
+  # exclusions don't block them). The same guards appear on the prepare/upload
   # condition parameters in stage.build.yml.
-  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/masters/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/support/')))
   jobs:
   - template: stage.sonar.yml
     parameters:

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -88,7 +88,10 @@ stages:
   - Test
   - ${{ each stage in parameters.sonarDependsOn }}:
     - ${{ stage }}
-  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  # Sonar runs only on non-PR triggers (push to develop/masters/release/support).
+  # PR analysis is skipped because the SonarCloud project is NOT_BOUND to GitHub;
+  # remove the Build.Reason clause to restore PR decoration once the binding is set up.
+  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - template: stage.sonar.yml
     parameters:

--- a/Activities/.pipelines/templates/stage.start.yml
+++ b/Activities/.pipelines/templates/stage.start.yml
@@ -1,6 +1,6 @@
 # Local replacement for Activities/stage.start.yml@common
-# Uses path-trigger-based should-run check instead of GitHub API label check.
-# References @common for build, test, and sonar templates.
+# Build, test, and Sonar templates are vendored under templates/ and templates/Sonar/
+# (originally from UiPath/AzurePipelinesTemplates @ uipath.community.activities.1.3.0).
 
 parameters:
   projectName: ''
@@ -9,6 +9,7 @@ parameters:
   buildPoolName: ''
   testPoolName: ''
   sonarKeyPrefix: ''
+  sonarServiceConnection: 'SonarCloudActivities'
   runSettingsFilePath: '$(RunSettingsFilePath)'
   preBuild: []
   postBuild: []
@@ -32,19 +33,19 @@ stages:
   displayName: ${{ format('Build {0} activities', parameters.projectName) }}
   variables:
     Solution: '${{ parameters.solutionPath }}'
-    RunAnalysis: 'false'
   jobs:
   # Local should-run check — no GitHub API token needed
   - template: stage.shouldrun.yml
 
-  # Build job from common templates (unchanged)
-  - template: Activities/stage.build.yml@common
+  # Build job from local vendored templates
+  - template: stage.build.yml
     parameters:
       projectName: ${{ parameters.projectName }}
       solutionPath: ${{ parameters.solutionPath }}
       poolName: ${{ parameters.buildPoolName }}
       tagName: ${{ parameters.tagName }}
       sonarKeyPrefix: ${{ parameters.sonarKeyPrefix }}
+      sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
       sdkBuild: ${{ parameters.sdkBuild }}
       requiresLfs: ${{ parameters.requiresLfs }}
       hasQaPackages: ${{ parameters.hasQaPackages }}
@@ -64,7 +65,7 @@ stages:
   dependsOn: Build
   condition: and(succeeded(), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'))
   jobs:
-  - template: Activities/stage.test.yml@common
+  - template: stage.test.yml
     parameters:
       poolName: ${{ parameters.testPoolName }}
       runSettingsFile: ${{ parameters.runSettingsFilePath }}
@@ -87,11 +88,9 @@ stages:
   - Test
   - ${{ each stage in parameters.sonarDependsOn }}:
     - ${{ stage }}
-  variables:
-    RunAnalysis: 'false'
-  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'))
+  condition: and(not(canceled()), eq(variables['RunAnalysis'], 'true'), eq(stageDependencies.Build.outputs['DetermineShouldRun.SetRunVariable.BuildShouldRun'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
   jobs:
-  - template: Activities/stage.sonar.yml@common
+  - template: stage.sonar.yml
     parameters:
       additionalSonarTasks: ${{ parameters.additionalSonarTasks }}
 

--- a/Activities/.pipelines/templates/stage.test.yml
+++ b/Activities/.pipelines/templates/stage.test.yml
@@ -95,7 +95,12 @@ jobs:
     displayName: "Download code coverage from TestRuns"
     inputs:
       scriptName: "$(ToolsPath)/Download-TestRunAttachments.ps1"
-      arguments: "-project $(System.TeamProject) -buildId $(Build.BuildId) -accessToken $(System.AccessToken) -outputPath \"$(Build.ArtifactStagingDirectory)\\CodeCoverage\""
+      arguments: "-project $(System.TeamProject) -buildId $(Build.BuildId) -outputPath \"$(Build.ArtifactStagingDirectory)\\CodeCoverage\""
+    env:
+      # Token read by the script via $env:SYSTEM_ACCESSTOKEN — passing it on the
+      # command line would expose it in agent process listings even though
+      # AzDO masks it in logs.
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     condition: always()
 
   - task: PublishCodeCoverageResults@1

--- a/Activities/.pipelines/templates/stage.test.yml
+++ b/Activities/.pipelines/templates/stage.test.yml
@@ -1,0 +1,118 @@
+parameters:
+  vstsProject: ''
+  poolName: ''
+  runSettingsFilePath: ''
+  preTestRun: []
+  postTestRun: []
+
+jobs:
+- job: RunTests
+  displayName: "Run tests"
+  timeoutInMinutes: 90
+  pool:
+    ${{ if eq(parameters.poolName, '') }}:
+      vmImage: $(vmImage)
+    ${{ if ne(parameters.poolName, '') }}:
+      name: ${{ parameters.poolName }}
+    demands:
+      - npm
+      - msbuild
+      - visualstudio
+
+  variables:
+    - template: stage.variables.yml
+
+  steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download test artifact"
+    inputs:
+      artifactName: "OutputTests"
+      downloadPath: "$(Build.SourcesDirectory)"
+    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+
+  - task: BuildProcessCleaner@0
+
+  - task: VisualStudioTestPlatformInstaller@1
+    displayName: "VSTest Platform Installer"
+    inputs:
+      versionSelector: 'specificVersion'
+      testPlatformVersion: 17.2.0
+
+  - powershell: |
+      $content = ""
+      if ('$(IncludeLongRunning)' -ne 'true') {
+        $content = "Category!=LongRunning"
+      }
+
+      Write-Host "testFilterCriteria = $content"
+      Write-Output "##vso[task.setvariable variable=testFilterCriteria;]$content"
+    displayName: 'Set testFilterCriteria variable'
+
+  - ${{ parameters.preTestRun }}
+
+  - task: VSTest@2
+    displayName: "Run Smoke Tests"
+    inputs:
+      testAssemblyVer2: "**\\*tests.dll\n**\\*Test.dll\n**\\*UnitTest.dll\n!**\\*TestAdapter.dll\n!**\\obj\\**"
+      testRunTitle: "Unit Tests"
+      platform: "$(BuildPlatform)"
+      codeCoverageEnabled: "true"
+      publishRunAttachments: False
+      configuration: "$(BuildConfiguration)"
+      testFiltercriteria: $(testFilterCriteria)
+      runSettingsFile: ${{ parameters.runSettingsFilePath }}
+      vsTestVersion: toolsInstaller
+    condition: and(and(succeeded(), eq(variables['RunTests'], 'true')), ne(variables['TestRun'], 'AllTests'))
+
+  - task: VSTest@2
+    displayName: "Run All Tests"
+    inputs:
+      testAssemblyVer2: "**\\*tests.dll\n**\\*Test.dll\n**\\*UnitTest.dll\n!**\\*TestAdapter.dll\n!**\\obj\\**"
+      testRunTitle: "Unit Tests"
+      platform: "$(BuildPlatform)"
+      codeCoverageEnabled: "true"
+      publishRunAttachments: False
+      configuration: "$(BuildConfiguration)"
+      runSettingsFile: ${{ parameters.runSettingsFilePath }}
+      vsTestVersion: toolsInstaller
+    condition: and(and(succeeded(), eq(variables['RunTests'], 'true')), eq(variables['TestRun'], 'AllTests'))
+    timeoutInMinutes: 120
+
+  - task: PowerShell@1
+    displayName: "Stop all processes used in tests"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: "
+      Get-Process -Name 'excel', 'winword', 'powerpnt'  -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+      "
+    condition: succeededOrFailed()
+
+  - task: PowerShell@1
+    displayName: "Download code coverage from TestRuns"
+    inputs:
+      scriptName: "$(ToolsPath)/Download-TestRunAttachments.ps1"
+      arguments: "-project $(System.TeamProject) -buildId $(Build.BuildId) -accessToken $(System.AccessToken) -outputPath \"$(Build.ArtifactStagingDirectory)\\CodeCoverage\""
+    condition: always()
+
+  - task: PublishCodeCoverageResults@1
+    displayName: "Publish backend unit tests code coverage"
+    inputs:
+      codeCoverageTool: "Cobertura"
+      summaryFileLocation: "$(Build.ArtifactStagingDirectory)\\CodeCoverage\\*.coverage"
+    condition: and(succeededOrFailed(), ne(variables['PublishUTCoverage'], false))
+
+  - task: PowerShell@1
+    displayName: "Convert coverage to coveragexml"
+    inputs:
+      scriptName: "$(ToolsPath)/Convert-CoverageToCoverageXml.ps1"
+      arguments: "-inputPath \"$(Build.ArtifactStagingDirectory)\\CodeCoverage\" -outputPath \"$(Build.SourcesDirectory)\\TestResults\\UnitTests.coveragexml\""
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact - CodeCoverage'
+    inputs:
+      pathtoPublish: "$(Build.SourcesDirectory)\\TestResults\\UnitTests.coveragexml"
+      artifactName: CodeCoverage
+    condition: succeededOrFailed()
+
+  - ${{ parameters.postTestRun }}

--- a/Activities/.pipelines/templates/stage.test.yml
+++ b/Activities/.pipelines/templates/stage.test.yml
@@ -30,6 +30,10 @@ jobs:
       downloadPath: "$(Build.SourcesDirectory)"
     condition: and(succeeded(), eq(variables['RunTests'], 'true'))
 
+  # Exact-patch pin clears SonarCloud's "use complete version number" hotspot.
+  # Must be bumped in lockstep with the installed extension version on AzDO —
+  # otherwise the pipeline fails to compile with "A task is missing"
+  # (see commit b587daa for the prior occurrence with SonarCloudAnalyze).
   - task: BuildProcessCleaner@0.9147.15998
 
   - task: VisualStudioTestPlatformInstaller@1

--- a/Activities/.pipelines/templates/stage.test.yml
+++ b/Activities/.pipelines/templates/stage.test.yml
@@ -30,7 +30,7 @@ jobs:
       downloadPath: "$(Build.SourcesDirectory)"
     condition: and(succeeded(), eq(variables['RunTests'], 'true'))
 
-  - task: BuildProcessCleaner@0
+  - task: BuildProcessCleaner@0.9147.15998
 
   - task: VisualStudioTestPlatformInstaller@1
     displayName: "VSTest Platform Installer"

--- a/Activities/.pipelines/templates/stage.variables.yml
+++ b/Activities/.pipelines/templates/stage.variables.yml
@@ -13,5 +13,6 @@ variables:
   InstrumentedDllsArtifactName: "InstrumentedDlls"
   PrereleaseTag: ""
   Build.Repository.Clean: true
+  CleanGit: true
   SystemAccessToken: $(System.AccessToken)
   PlatformVersion: "19.10.2"

--- a/Activities/.pipelines/templates/stage.variables.yml
+++ b/Activities/.pipelines/templates/stage.variables.yml
@@ -1,0 +1,17 @@
+variables:
+  VSVersion: "16.0"
+  BuildPlatform: "Any CPU"
+  BuildConfiguration: "Release"
+  vmImage: "windows-latest"
+  OutputDirectory: "$(Build.SourcesDirectory)\\Activities\\Output\\"
+  ArtifactsOutputPath: "$(Build.SourcesDirectory)\\Output\\Packages"
+  ExplorerStandaloneOutputPath: "$(Build.SourcesDirectory)\\Output\\ExplorerStandalone"
+  QAArtifactsOutputPath: "$(Build.SourcesDirectory)\\Output\\TestPackages"
+  InstrumentedDllsPath: "$(Build.SourcesDirectory)\\Output\\InstrumentedDlls"
+  ArtifactName: "Packages"
+  QAArtifactName: "TestPackages"
+  InstrumentedDllsArtifactName: "InstrumentedDlls"
+  PrereleaseTag: ""
+  Build.Repository.Clean: true
+  SystemAccessToken: $(System.AccessToken)
+  PlatformVersion: "19.10.2"

--- a/Activities/.pipelines/templates/stage.variables.yml
+++ b/Activities/.pipelines/templates/stage.variables.yml
@@ -1,5 +1,5 @@
 variables:
-  VSVersion: "16.0"
+  VSVersion: "17.0"
   BuildPlatform: "Any CPU"
   BuildConfiguration: "Release"
   vmImage: "windows-latest"

--- a/Activities/.pipelines/variables/variables.yml
+++ b/Activities/.pipelines/variables/variables.yml
@@ -8,4 +8,3 @@ variables:
   TestRunnerVersion: "1.594.543"
   TestsStudioVersion: "24.10.8"
   RunAnalysis: 'true'
-  

--- a/Activities/.pipelines/variables/variables.yml
+++ b/Activities/.pipelines/variables/variables.yml
@@ -7,4 +7,5 @@ variables:
   ToolsPath: "$(Build.SourcesDirectory)\\Activities\\Tools"
   TestRunnerVersion: "1.594.543"
   TestsStudioVersion: "24.10.8"
+  RunAnalysis: 'true'
   

--- a/Activities/Credentials/azure-pipelines.yml
+++ b/Activities/Credentials/azure-pipelines.yml
@@ -38,7 +38,6 @@ stages:
       projectName: 'Credentials'
       solutionPath: '$(SolutionsPath)/Activities.Credentials.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/Credentials/azure-pipelines.yml
+++ b/Activities/Credentials/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
     parameters:
       projectName: 'Credentials'
       solutionPath: '$(SolutionsPath)/Activities.Credentials.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/Credentials/azure-pipelines.yml
+++ b/Activities/Credentials/azure-pipelines.yml
@@ -1,11 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-
 trigger:
   batch: true
   branches:
@@ -41,7 +33,6 @@ variables:
   - template: ..\.pipelines\variables\variables.yml
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'Credentials'
@@ -50,20 +41,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Cryptography/azure-pipelines.yml
+++ b/Activities/Cryptography/azure-pipelines.yml
@@ -38,7 +38,6 @@ stages:
       projectName: 'Cryptography'
       solutionPath: '$(SolutionsPath)/Activities.Cryptography.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/Cryptography/azure-pipelines.yml
+++ b/Activities/Cryptography/azure-pipelines.yml
@@ -1,16 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-  - repository: automationTests
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.waitforbuild.1.0.3
-    endpoint: "GitHub connection"
-
 trigger:
   batch: true
   branches:
@@ -46,7 +33,6 @@ variables:
   - template: ..\.pipelines\variables\variables.yml
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'Cryptography'
@@ -55,20 +41,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Cryptography/azure-pipelines.yml
+++ b/Activities/Cryptography/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
     parameters:
       projectName: 'Cryptography'
       solutionPath: '$(SolutionsPath)/Activities.Cryptography.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/Database/azure-pipelines.yml
+++ b/Activities/Database/azure-pipelines.yml
@@ -1,21 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-  - repository: automationTests
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.waitforbuild.1.0.3
-    endpoint: "GitHub connection"
-  - repository: template-helpers
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    endpoint: "UiPath"
-    ref: refs/tags/uipath.templates.helpers.1.1.4
-
 trigger:
   batch: true
   branches:
@@ -53,7 +35,6 @@ variables:
     value: false
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'Database'
@@ -62,20 +43,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Database/azure-pipelines.yml
+++ b/Activities/Database/azure-pipelines.yml
@@ -39,7 +39,6 @@ stages:
     parameters:
       projectName: 'Database'
       solutionPath: '$(SolutionsPath)/Activities.Database.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/Database/azure-pipelines.yml
+++ b/Activities/Database/azure-pipelines.yml
@@ -40,7 +40,6 @@ stages:
       projectName: 'Database'
       solutionPath: '$(SolutionsPath)/Activities.Database.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/Database/stage.create.byos.agent.yml
+++ b/Activities/Database/stage.create.byos.agent.yml
@@ -48,7 +48,7 @@ jobs:
       expiryTimeMinutes: 90
       removePublicIp: "False"
 
-  - template: AzurePipelines/wait-for-agent.yml@template-helpers
+  - template: ../.pipelines/templates/AzurePipelines/wait-for-agent.yml
     parameters:
       capabilities: "{'agentKey': '$(athenaservicesAgentPrefix)-$(Build.BuildId)'}"
       azureDevOpsToken: "$(System.AccessToken)"

--- a/Activities/FTP/azure-pipelines.yml
+++ b/Activities/FTP/azure-pipelines.yml
@@ -38,7 +38,6 @@ stages:
       projectName: 'FTP'
       solutionPath: '$(SolutionsPath)/Activities.FTP.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/FTP/azure-pipelines.yml
+++ b/Activities/FTP/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
     parameters:
       projectName: 'FTP'
       solutionPath: '$(SolutionsPath)/Activities.FTP.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/FTP/azure-pipelines.yml
+++ b/Activities/FTP/azure-pipelines.yml
@@ -1,11 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-
 trigger:
   batch: true
   branches:
@@ -41,7 +33,6 @@ variables:
   - template: ..\.pipelines\variables\variables.yml
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'FTP'
@@ -50,20 +41,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Java/azure-pipelines.yml
+++ b/Activities/Java/azure-pipelines.yml
@@ -1,11 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-
 trigger:
   batch: true
   branches:
@@ -41,7 +33,6 @@ variables:
   - template: ..\.pipelines\variables\variables.yml
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'Java'
@@ -50,20 +41,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Java/azure-pipelines.yml
+++ b/Activities/Java/azure-pipelines.yml
@@ -38,7 +38,6 @@ stages:
       projectName: 'Java'
       solutionPath: '$(SolutionsPath)/Activities.Java.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/Java/azure-pipelines.yml
+++ b/Activities/Java/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
     parameters:
       projectName: 'Java'
       solutionPath: '$(SolutionsPath)/Activities.Java.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -1,16 +1,3 @@
-resources:
-  repositories:
-  - repository: common
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.community.activities.1.3.0
-    endpoint: "GitHub connection"
-  - repository: automationTests
-    type: github
-    name: UiPath/AzurePipelinesTemplates
-    ref: refs/tags/uipath.waitforbuild.1.0.3
-    endpoint: "GitHub connection"
-
 trigger:
   batch: true
   branches:
@@ -46,7 +33,6 @@ variables:
   - template: ..\.pipelines\variables\variables.yml
 
 stages:
-  # Uses local stage.start.yml instead of @common to avoid GitHub API token dependency
   - template: ..\.pipelines\templates\stage.start.yml
     parameters:
       projectName: 'Python'
@@ -55,20 +41,6 @@ stages:
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false
-      postBuild:
-      - powershell: |
-          $sonarDir = Join-Path "$(Pipeline.Workspace)" ".sonarqube"
-          if (-not (Test-Path $sonarDir)) {
-            New-Item -ItemType Directory -Path $sonarDir | Out-Null
-          }
-          $scannerDir = Join-Path $sonarDir "bin"
-          New-Item -ItemType Directory -Path $scannerDir -Force | Out-Null
-          $stubExe = Join-Path $scannerDir "SonarScanner.MSBuild.exe"
-          if (-not (Test-Path $stubExe)) {
-            New-Item -ItemType File -Path $stubExe -Force | Out-Null
-          }
-          Write-Host "##vso[task.setvariable variable=SONARQUBE_SCANNER_MSBUILD_EXE]$stubExe"
-        displayName: 'Create Sonar placeholders (analysis disabled)'
       preTestRun:
       - task: UseDotNet@2
         displayName: 'Install .NET 6 SDK'

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
     parameters:
       projectName: 'Python'
       solutionPath: '$(SolutionsPath)/Activities.Python.sln'
-      sonarKeyPrefix: 'CommunityActivities'
       sdkBuild: false
       enableCDStages: false
       hasQaPackages: false

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -38,7 +38,6 @@ stages:
       projectName: 'Python'
       solutionPath: '$(SolutionsPath)/Activities.Python.sln'
       sdkBuild: false
-      enableCDStages: false
       hasQaPackages: false
       preTestRun:
       - task: UseDotNet@2

--- a/Activities/Tools/Checkout-BuildBranch.ps1
+++ b/Activities/Tools/Checkout-BuildBranch.ps1
@@ -1,8 +1,3 @@
-param(
-    [Parameter(Mandatory = $true)]
-    [string] $githubAuthToken
-)
-
 Import-Module ([System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "\Utils-RemoteBranch.psm1")))
 
 Set-Location -Path $env:BUILD_SOURCESDIRECTORY
@@ -11,12 +6,11 @@ Write-Host "Running in $env:BUILD_SOURCESDIRECTORY"
 $sourceBranch = $env:SYSTEM_PULLREQUEST_SOURCEBRANCH
 $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
 
-$githubAuthorizationHeaderBase64 = [System.Convert]::ToBase64String([char[]]$githubAuthToken)
-Write-Host "git -c http.extraheader=""AUTHORIZATION: basic AUTH_TOKEN_NOT_DISPLAYED_FOR_SECURITY_REASONS"" fetch origin $sourceBranch"
-Invoke-Git "-c http.extraheader=""AUTHORIZATION: basic $githubAuthorizationHeaderBase64"" fetch origin $sourceBranch"
+Write-Host "git fetch origin $sourceBranch"
+Invoke-Git "fetch origin $sourceBranch"
 
-Write-Host "git -c http.extraheader=""AUTHORIZATION: basic AUTH_TOKEN_NOT_DISPLAYED_FOR_SECURITY_REASONS"" fetch origin $targetBranch"
-Invoke-Git "-c http.extraheader=""AUTHORIZATION: basic $githubAuthorizationHeaderBase64"" fetch origin $targetBranch"
+Write-Host "git fetch origin $targetBranch"
+Invoke-Git "fetch origin $targetBranch"
 
 Write-Host "Re-creating merge commit without a ref, based on source branch and target branch commit ids"
 Write-Host "git checkout $env:TargetBranchCommitId"
@@ -25,8 +19,8 @@ Invoke-Git "checkout $env:TargetBranchCommitId"
 Invoke-Git "config user.email ""devtest-team@uipath.com"""
 Invoke-Git "config user.name ""$env:BUILD_SOURCEVERSIONAUTHOR"""
 
-Write-Host "git -c http.extraheader=""AUTHORIZATION: basic AUTH_TOKEN_NOT_DISPLAYED_FOR_SECURITY_REASONS"" merge $env:SourceBranchCommitId"
-Invoke-Git "-c http.extraheader=""AUTHORIZATION: basic $githubAuthorizationHeaderBase64"" merge $env:SourceBranchCommitId"
+Write-Host "git merge $env:SourceBranchCommitId"
+Invoke-Git "merge $env:SourceBranchCommitId"
 
 $currentCommit = & git log -1
 Write-Host "Last commit is $currentCommit"

--- a/Activities/Tools/Download-TestRunAttachments.ps1
+++ b/Activities/Tools/Download-TestRunAttachments.ps1
@@ -3,7 +3,6 @@ param(
     [string]$project,
     [Parameter(Mandatory = $true)]
     [string] $buildId,
-    [Parameter(Mandatory = $true)]
     [string] $accessToken,
     [string] $organization = "UiPath",
     [Parameter(Mandatory = $true)]
@@ -12,6 +11,16 @@ param(
 function Main {
 
     New-item -ItemType Directory -Path $outputPath -Force
+
+    # Prefer the env-var pathway (set by the caller's env: block) — keeps the
+    # token off the command line and out of agent process listings. Falls back
+    # to the -accessToken parameter for backward compatibility.
+    if ([string]::IsNullOrEmpty($accessToken)) {
+        $accessToken = $env:SYSTEM_ACCESSTOKEN
+    }
+    if ([string]::IsNullOrEmpty($accessToken)) {
+        throw "Access token is required: pass via env (SYSTEM_ACCESSTOKEN) or -accessToken parameter."
+    }
 
     $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f "", $accessToken)))
 


### PR DESCRIPTION
## Context
The 6 activity-pack CI pipelines (Python, Credentials, Cryptography, Database, FTP, Java) pulled their build/test/Sonar logic from the private `UiPath/AzurePipelinesTemplates` repo via a service connection. Signing/publish run elsewhere (`opensource-deployments`).

## Problem
- Build 12140055 failed: GitHub revoked the SAML-bound OAuth token on the `"GitHub connection"` service connection. All 6 packs would fail identically on next trigger.
- Sonar has been disabled since 2026-02-27 (`2584bed`). Three months of code-quality data missing.
- Both are symptoms of a public repo carrying a long-lived credential to a private resource.

## Behavior Before
Pipeline compile fails on the `@common` resource fetch (SAML 403). Sonar was hardcoded off; an inline PowerShell stub created placeholder scanner files.

## Behavior After
- Templates resolve locally. Zero `endpoint:` references, zero `resources: repositories:`, no service connection in PR scope.
- Sonar runs on protected-branch pushes (`develop`, `masters/*`, `release/*`, `support/*`) only — analyses the consolidated `UiPath_Community.Activities` project on SonarCloud. **PR decoration is intentionally skipped** until the admin work in `Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md` is done (one-line YAML revert re-enables it).
- Vendored YAML refactored to route parameters through `env:` blocks (SonarCloud `azurepipelines:S7637` injection findings cleared, 11 hotspots resolved).
- VS 16 → 17 and `NuGetAuthenticate@0` → `@1` (clears two CI warnings).

## Caveats — admin work owed after merge
- **SonarCloud main-branch rename `master` → `develop`** is the gate for PR decoration. Full walkthrough in `Activities/.pipelines/SONARCLOUD_ADMIN_CHECKLIST.md` (project key + binding + token already verified working).
- Swap SonarCloud service-connection token to project-scoped, enable AzDO "no secrets on fork builds", reset SonarCloud "new code" baseline before merging the first restored PR to avoid 3-month drift.
- After verification, `"GitHub connection"` and `"UiPath (4)"` service connections can be deleted — nothing references them.
- `$(StudioLicense)` exposure on agent process listing is pre-existing, tracked separately.

## How to Test
1. Manual build on each pack — should compile with no external resource resolution.
2. Same-repo PR on any pack — Build/Test pass; PublishSonar stage skipped cleanly (no error).
3. Push to `develop` — Sonar runs and analyses `UiPath_Community.Activities`.

## Reviewing the history

This branch went through four review rounds (Copilot bot + one human reviewer + one adversarial Claude review). The exploratory commits in the middle are net-zero — `1ba42f2` adds the PR-skip → `2be7a4d` removes it as an optimistic test → `d4e3bd3` restores it after the test failed against the stale-`master` Sonar branch; `87ef8ab` pins Sonar tasks to exact patch → `b587daa` reverts the SonarSource pins (wrong version source). Commit messages narrate the why of each step. **For the final merged net state, read the tip commit's tree directly rather than diffing arbitrary intermediates.** If merged with history preserved, future `git blame` readers should expect to step over several reverts; squash-merge avoids that.