### PR TITLE
feat(pipelines): Publish robot logs as runtime-tests pipeline artifact [STUD-80279]

### DIFF
--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -75,8 +75,11 @@ jobs:
         exit 0
       fi
       if docker exec "$CID" test -d /home/robotuser/.local/share/UiPath/Logs; then
-        docker cp "$CID:/home/robotuser/.local/share/UiPath/Logs/." "$DST"
-        echo "Copied robot logs from container to $DST"
+        if docker cp "$CID:/home/robotuser/.local/share/UiPath/Logs/." "$DST"; then
+          echo "Copied robot logs from container to $DST"
+        else
+          echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST failed." > "$DST/no-logs.txt"
+        fi
       else
         echo "Robot log directory /home/robotuser/.local/share/UiPath/Logs does not exist in the container." > "$DST/no-logs.txt"
       fi

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -82,7 +82,7 @@ jobs:
           echo "Copied robot logs from container to $DST"
         fi
       else
-        echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST failed (the log directory may not exist in the container, or docker cp failed for another reason)." > "$DST/no-logs.txt"
+        echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST failed (the log directory may not exist in the container, or docker cp failed for another reason)." > "$DST/staging-errors.txt"
       fi
     displayName: 'Stage robot logs'
     condition: always()

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -88,7 +88,7 @@ jobs:
     condition: always()
     inputs:
       PathToPublish: '$(System.ArtifactsDirectory)/RobotLogs'
-      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)'
+      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)_$(System.JobAttempt)'
       ArtifactType: 'Container'
 
   - ${{ each step in parameters.afterTestsCustomSteps }}:

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -64,6 +64,33 @@ jobs:
     displayName: 'Run tests'
     env: ${{ parameters.environment }}
 
+  - bash: |
+      set +e
+      cd $(Build.SourcesDirectory)/Activities/.pipelines/docker
+      DST="$(System.ArtifactsDirectory)/RobotLogs"
+      mkdir -p "$DST"
+      CID=$(docker-compose ps -q robot)
+      if [ -z "$CID" ]; then
+        echo "Robot container not found." > "$DST/no-logs.txt"
+        exit 0
+      fi
+      if docker exec "$CID" test -d /home/robotuser/.local/share/UiPath/Logs; then
+        docker cp "$CID:/home/robotuser/.local/share/UiPath/Logs/." "$DST"
+        echo "Copied robot logs from container to $DST"
+      else
+        echo "Robot log directory /home/robotuser/.local/share/UiPath/Logs does not exist in the container." > "$DST/no-logs.txt"
+      fi
+    displayName: 'Stage robot logs'
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish robot logs'
+    condition: always()
+    inputs:
+      PathToPublish: '$(System.ArtifactsDirectory)/RobotLogs'
+      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)'
+      ArtifactType: 'Container'
+
   - ${{ each step in parameters.afterTestsCustomSteps }}:
     - ${{ step }}
 

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -74,14 +74,15 @@ jobs:
         echo "Robot container not found." > "$DST/no-logs.txt"
         exit 0
       fi
-      if docker exec "$CID" test -d /home/robotuser/.local/share/UiPath/Logs; then
-        if docker cp "$CID:/home/robotuser/.local/share/UiPath/Logs/." "$DST"; then
-          echo "Copied robot logs from container to $DST"
+      if docker cp "$CID:/home/robotuser/.local/share/UiPath/Logs/." "$DST"; then
+        if [ -z "$(find "$DST" -type f -print -quit)" ]; then
+          echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST succeeded but staged no files (the container log directory was empty)." > "$DST/no-logs.txt"
+          echo "Container log directory was empty; wrote placeholder."
         else
-          echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST failed." > "$DST/no-logs.txt"
+          echo "Copied robot logs from container to $DST"
         fi
       else
-        echo "Robot log directory /home/robotuser/.local/share/UiPath/Logs does not exist in the container." > "$DST/no-logs.txt"
+        echo "docker cp from $CID:/home/robotuser/.local/share/UiPath/Logs/. to $DST failed (the log directory may not exist in the container, or docker cp failed for another reason)." > "$DST/no-logs.txt"
       fi
     displayName: 'Stage robot logs'
     condition: always()

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.portable.yml
@@ -69,7 +69,7 @@ jobs:
       cd $(Build.SourcesDirectory)/Activities/.pipelines/docker
       DST="$(System.ArtifactsDirectory)/RobotLogs"
       mkdir -p "$DST"
-      CID=$(docker-compose ps -q robot)
+      CID=$(docker-compose ps -a -q robot)
       if [ -z "$CID" ]; then
         echo "Robot container not found." > "$DST/no-logs.txt"
         exit 0

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -95,8 +95,13 @@ jobs:
       $dst = "$(System.ArtifactsDirectory)\RobotLogs"
       New-Item -ItemType Directory -Force -Path $dst | Out-Null
       if (Test-Path $src) {
-        Copy-Item -Path "$src\*" -Destination $dst -Recurse -Force -ErrorAction Continue
-        Write-Host "Copied robot logs from $src to $dst"
+        Copy-Item -Path "$src\*" -Destination $dst -Recurse -Force -ErrorAction Continue -ErrorVariable copyErrors
+        if ($copyErrors) {
+          "Copy-Item from $src to $dst encountered errors: $($copyErrors -join '; ')" | Out-File "$dst\no-logs.txt"
+          Write-Host "Copy-Item from $src to $dst encountered errors; wrote details to no-logs.txt."
+        } else {
+          Write-Host "Copied robot logs from $src to $dst"
+        }
       } else {
         "Robot log directory $src does not exist on this agent run." | Out-File "$dst\no-logs.txt"
         Write-Host "No robot logs found at $src; wrote placeholder."

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -99,6 +99,9 @@ jobs:
         if ($copyErrors) {
           "Copy-Item from $src to $dst encountered errors: $($copyErrors -join '; ')" | Out-File "$dst\no-logs.txt"
           Write-Host "Copy-Item from $src to $dst encountered errors; wrote details to no-logs.txt."
+        } elseif ((Get-ChildItem -Path $dst -Recurse -File | Measure-Object).Count -eq 0) {
+          "Source directory $src exists but contains no files; nothing was staged." | Out-File "$dst\no-logs.txt"
+          Write-Host "Source directory $src was empty; wrote placeholder."
         } else {
           Write-Host "Copied robot logs from $src to $dst"
         }

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -109,7 +109,7 @@ jobs:
     condition: always()
     inputs:
       PathToPublish: '$(System.ArtifactsDirectory)/RobotLogs'
-      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)'
+      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)_$(System.JobAttempt)'
       ArtifactType: 'Container'
 
   - ${{ each step in parameters.afterTestsCustomSteps }}:

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -90,6 +90,28 @@ jobs:
     displayName: 'Execute tests'
     env: ${{ parameters.environment }}
 
+  - powershell: |
+      $src = "$env:LOCALAPPDATA\UiPath\Logs"
+      $dst = "$(System.ArtifactsDirectory)\RobotLogs"
+      New-Item -ItemType Directory -Force -Path $dst | Out-Null
+      if (Test-Path $src) {
+        Copy-Item -Path "$src\*" -Destination $dst -Recurse -Force -ErrorAction Continue
+        Write-Host "Copied robot logs from $src to $dst"
+      } else {
+        "Robot log directory $src does not exist on this agent run." | Out-File "$dst\no-logs.txt"
+        Write-Host "No robot logs found at $src; wrote placeholder."
+      }
+    displayName: 'Stage robot logs'
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish robot logs'
+    condition: always()
+    inputs:
+      PathToPublish: '$(System.ArtifactsDirectory)/RobotLogs'
+      ArtifactName: 'RuntimeTestsLogs_$(System.StageName)'
+      ArtifactType: 'Container'
+
   - ${{ each step in parameters.afterTestsCustomSteps }}:
     - ${{ step }}
 

--- a/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
+++ b/Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml
@@ -97,16 +97,16 @@ jobs:
       if (Test-Path $src) {
         Copy-Item -Path "$src\*" -Destination $dst -Recurse -Force -ErrorAction Continue -ErrorVariable copyErrors
         if ($copyErrors) {
-          "Copy-Item from $src to $dst encountered errors: $($copyErrors -join '; ')" | Out-File "$dst\no-logs.txt"
-          Write-Host "Copy-Item from $src to $dst encountered errors; wrote details to no-logs.txt."
+          "Copy-Item from $src to $dst encountered errors: $($copyErrors -join '; ')" | Out-File "$dst\staging-errors.txt" -Encoding utf8
+          Write-Host "Copy-Item from $src to $dst encountered errors; wrote details to staging-errors.txt (some logs may still have been copied)."
         } elseif ((Get-ChildItem -Path $dst -Recurse -File | Measure-Object).Count -eq 0) {
-          "Source directory $src exists but contains no files; nothing was staged." | Out-File "$dst\no-logs.txt"
+          "Source directory $src exists but contains no files; nothing was staged." | Out-File "$dst\no-logs.txt" -Encoding utf8
           Write-Host "Source directory $src was empty; wrote placeholder."
         } else {
           Write-Host "Copied robot logs from $src to $dst"
         }
       } else {
-        "Robot log directory $src does not exist on this agent run." | Out-File "$dst\no-logs.txt"
+        "Robot log directory $src does not exist on this agent run." | Out-File "$dst\no-logs.txt" -Encoding utf8
         Write-Host "No robot logs found at $src; wrote placeholder."
       }
     displayName: 'Stage robot logs'


### PR DESCRIPTION
## Context

The shared runtime-tests stage templates (`Activities/.pipelines/jobs/stage.run.runtime.tests.windows.yml` and `…portable.yml`) are reused across every runtime-tests stage in the repo — Python, Database, Cryptography. Each stage downloads the test pack, executes the codedwf tests runner against a real UiPath Robot (Windows host-installed; Portable in a Linux container started by `docker-compose up -d robot`), and publishes the `results*.trx` test results. The Robot writes its own execution logs to the local `UiPath\Logs` directory on whichever host runs it.

## Problem Statement

Robot execution logs (containing the `LogMessage` activity output from the tested workflows) never leave the build agent. The codedwf tests runner does not stream Robot output to the ADO console, and the stage templates publish only `results*.trx` — nothing captures the Robot's local log directory. When the ephemeral hosted-agent VM is torn down at job end, those logs are gone. This is most painful exactly when a failure investigation needs them.

## Analysis

Verified on ADO run 12014946 (2026-05-13): a clean ~2-minute silent gap in the live console between `Start execution of Tests/SampleTest.xaml` and `Finishing: Execute tests`. The two `LogMessage` activities in `Activities/Python/UiPath.Python.RuntimeTests/Tests/SampleTest.xaml` (`"Start python test"`, `"Python Path: …"`) produced no console output and left no artifact behind. Robot logs *do* exist on disk during the run — at `%LOCALAPPDATA%\UiPath\Logs` on the Windows agent and at `/home/robotuser/.local/share/UiPath/Logs` inside the portable robot container — they're just never published.

Related: STUD=79858 (parent ticket, just a reference for context).

## Behavior Before This PR

A Python runtime-tests run on Windows executes `SampleTest.xaml`. The two `LogMessage` Warn entries are written to the Robot's local log file. The job finishes. The agent VM is recycled. The build's published artifacts contain `Packages` and `RuntimeTestsPackages` (test results land separately in the Tests tab via `PublishTestResults@2`, not in the Artifacts tab) — no Robot log files. A reviewer investigating a failure has no execution-time signal beyond the test runner's stdout.

## Behavior After This PR

Same scenario: the Robot writes `Execution_*.log` to disk during the run. After the test step (regardless of pass/fail — `condition: always()`), a new staging step copies the log directory into `$(System.ArtifactsDirectory)/RobotLogs`, and `PublishBuildArtifacts@1` publishes it as `RuntimeTestsLogs_<StageName>_<JobAttempt>`. The merged build produces one artifact per stage-attempt that ran (`RuntimeTestsLogs_PythonRuntimeTestsWindows_1`, `RuntimeTestsLogs_DatabaseRuntimeTestsWindows_1`, etc.). A reviewer downloads the artifact for the failing stage-attempt and reads the Robot's full execution log offline.

## Considered Use Cases

- **Test failure** — `condition: always()` on both steps so the artifact ships even when `Execute tests` / `Run tests` fails (the investigation-worthy case).
- **No Robot logs present on disk** — staging writes a `no-logs.txt` placeholder so `PublishBuildArtifacts@1` never fails on an empty path.
- **Shared template, multiple stages** — per-stage `$(System.StageName)` component on the artifact name prevents the collision that would otherwise occur across Python / Database / Cryptography (same lesson STUD=79858 baked in).
- **Stage rerun after failure** — per-attempt `$(System.JobAttempt)` component produces a distinct artifact per attempt (`…_1` for the failed run, `…_2` for the rerun), so the failed attempt's logs remain accessible and unambiguous instead of being merged or overwritten by the rerun's publish.
- **Portable container not running** — bash step uses `set +e` plus explicit `exit 0` plus a placeholder write, so a missing container does not fail the job.

## Implementation

In-container log path on Portable (`/home/robotuser/.local/share/UiPath/Logs`) is inferred from the standard Linux Robot config location (the same dir holds `UiPath.settings`) — it is the load-bearing assumption in this PR. The first portable pipeline run validates it: a portable artifact containing only `no-logs.txt` means the path needs adjusting.

## Caveats / Out of Scope

- Low-level Robot trace capture (`UiRobot.exe trace --enableLowLevel`) — separate follow-up if basic logs prove insufficient.
- Streaming Robot output to the ADO console live — that's a fix in the codedwf tests runner, not the pipeline templates.
- A `docker-compose.yml` bind-mount alternative was considered and rejected — larger blast radius (changes the runtime contract for every consumer of the compose file) for a best-effort log capture.

## How To Test

- [x] Open the linked ADO build for this PR. Confirm a `RuntimeTestsLogs_<StageName>_1` artifact appears for each runtime-tests stage (Python Windows, Python Portable, Database, Cryptography).
- [X] Download the Python Windows artifact. Open the `Execution_*.log` file produced during the `SampleTest.xaml` run and confirm the two `LogMessage` Warn entries (`"Start python test"`, `"Python Path: …"`) are present.
- [X] Confirm the existing `Packages` and `RuntimeTestsPackages` artifacts and the per-stage results in the **Tests** tab are unchanged from the develop baseline.