### PR TITLE
feat(cryptography): configurable AES key size for OpenSslEnc [STUD-80390]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricDecryptOptions.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricDecryptOptions.cs
@@ -18,7 +18,7 @@ namespace UiPath.Cryptography.Activities.API
         /// key size used at encrypt time (e.g. the <c>openssl enc -aes-128-cbc</c> producer).
         /// Applies only when the algorithm is AES; ignored otherwise. Default
         /// <see cref="AesKeySize.Aes256"/> matches today's hardcoded behaviour. Set only by
-        /// the <see cref="OpenSslEnc(PasswordKey, int, AesKeySize, Encoding)"/> factory.
+        /// the <see cref="OpenSslEnc(PasswordKey, int, Encoding, AesKeySize)"/> factory.
         /// </summary>
         public AesKeySize AesKeySize { get; private init; } = AesKeySize.Aes256;
 
@@ -52,13 +52,13 @@ namespace UiPath.Cryptography.Activities.API
         /// Pass <c>10_000</c> when reading output produced by <c>openssl enc -pbkdf2</c> without an explicit
         /// <c>-iter</c> flag (openssl's back-compat default).
         /// </param>
+        /// <param name="encoding">Plaintext encoding for <c>DecryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>DecryptBytes</c> / <c>DecryptFile</c>.</param>
         /// <param name="aesKeySize">
         /// AES key size — must match the value used at encrypt time (e.g.
         /// <c>openssl enc -aes-128-cbc</c> ↔ <see cref="AesKeySize.Aes128"/>). Ignored when the
         /// algorithm is not AES. Default <see cref="AesKeySize.Aes256"/>.
         /// </param>
-        /// <param name="encoding">Plaintext encoding for <c>DecryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>DecryptBytes</c> / <c>DecryptFile</c>.</param>
-        public static SymmetricDecryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, AesKeySize aesKeySize = AesKeySize.Aes256, Encoding encoding = null) =>
+        public static SymmetricDecryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null, AesKeySize aesKeySize = AesKeySize.Aes256) =>
             new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, AesKeySize = aesKeySize, TextEncoding = encoding ?? Encoding.UTF8 };
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricDecryptOptions.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricDecryptOptions.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using UiPath.Cryptography.Enums;
 
 namespace UiPath.Cryptography.Activities.API
 {
@@ -11,6 +12,15 @@ namespace UiPath.Cryptography.Activities.API
     public sealed class SymmetricDecryptOptions : CryptoOptions
     {
         private SymmetricDecryptOptions() { }
+
+        /// <summary>
+        /// AES key size for <see cref="SymmetricWireFormat.OpenSslEnc"/>. Must match the
+        /// key size used at encrypt time (e.g. the <c>openssl enc -aes-128-cbc</c> producer).
+        /// Applies only when the algorithm is AES; ignored otherwise. Default
+        /// <see cref="AesKeySize.Aes256"/> matches today's hardcoded behaviour. Set only by
+        /// the <see cref="OpenSslEnc(PasswordKey, int, AesKeySize, Encoding)"/> factory.
+        /// </summary>
+        public AesKeySize AesKeySize { get; private init; } = AesKeySize.Aes256;
 
         /// <summary>Decrypts <see cref="SymmetricWireFormat.Classic"/> ciphertext.</summary>
         /// <param name="key">Password material; must match the key used at encrypt time.</param>
@@ -42,8 +52,13 @@ namespace UiPath.Cryptography.Activities.API
         /// Pass <c>10_000</c> when reading output produced by <c>openssl enc -pbkdf2</c> without an explicit
         /// <c>-iter</c> flag (openssl's back-compat default).
         /// </param>
+        /// <param name="aesKeySize">
+        /// AES key size — must match the value used at encrypt time (e.g.
+        /// <c>openssl enc -aes-128-cbc</c> ↔ <see cref="AesKeySize.Aes128"/>). Ignored when the
+        /// algorithm is not AES. Default <see cref="AesKeySize.Aes256"/>.
+        /// </param>
         /// <param name="encoding">Plaintext encoding for <c>DecryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>DecryptBytes</c> / <c>DecryptFile</c>.</param>
-        public static SymmetricDecryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null) =>
-            new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, TextEncoding = encoding ?? Encoding.UTF8 };
+        public static SymmetricDecryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, AesKeySize aesKeySize = AesKeySize.Aes256, Encoding encoding = null) =>
+            new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, AesKeySize = aesKeySize, TextEncoding = encoding ?? Encoding.UTF8 };
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricEncryptOptions.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricEncryptOptions.cs
@@ -27,7 +27,7 @@ namespace UiPath.Cryptography.Activities.API
         /// the algorithm is AES; ignored by every other algorithm and every other wire format.
         /// Default <see cref="AesKeySize.Aes256"/> matches today's hardcoded behaviour, so
         /// existing AES-256 callers are unaffected. Set only by the
-        /// <see cref="OpenSslEnc(PasswordKey, int, AesKeySize, Encoding)"/> factory.
+        /// <see cref="OpenSslEnc(PasswordKey, int, Encoding, AesKeySize)"/> factory.
         /// </summary>
         public AesKeySize AesKeySize { get; private init; } = AesKeySize.Aes256;
 
@@ -95,14 +95,14 @@ namespace UiPath.Cryptography.Activities.API
         /// decryptable by <c>openssl enc -pbkdf2 -iter 600000 -md sha256</c>.) Pass <c>10_000</c>
         /// to match the openssl back-compat default explicitly.
         /// </param>
+        /// <param name="encoding">Plaintext encoding for <c>EncryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>EncryptBytes</c> / <c>EncryptFile</c>.</param>
         /// <param name="aesKeySize">
         /// AES key size — <see cref="AesKeySize.Aes128"/>, <see cref="AesKeySize.Aes192"/>, or
         /// <see cref="AesKeySize.Aes256"/> (default). Set to match the peer's
         /// <c>openssl enc -aes-128-cbc</c> / <c>-aes-192-cbc</c> / <c>-aes-256-cbc</c> choice.
         /// Ignored when the algorithm is not AES.
         /// </param>
-        /// <param name="encoding">Plaintext encoding for <c>EncryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>EncryptBytes</c> / <c>EncryptFile</c>.</param>
-        public static SymmetricEncryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, AesKeySize aesKeySize = AesKeySize.Aes256, Encoding encoding = null) =>
+        public static SymmetricEncryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null, AesKeySize aesKeySize = AesKeySize.Aes256) =>
             new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, AesKeySize = aesKeySize, TextEncoding = encoding ?? Encoding.UTF8 };
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricEncryptOptions.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Models/SymmetricEncryptOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using UiPath.Cryptography.Enums;
 
 namespace UiPath.Cryptography.Activities.API
 {
@@ -20,6 +21,15 @@ namespace UiPath.Cryptography.Activities.API
         /// <see cref="Raw(RawKey, byte[], Encoding)"/> factory.
         /// </summary>
         public byte[] IV { get; private init; }
+
+        /// <summary>
+        /// AES key size for <see cref="SymmetricWireFormat.OpenSslEnc"/>. Applies only when
+        /// the algorithm is AES; ignored by every other algorithm and every other wire format.
+        /// Default <see cref="AesKeySize.Aes256"/> matches today's hardcoded behaviour, so
+        /// existing AES-256 callers are unaffected. Set only by the
+        /// <see cref="OpenSslEnc(PasswordKey, int, AesKeySize, Encoding)"/> factory.
+        /// </summary>
+        public AesKeySize AesKeySize { get; private init; } = AesKeySize.Aes256;
 
         /// <summary>Produces <see cref="SymmetricWireFormat.Classic"/> output — UiPath's frozen, byte-stable layout (PBKDF2-HMAC-SHA1 @ 10 000 iter).</summary>
         /// <param name="key">Password material; PBKDF2 stretches it to the cipher key.</param>
@@ -85,8 +95,14 @@ namespace UiPath.Cryptography.Activities.API
         /// decryptable by <c>openssl enc -pbkdf2 -iter 600000 -md sha256</c>.) Pass <c>10_000</c>
         /// to match the openssl back-compat default explicitly.
         /// </param>
+        /// <param name="aesKeySize">
+        /// AES key size — <see cref="AesKeySize.Aes128"/>, <see cref="AesKeySize.Aes192"/>, or
+        /// <see cref="AesKeySize.Aes256"/> (default). Set to match the peer's
+        /// <c>openssl enc -aes-128-cbc</c> / <c>-aes-192-cbc</c> / <c>-aes-256-cbc</c> choice.
+        /// Ignored when the algorithm is not AES.
+        /// </param>
         /// <param name="encoding">Plaintext encoding for <c>EncryptText</c>. Null defaults to <see cref="Encoding.UTF8"/>; ignored by <c>EncryptBytes</c> / <c>EncryptFile</c>.</param>
-        public static SymmetricEncryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null) =>
-            new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, TextEncoding = encoding ?? Encoding.UTF8 };
+        public static SymmetricEncryptOptions OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, AesKeySize aesKeySize = AesKeySize.Aes256, Encoding encoding = null) =>
+            new() { Key = key, Format = SymmetricWireFormat.OpenSslEnc, KdfIterations = kdfIterations, AesKeySize = aesKeySize, TextEncoding = encoding ?? Encoding.UTF8 };
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Services/CryptographyService.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Services/CryptographyService.cs
@@ -19,7 +19,7 @@ namespace UiPath.Cryptography.Activities.API
             ArgumentNullException.ThrowIfNull(options);
             ValidateSymmetric(algorithm, options, options.IV);
             return options.Key.UseKeyBytes(keyBytes =>
-                SymmetricInteropHelper.DispatchEncrypt(algorithm, options.Format, options.KdfIterations, keyBytes, options.IV, input));
+                SymmetricInteropHelper.DispatchEncrypt(algorithm, options.Format, options.KdfIterations, keyBytes, options.IV, input, options.AesKeySize));
         }
 
         public byte[] DecryptBytes(byte[] input, EncryptionAlgorithm algorithm, SymmetricDecryptOptions options)
@@ -28,7 +28,7 @@ namespace UiPath.Cryptography.Activities.API
             ArgumentNullException.ThrowIfNull(options);
             ValidateSymmetric(algorithm, options, iv: null);
             return options.Key.UseKeyBytes(keyBytes =>
-                SymmetricInteropHelper.DispatchDecrypt(algorithm, options.Format, options.KdfIterations, keyBytes, input));
+                SymmetricInteropHelper.DispatchDecrypt(algorithm, options.Format, options.KdfIterations, keyBytes, input, options.AesKeySize));
         }
 
         public string EncryptText(string input, EncryptionAlgorithm algorithm, SymmetricEncryptOptions options)

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/coded-api.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/coded-api.md
@@ -72,7 +72,7 @@ The options object bundles the key, wire format, and any format-specific knobs (
 | `SymmetricEncryptOptions.Classic(PasswordKey key, Encoding encoding = null)` / `SymmetricDecryptOptions.Classic(PasswordKey key, Encoding encoding = null)` | `Classic` | `PasswordKey` | Default. Frozen wire format for back-compat (PBKDF2-HMAC-SHA1 @ 10 000 iter). |
 | `SymmetricEncryptOptions.Owasp2026(PasswordKey key, int kdfIterations = 1_300_000, Encoding encoding = null)` | `Owasp2026` | `PasswordKey` | Same wire layout as Classic with PBKDF2-HMAC-SHA1 at OWASP 2026's recommended iteration count. |
 | `SymmetricEncryptOptions.Raw(RawKey key, byte[] iv = null, Encoding encoding = null)` / `SymmetricDecryptOptions.Raw(RawKey key, Encoding encoding = null)` | `Raw` | `RawKey` | Caller-supplied key + IV. Third-party interop. |
-| `SymmetricEncryptOptions.OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null)` | `OpenSslEnc` | `PasswordKey` | `openssl enc`-compatible (`Salted__` magic + PBKDF2-HMAC-SHA256). |
+| `SymmetricEncryptOptions.OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null, AesKeySize aesKeySize = AesKeySize.Aes256)` | `OpenSslEnc` | `PasswordKey` | `openssl enc`-compatible (`Salted__` magic + PBKDF2-HMAC-SHA256). `aesKeySize` selects AES-128 / -192 / -256 to match the peer's `openssl enc -aes-N-cbc`. |
 
 The decrypt factories take the same shape (no `IV` on the decrypt side — the IV is read from the ciphertext stream automatically). The optional `encoding:` parameter sets `TextEncoding` on the options (defaults to UTF-8) and is only consulted by `EncryptText` / `DecryptText`.
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using UiPath.Cryptography.Enums;
 using Xunit;
 
 #pragma warning disable CS0618 // obsolete algorithms reachable via opt-in formats
@@ -34,32 +35,36 @@ namespace UiPath.Cryptography.Activities.Tests
         // ────────────────────────────────────────────────────────────────────────
 
         [Theory]
-        [InlineData(600_000)]
-        [InlineData(50_000)]
-        public void OpenSslEnc_AesCbc_ExternalToInternal(int iterations)
+        [InlineData(600_000, AesKeySize.Aes128)]
+        [InlineData(600_000, AesKeySize.Aes192)]
+        [InlineData(600_000, AesKeySize.Aes256)]
+        [InlineData(50_000, AesKeySize.Aes256)]
+        public void OpenSslEnc_AesCbc_ExternalToInternal(int iterations, AesKeySize aesKeySize)
         {
             byte[] plainBytes = Encoding.UTF8.GetBytes(Plaintext);
-            byte[] externalBlob = BclOpenSslEnc.EncryptAesCbc(plainBytes, Password, iterations);
+            byte[] externalBlob = BclOpenSslEnc.EncryptAesCbc(plainBytes, Password, iterations, (int)aesKeySize / 8);
 
             string decrypted = RunDecryptText(
                 EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
                 password: Password, input: Convert.ToBase64String(externalBlob),
-                inputEncoding: Encoding.UTF8, iterations: iterations);
+                inputEncoding: Encoding.UTF8, iterations: iterations, aesKeySize: aesKeySize);
 
             Assert.Equal(Plaintext, decrypted);
         }
 
         [Theory]
-        [InlineData(600_000)]
-        [InlineData(50_000)]
-        public void OpenSslEnc_AesCbc_InternalToExternal(int iterations)
+        [InlineData(600_000, AesKeySize.Aes128)]
+        [InlineData(600_000, AesKeySize.Aes192)]
+        [InlineData(600_000, AesKeySize.Aes256)]
+        [InlineData(50_000, AesKeySize.Aes256)]
+        public void OpenSslEnc_AesCbc_InternalToExternal(int iterations, AesKeySize aesKeySize)
         {
             string encryptedBase64 = RunEncryptText(
                 EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
-                password: Password, inputEncoding: Encoding.UTF8, iterations: iterations);
+                password: Password, inputEncoding: Encoding.UTF8, iterations: iterations, aesKeySize: aesKeySize);
 
             byte[] blob = Convert.FromBase64String(encryptedBase64);
-            byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations);
+            byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations, (int)aesKeySize / 8);
 
             Assert.Equal(Plaintext, Encoding.UTF8.GetString(decrypted));
         }
@@ -238,11 +243,11 @@ namespace UiPath.Cryptography.Activities.Tests
             private const int AeadIvSize = 12;
             private const int AeadTagSize = 16;
 
-            public static byte[] EncryptAesCbc(byte[] plain, string password, int iterations)
+            public static byte[] EncryptAesCbc(byte[] plain, string password, int iterations, int keySizeBytes = AesCbcKeySize)
             {
                 byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
                 byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
-                (byte[] key, byte[] iv) = DeriveKeyAndIv(passwordBytes, salt, iterations, AesCbcKeySize, AesCbcIvSize);
+                (byte[] key, byte[] iv) = DeriveKeyAndIv(passwordBytes, salt, iterations, keySizeBytes, AesCbcIvSize);
 
                 byte[] cipher;
                 using (var aes = Aes.Create())
@@ -260,14 +265,14 @@ namespace UiPath.Cryptography.Activities.Tests
                 return Concat(Magic, salt, cipher);
             }
 
-            public static byte[] DecryptAesCbc(byte[] blob, string password, int iterations)
+            public static byte[] DecryptAesCbc(byte[] blob, string password, int iterations, int keySizeBytes = AesCbcKeySize)
             {
                 AssertMagicPrefix(blob);
                 byte[] salt = blob.AsSpan(Magic.Length, SaltSize).ToArray();
                 byte[] cipher = blob.AsSpan(Magic.Length + SaltSize).ToArray();
 
                 byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
-                (byte[] key, byte[] iv) = DeriveKeyAndIv(passwordBytes, salt, iterations, AesCbcKeySize, AesCbcIvSize);
+                (byte[] key, byte[] iv) = DeriveKeyAndIv(passwordBytes, salt, iterations, keySizeBytes, AesCbcIvSize);
 
                 using var aes = Aes.Create();
                 aes.Key = key;
@@ -509,7 +514,8 @@ namespace UiPath.Cryptography.Activities.Tests
             string key = null,
             string iv = null,
             int iterations = 0,
-            Encoding inputEncoding = null)
+            Encoding inputEncoding = null,
+            AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new EncryptText
             {
@@ -518,6 +524,7 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                AesKeySize = aesKeySize,
             };
 
             var args = new Dictionary<string, object>
@@ -547,7 +554,8 @@ namespace UiPath.Cryptography.Activities.Tests
             string password = null,
             string key = null,
             int iterations = 0,
-            Encoding inputEncoding = null)
+            Encoding inputEncoding = null,
+            AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new DecryptText
             {
@@ -556,6 +564,7 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                AesKeySize = aesKeySize,
             };
 
             var args = new Dictionary<string, object>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropOpenSslCliTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropOpenSslCliTests.cs
@@ -32,14 +32,12 @@ namespace UiPath.Cryptography.Activities.Tests
         // openssl enc → UiPath DecryptText
         // ────────────────────────────────────────────────────────────────────────
 
-        // NOTE: UiPath's OpenSslEnc format derives the maximum legal key size for the algorithm
-        // (AES → 256-bit / 32 bytes), so only aes-256-cbc rounds-trips with the activity surface.
-        // openssl-side aes-128-cbc would require a key-size knob on the activity that doesn't
-        // exist today — this is a known limitation, not a test gap.
         [Theory]
-        [InlineData("aes-256-cbc", 600_000)]
-        [InlineData("aes-256-cbc", 50_000)]
-        public void OpenSslCli_Encrypts_UiPathDecrypts(string opensslAlgorithm, int iterations)
+        [InlineData("aes-128-cbc", 600_000, AesKeySize.Aes128)]
+        [InlineData("aes-192-cbc", 600_000, AesKeySize.Aes192)]
+        [InlineData("aes-256-cbc", 600_000, AesKeySize.Aes256)]
+        [InlineData("aes-256-cbc", 50_000, AesKeySize.Aes256)]
+        public void OpenSslCli_Encrypts_UiPathDecrypts(string opensslAlgorithm, int iterations, AesKeySize aesKeySize)
         {
             if (!OpenSslAvailable) return; // no-op when openssl is missing
 
@@ -67,7 +65,7 @@ namespace UiPath.Cryptography.Activities.Tests
                 string decrypted = RunDecryptText(
                     EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
                     password: Password, input: base64,
-                    inputEncoding: Encoding.UTF8, iterations: iterations);
+                    inputEncoding: Encoding.UTF8, iterations: iterations, aesKeySize: aesKeySize);
 
                 decrypted.ShouldBe(Plaintext);
             }
@@ -82,9 +80,11 @@ namespace UiPath.Cryptography.Activities.Tests
         // ────────────────────────────────────────────────────────────────────────
 
         [Theory]
-        [InlineData("aes-256-cbc", 600_000)]
-        [InlineData("aes-256-cbc", 50_000)]
-        public void UiPathEncrypts_OpenSslCli_Decrypts(string opensslAlgorithm, int iterations)
+        [InlineData("aes-128-cbc", 600_000, AesKeySize.Aes128)]
+        [InlineData("aes-192-cbc", 600_000, AesKeySize.Aes192)]
+        [InlineData("aes-256-cbc", 600_000, AesKeySize.Aes256)]
+        [InlineData("aes-256-cbc", 50_000, AesKeySize.Aes256)]
+        public void UiPathEncrypts_OpenSslCli_Decrypts(string opensslAlgorithm, int iterations, AesKeySize aesKeySize)
         {
             if (!OpenSslAvailable) return;
 
@@ -94,7 +94,7 @@ namespace UiPath.Cryptography.Activities.Tests
             {
                 string encrypted = RunEncryptText(
                     EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
-                    password: Password, iterations: iterations, inputEncoding: Encoding.UTF8);
+                    password: Password, iterations: iterations, inputEncoding: Encoding.UTF8, aesKeySize: aesKeySize);
 
                 File.WriteAllBytes(cipherPath, Convert.FromBase64String(encrypted));
 
@@ -186,7 +186,7 @@ namespace UiPath.Cryptography.Activities.Tests
         }
 
         private static string RunEncryptText(EncryptionAlgorithm algorithm, SymmetricWireFormat format, KeyBytesFormat keyFormat,
-            string password = null, int iterations = 0, Encoding inputEncoding = null)
+            string password = null, int iterations = 0, Encoding inputEncoding = null, AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new EncryptText
             {
@@ -195,6 +195,7 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                AesKeySize = aesKeySize,
             };
             var args = new Dictionary<string, object>
             {
@@ -207,7 +208,7 @@ namespace UiPath.Cryptography.Activities.Tests
         }
 
         private static string RunDecryptText(EncryptionAlgorithm algorithm, SymmetricWireFormat format, KeyBytesFormat keyFormat,
-            string input, string password = null, int iterations = 0, Encoding inputEncoding = null)
+            string input, string password = null, int iterations = 0, Encoding inputEncoding = null, AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new DecryptText
             {
@@ -216,6 +217,7 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                AesKeySize = aesKeySize,
             };
             var args = new Dictionary<string, object>
             {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptFile.cs
@@ -85,6 +85,12 @@ namespace UiPath.Cryptography.Activities
         [LocalizedDescription(nameof(Resources.Activity_DecryptFile_Property_KdfIterations_Description))]
         public InArgument<int> KdfIterations { get; set; }
 
+        [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_DecryptFile_Property_AesKeySize_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_DecryptFile_Property_AesKeySize_Description))]
+        [DefaultValue(AesKeySize.Aes256)]
+        public AesKeySize AesKeySize { get; set; } = AesKeySize.Aes256;
+
         [Browsable(false)]
         [Obsolete("Legacy property kept for XAML back-compat with workflows that persisted the active file input mode. The activity now infers the mode from which side is bound.")]
         public FileInputMode FileInputModeSwitch { get; set; }
@@ -289,7 +295,7 @@ namespace UiPath.Cryptography.Activities
                 {
                     try
                     {
-                        return SymmetricInteropHelper.DispatchDecrypt(Algorithm, Format, iterations, k, encrypted);
+                        return SymmetricInteropHelper.DispatchDecrypt(Algorithm, Format, iterations, k, encrypted, AesKeySize);
                     }
                     catch (CryptographicException ex)
                     {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
@@ -76,6 +76,12 @@ namespace UiPath.Cryptography.Activities
         [LocalizedDescription(nameof(Resources.Activity_DecryptText_Property_KdfIterations_Description))]
         public InArgument<int> KdfIterations { get; set; }
 
+        [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_DecryptText_Property_AesKeySize_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_DecryptText_Property_AesKeySize_Description))]
+        [DefaultValue(AesKeySize.Aes256)]
+        public AesKeySize AesKeySize { get; set; } = AesKeySize.Aes256;
+
         [LocalizedCategory(nameof(Resources.Output))]
         [LocalizedDisplayName(nameof(Resources.Activity_DecryptText_Property_Result_Name))]
         [LocalizedDescription(nameof(Resources.Activity_DecryptText_Property_Result_Description))]
@@ -238,7 +244,7 @@ namespace UiPath.Cryptography.Activities
                     try
                     {
                         return SymmetricInteropHelper.DispatchDecrypt(
-                            Algorithm, Format, iterations, k, Convert.FromBase64String(input));
+                            Algorithm, Format, iterations, k, Convert.FromBase64String(input), AesKeySize);
                     }
                     catch (CryptographicException ex)
                     {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
@@ -101,6 +101,12 @@ namespace UiPath.Cryptography.Activities
         public InArgument<int> KdfIterations { get; set; }
 
         [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_EncryptFile_Property_AesKeySize_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_EncryptFile_Property_AesKeySize_Description))]
+        [DefaultValue(AesKeySize.Aes256)]
+        public AesKeySize AesKeySize { get; set; } = AesKeySize.Aes256;
+
+        [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_EncryptFile_Property_OutputFilePath_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EncryptFile_Property_OutputFilePath_Description))]
         public InArgument<string> OutputFilePath { get; set; }
@@ -264,7 +270,7 @@ namespace UiPath.Cryptography.Activities
                 keyString: key, keySecureString: keySecureString,
                 ivString: ivString, kdfIterations: iterations, needsIv: true,
                 dispatch: (k, iv) => SymmetricInteropHelper.DispatchEncrypt(
-                    Algorithm, Format, iterations, k, iv, inputBytes));
+                    Algorithm, Format, iterations, k, iv, inputBytes, AesKeySize));
         }
 
         private byte[] ExecutePgpEncrypt(CodeActivityContext context, string inputPath)

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -81,6 +81,12 @@ namespace UiPath.Cryptography.Activities
         [LocalizedDescription(nameof(Resources.Activity_EncryptText_Property_KdfIterations_Description))]
         public InArgument<int> KdfIterations { get; set; }
 
+        [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_EncryptText_Property_AesKeySize_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_EncryptText_Property_AesKeySize_Description))]
+        [DefaultValue(AesKeySize.Aes256)]
+        public AesKeySize AesKeySize { get; set; } = AesKeySize.Aes256;
+
         [LocalizedCategory(nameof(Resources.Output))]
         [LocalizedDisplayName(nameof(Resources.Activity_EncryptText_Property_Result_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EncryptText_Property_Result_Description))]
@@ -247,7 +253,7 @@ namespace UiPath.Cryptography.Activities
                 keyString: key, keySecureString: keySecureString,
                 ivString: ivString, kdfIterations: iterations, needsIv: true,
                 dispatch: (k, iv) => SymmetricInteropHelper.DispatchEncrypt(
-                    Algorithm, Format, iterations, k, iv, keyEncoding.GetBytes(input)));
+                    Algorithm, Format, iterations, k, iv, keyEncoding.GetBytes(input), AesKeySize));
 
             return Convert.ToBase64String(encrypted);
         }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -71,6 +71,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         public DesignProperty<SymmetricWireFormat> Format { get; set; } = new DesignProperty<SymmetricWireFormat>();
         public DesignProperty<KeyBytesFormat> KeyFormat { get; set; } = new DesignProperty<KeyBytesFormat>();
         public DesignInArgument<int> KdfIterations { get; set; } = new DesignInArgument<int>();
+        public DesignProperty<AesKeySize> AesKeySize { get; set; } = new DesignProperty<AesKeySize>();
 
         /// <summary>
         /// Configures Algorithm dropdown, Key, KeySecureString, and KeyEncodingString properties.
@@ -148,6 +149,17 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             KdfIterations.IsVisible = false;
             KdfIterations.OrderIndex = orderIndex++;
             KdfIterations.Category = Resources.Input;
+
+            AesKeySize.IsPrincipal = false;
+            AesKeySize.IsVisible = false;
+            AesKeySize.OrderIndex = orderIndex++;
+            AesKeySize.Category = Resources.Input;
+            AesKeySize.DataSource = DataSourceHelper.ForEnum(
+                Enums.AesKeySize.Aes128,
+                Enums.AesKeySize.Aes192,
+                Enums.AesKeySize.Aes256);
+            AesKeySize.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
+            AesKeySize.Value = Enums.AesKeySize.Aes256;
         }
 
         /// <summary>
@@ -305,10 +317,12 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             bool isPgp = Algorithm.Value == EncryptionAlgorithm.PGP;
             bool isRaw = Format.Value == SymmetricWireFormat.Raw;
             bool isOwasp2026OrOpenSsl = Format.Value == SymmetricWireFormat.Owasp2026 || Format.Value == SymmetricWireFormat.OpenSslEnc;
+            bool isOpenSslAes = Format.Value == SymmetricWireFormat.OpenSslEnc && Algorithm.Value == EncryptionAlgorithm.AES;
 
             Format.IsVisible = !isPgp;
             KeyFormat.IsVisible = !isPgp && isRaw;
             KdfIterations.IsVisible = !isPgp && isOwasp2026OrOpenSsl;
+            AesKeySize.IsVisible = !isPgp && isOpenSslAes;
 
             // Surface the underlying KDF in the visible label so the iteration count's effect is unambiguous.
             if (KdfIterations.IsVisible)

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -8,6 +8,7 @@ using UiPath.Cryptography.Activities.Helpers;
 using UiPath.Cryptography.Activities.Properties;
 using UiPath.Cryptography.Enums;
 using UiPath.Platform.ResourceHandling;
+using AesKeySizeEnum = UiPath.Cryptography.Enums.AesKeySize;
 
 #pragma warning disable CS0618 // obsolete encryption algorithm
 
@@ -155,11 +156,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             AesKeySize.OrderIndex = orderIndex++;
             AesKeySize.Category = Resources.Input;
             AesKeySize.DataSource = DataSourceHelper.ForEnum(
-                Enums.AesKeySize.Aes128,
-                Enums.AesKeySize.Aes192,
-                Enums.AesKeySize.Aes256);
+                AesKeySizeEnum.Aes128,
+                AesKeySizeEnum.Aes192,
+                AesKeySizeEnum.Aes256);
             AesKeySize.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
-            AesKeySize.Value = Enums.AesKeySize.Aes256;
+            AesKeySize.Value = AesKeySizeEnum.Aes256;
         }
 
         /// <summary>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -10,6 +10,7 @@ using UiPath.Cryptography.Activities.Helpers;
 using UiPath.Cryptography.Activities.Properties;
 using UiPath.Cryptography.Enums;
 using UiPath.Platform.ResourceHandling;
+using AesKeySizeEnum = UiPath.Cryptography.Enums.AesKeySize;
 
 #pragma warning disable CS0618 // obsolete encryption algorithm
 
@@ -175,11 +176,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             AesKeySize.OrderIndex = orderIndex++;
             AesKeySize.Category = Resources.Input;
             AesKeySize.DataSource = DataSourceHelper.ForEnum(
-                Enums.AesKeySize.Aes128,
-                Enums.AesKeySize.Aes192,
-                Enums.AesKeySize.Aes256);
+                AesKeySizeEnum.Aes128,
+                AesKeySizeEnum.Aes192,
+                AesKeySizeEnum.Aes256);
             AesKeySize.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
-            AesKeySize.Value = Enums.AesKeySize.Aes256;
+            AesKeySize.Value = AesKeySizeEnum.Aes256;
         }
 
         /// <summary>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -77,6 +77,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         public DesignProperty<KeyBytesFormat> KeyFormat { get; set; } = new DesignProperty<KeyBytesFormat>();
         public DesignInArgument<string> Iv { get; set; } = new DesignInArgument<string>();
         public DesignInArgument<int> KdfIterations { get; set; } = new DesignInArgument<int>();
+        public DesignProperty<AesKeySize> AesKeySize { get; set; } = new DesignProperty<AesKeySize>();
 
         /// <summary>
         /// Configures Algorithm dropdown, DeprecatedWarning, Key, KeySecureString,
@@ -168,6 +169,17 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             KdfIterations.IsVisible = false;
             KdfIterations.OrderIndex = orderIndex++;
             KdfIterations.Category = Resources.Input;
+
+            AesKeySize.IsPrincipal = false;
+            AesKeySize.IsVisible = false;
+            AesKeySize.OrderIndex = orderIndex++;
+            AesKeySize.Category = Resources.Input;
+            AesKeySize.DataSource = DataSourceHelper.ForEnum(
+                Enums.AesKeySize.Aes128,
+                Enums.AesKeySize.Aes192,
+                Enums.AesKeySize.Aes256);
+            AesKeySize.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown };
+            AesKeySize.Value = Enums.AesKeySize.Aes256;
         }
 
         /// <summary>
@@ -326,11 +338,13 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             bool isPgp = Algorithm.Value == EncryptionAlgorithm.PGP;
             bool isRaw = Format.Value == SymmetricWireFormat.Raw;
             bool isOwasp2026OrOpenSsl = Format.Value == SymmetricWireFormat.Owasp2026 || Format.Value == SymmetricWireFormat.OpenSslEnc;
+            bool isOpenSslAes = Format.Value == SymmetricWireFormat.OpenSslEnc && Algorithm.Value == EncryptionAlgorithm.AES;
 
             Format.IsVisible = !isPgp;
             KeyFormat.IsVisible = !isPgp && isRaw;
             Iv.IsVisible = !isPgp && isRaw;
             KdfIterations.IsVisible = !isPgp && isOwasp2026OrOpenSsl;
+            AesKeySize.IsVisible = !isPgp && isOpenSslAes;
 
             // Surface the underlying KDF in the visible label so the iteration count's effect is unambiguous.
             if (KdfIterations.IsVisible)

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
@@ -221,7 +221,25 @@ namespace UiPath.Cryptography.Activities.Properties {
                 return ResourceManager.GetString("Activity_DecryptFile_Property_KdfIterations_Name", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc.
+        /// </summary>
+        public static string Activity_DecryptFile_Property_AesKeySize_Description {
+            get {
+                return ResourceManager.GetString("Activity_DecryptFile_Property_AesKeySize_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size.
+        /// </summary>
+        public static string Activity_DecryptFile_Property_AesKeySize_Name {
+            get {
+                return ResourceManager.GetString("Activity_DecryptFile_Property_AesKeySize_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The key that you want to use to decrypt the specified file..
         /// </summary>
@@ -617,7 +635,25 @@ namespace UiPath.Cryptography.Activities.Properties {
                 return ResourceManager.GetString("Activity_DecryptText_Property_KdfIterations_Name", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc.
+        /// </summary>
+        public static string Activity_DecryptText_Property_AesKeySize_Description {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_AesKeySize_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size.
+        /// </summary>
+        public static string Activity_DecryptText_Property_AesKeySize_Name {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_AesKeySize_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The key that you want to use to decrypt the specified file..
         /// </summary>
@@ -1022,7 +1058,25 @@ namespace UiPath.Cryptography.Activities.Properties {
                 return ResourceManager.GetString("Activity_EncryptFile_Property_KdfIterations_Name", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc.
+        /// </summary>
+        public static string Activity_EncryptFile_Property_AesKeySize_Description {
+            get {
+                return ResourceManager.GetString("Activity_EncryptFile_Property_AesKeySize_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size.
+        /// </summary>
+        public static string Activity_EncryptFile_Property_AesKeySize_Name {
+            get {
+                return ResourceManager.GetString("Activity_EncryptFile_Property_AesKeySize_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The key that you want to use to encrypt the specified file..
         /// </summary>
@@ -1436,7 +1490,25 @@ namespace UiPath.Cryptography.Activities.Properties {
                 return ResourceManager.GetString("Activity_EncryptText_Property_KdfIterations_Name", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc.
+        /// </summary>
+        public static string Activity_EncryptText_Property_AesKeySize_Description {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_AesKeySize_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AES key size.
+        /// </summary>
+        public static string Activity_EncryptText_Property_AesKeySize_Name {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_AesKeySize_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The key that you want to use to encrypt the specified file..
         /// </summary>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -1478,6 +1478,14 @@
     <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
     <comment>Property description</comment>
   </data>
+  <data name="Activity_EncryptText_Property_AesKeySize_Name" xml:space="preserve">
+    <value>AES key size</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_EncryptText_Property_AesKeySize_Description" xml:space="preserve">
+    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. Default: 256-bit.</value>
+    <comment>Property description</comment>
+  </data>
 
   <data name="Activity_DecryptText_Property_Format_Name" xml:space="preserve">
     <value>Wire format</value>
@@ -1501,6 +1509,14 @@
   </data>
   <data name="Activity_DecryptText_Property_KdfIterations_Description" xml:space="preserve">
     <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_AesKeySize_Name" xml:space="preserve">
+    <value>AES key size</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_AesKeySize_Description" xml:space="preserve">
+    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 
@@ -1536,6 +1552,14 @@
     <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
     <comment>Property description</comment>
   </data>
+  <data name="Activity_EncryptFile_Property_AesKeySize_Name" xml:space="preserve">
+    <value>AES key size</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_EncryptFile_Property_AesKeySize_Description" xml:space="preserve">
+    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. Default: 256-bit.</value>
+    <comment>Property description</comment>
+  </data>
 
   <data name="Activity_DecryptFile_Property_Format_Name" xml:space="preserve">
     <value>Wire format</value>
@@ -1559,6 +1583,14 @@
   </data>
   <data name="Activity_DecryptFile_Property_KdfIterations_Description" xml:space="preserve">
     <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_DecryptFile_Property_AesKeySize_Name" xml:space="preserve">
+    <value>AES key size</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_DecryptFile_Property_AesKeySize_Description" xml:space="preserve">
+    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -1483,7 +1483,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptText_Property_AesKeySize_Description" xml:space="preserve">
-    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. Default: 256-bit.</value>
+    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. The selected key size is not stored in the wire format — encrypt and decrypt sides must use matching values. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 
@@ -1516,7 +1516,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptText_Property_AesKeySize_Description" xml:space="preserve">
-    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. Default: 256-bit.</value>
+    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. The selected key size is not stored in the wire format — encrypt and decrypt sides must use matching values. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 
@@ -1557,7 +1557,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptFile_Property_AesKeySize_Description" xml:space="preserve">
-    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. Default: 256-bit.</value>
+    <value>AES key size in bits. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the peer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) uses. The selected key size is not stored in the wire format — encrypt and decrypt sides must use matching values. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 
@@ -1590,7 +1590,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptFile_Property_AesKeySize_Description" xml:space="preserve">
-    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. Default: 256-bit.</value>
+    <value>AES key size in bits used to encrypt the input. Applies only when Algorithm = AES and Format = OpenSslEnc; ignored otherwise. Must match the key size the producer (e.g. openssl enc -aes-128-cbc / -aes-192-cbc / -aes-256-cbc) used. The selected key size is not stored in the wire format — encrypt and decrypt sides must use matching values. Default: 256-bit.</value>
     <comment>Property description</comment>
   </data>
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -1475,7 +1475,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptText_Property_KdfIterations_Description" xml:space="preserve">
-    <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
+    <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Note: plain `openssl enc -pbkdf2 -md sha256` defaults to 10,000 iterations for back-compat — to round-trip with the CLI you must either pass `-iter 600000` on the openssl side or set this property to 10000. Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_EncryptText_Property_AesKeySize_Name" xml:space="preserve">
@@ -1508,7 +1508,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptText_Property_KdfIterations_Description" xml:space="preserve">
-    <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count.</value>
+    <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count. Note: plain `openssl enc -pbkdf2 -md sha256` defaults to 10,000 iterations — when reading openssl CLI output produced without an explicit `-iter` flag, set this property to 10000.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_DecryptText_Property_AesKeySize_Name" xml:space="preserve">
@@ -1549,7 +1549,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptFile_Property_KdfIterations_Description" xml:space="preserve">
-    <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
+    <value>PBKDF2 iteration count, used only for Owasp2026 and OpenSslEnc formats. Pre-filled with the value the format ships with: 1,300,000 for Owasp2026 (PBKDF2-HMAC-SHA1), 600,000 for OpenSslEnc (PBKDF2-HMAC-SHA256). Note: plain `openssl enc -pbkdf2 -md sha256` defaults to 10,000 iterations for back-compat — to round-trip with the CLI you must either pass `-iter 600000` on the openssl side or set this property to 10000. Override only when you need to interop with a peer using a different count. Minimum 1,000. The iteration count is not stored in the wire format — encrypt and decrypt sides must use matching values.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_EncryptFile_Property_AesKeySize_Name" xml:space="preserve">
@@ -1582,7 +1582,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptFile_Property_KdfIterations_Description" xml:space="preserve">
-    <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count.</value>
+    <value>PBKDF2 iteration count used to derive the key. Must match the value used at encryption time. Pre-filled with the value the chosen format ships with; override to match the producer if it used a different count. Note: plain `openssl enc -pbkdf2 -md sha256` defaults to 10,000 iterations — when reading openssl CLI output produced without an explicit `-iter` flag, set this property to 10000.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_DecryptFile_Property_AesKeySize_Name" xml:space="preserve">

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
@@ -126,6 +126,18 @@
           }
         },
         {
+          "Name": "AesKeySize",
+          "DisplayNameKey": "Activity_DecryptFile_Property_AesKeySize_Name",
+          "TooltipKey": "Activity_DecryptFile_Property_AesKeySize_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": false,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
+          }
+        },
+        {
           "Name": "Overwrite",
           "DisplayNameKey": "Activity_DecryptFile_Property_Overwrite_Name",
           "TooltipKey": "Activity_DecryptFile_Property_Overwrite_Description",
@@ -331,6 +343,18 @@
           "Name": "KdfIterations",
           "DisplayNameKey": "Activity_DecryptText_Property_KdfIterations_Name",
           "TooltipKey": "Activity_DecryptText_Property_KdfIterations_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": false,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
+          }
+        },
+        {
+          "Name": "AesKeySize",
+          "DisplayNameKey": "Activity_DecryptText_Property_AesKeySize_Name",
+          "TooltipKey": "Activity_DecryptText_Property_AesKeySize_Description",
           "IsRequired": false,
           "IsPrincipal": false,
           "IsVisible": false,
@@ -583,6 +607,18 @@
           }
         },
         {
+          "Name": "AesKeySize",
+          "DisplayNameKey": "Activity_EncryptFile_Property_AesKeySize_Name",
+          "TooltipKey": "Activity_EncryptFile_Property_AesKeySize_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": false,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
+          }
+        },
+        {
           "Name": "Overwrite",
           "DisplayNameKey": "Activity_EncryptFile_Property_Overwrite_Name",
           "TooltipKey": "Activity_EncryptFile_Property_Overwrite_Description",
@@ -805,6 +841,18 @@
           "Name": "KdfIterations",
           "DisplayNameKey": "Activity_EncryptText_Property_KdfIterations_Name",
           "TooltipKey": "Activity_EncryptText_Property_KdfIterations_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": false,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
+          }
+        },
+        {
+          "Name": "AesKeySize",
+          "DisplayNameKey": "Activity_EncryptText_Property_AesKeySize_Name",
+          "TooltipKey": "Activity_EncryptText_Property_AesKeySize_Description",
           "IsRequired": false,
           "IsPrincipal": false,
           "IsVisible": false,

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -568,7 +568,7 @@ namespace UiPath.Cryptography
         /// key (and IV, for non-AEAD and AEAD alike) derived via PBKDF2-HMAC-SHA256.
         /// AEAD layout is a UiPath extension — see <c>docs/symmetric-wire-format.md</c>.
         /// </summary>
-        public static byte[] EncryptDataOpenSslEnc(EncryptionAlgorithm algorithm, byte[] inputBytes, byte[] passwordBytes, int iterations)
+        public static byte[] EncryptDataOpenSslEnc(EncryptionAlgorithm algorithm, byte[] inputBytes, byte[] passwordBytes, int iterations, AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             if (algorithm == EncryptionAlgorithm.PGP)
                 throw new ArgumentException("Use PGP-specific methods for PGP encryption.", nameof(algorithm));
@@ -604,7 +604,9 @@ namespace UiPath.Cryptography
             }
 
             using var symmetric = GetSymmetricAlgorithmProvider(algorithm);
-            int symKeySize = GetLegalKeySizes(symmetric).Max();
+            int symKeySize = (algorithm == EncryptionAlgorithm.AES)
+                ? (int)aesKeySize / 8
+                : GetLegalKeySizes(symmetric).Max();
             int symIvSize = symmetric.IV.Length;
             var (symKey, symIv) = DeriveOpenSslKeyAndIv(passwordBytes, salt, iterations, symKeySize, symIvSize);
             symmetric.Key = symKey;
@@ -629,7 +631,7 @@ namespace UiPath.Cryptography
         /// <summary>
         /// OpenSSL <c>enc</c>-compatible decrypt: parses <c>Salted__(8) || salt(8) || ciphertext [|| tag]</c>.
         /// </summary>
-        public static byte[] DecryptDataOpenSslEnc(EncryptionAlgorithm algorithm, byte[] inputBytes, byte[] passwordBytes, int iterations)
+        public static byte[] DecryptDataOpenSslEnc(EncryptionAlgorithm algorithm, byte[] inputBytes, byte[] passwordBytes, int iterations, AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             if (algorithm == EncryptionAlgorithm.PGP)
                 throw new ArgumentException("Use PGP-specific methods for PGP decryption.", nameof(algorithm));
@@ -677,7 +679,9 @@ namespace UiPath.Cryptography
             }
 
             using var symmetric = GetSymmetricAlgorithmProvider(algorithm);
-            int symKeySize = GetLegalKeySizes(symmetric).Max();
+            int symKeySize = (algorithm == EncryptionAlgorithm.AES)
+                ? (int)aesKeySize / 8
+                : GetLegalKeySizes(symmetric).Max();
             int symIvSize = symmetric.IV.Length;
             var (symKey, symIv) = DeriveOpenSslKeyAndIv(passwordBytes, salt, iterations, symKeySize, symIvSize);
             symmetric.Key = symKey;

--- a/Activities/Cryptography/UiPath.Cryptography/Enums/AesKeySize.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/Enums/AesKeySize.cs
@@ -1,0 +1,16 @@
+using UiPath.Cryptography.Properties;
+
+namespace UiPath.Cryptography.Enums
+{
+    public enum AesKeySize
+    {
+        [LocalizedDescription(nameof(Resources.AesKeySize_Aes128))]
+        Aes128 = 128,
+
+        [LocalizedDescription(nameof(Resources.AesKeySize_Aes192))]
+        Aes192 = 192,
+
+        [LocalizedDescription(nameof(Resources.AesKeySize_Aes256))]
+        Aes256 = 256
+    }
+}

--- a/Activities/Cryptography/UiPath.Cryptography/Properties/UiPath.Cryptography.Designer.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/Properties/UiPath.Cryptography.Designer.cs
@@ -1409,7 +1409,34 @@ namespace UiPath.Cryptography.Properties {
                 return ResourceManager.GetString("RsaKeySize_Rsa4096", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to 128-bit.
+        /// </summary>
+        internal static string AesKeySize_Aes128 {
+            get {
+                return ResourceManager.GetString("AesKeySize_Aes128", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 192-bit.
+        /// </summary>
+        internal static string AesKeySize_Aes192 {
+            get {
+                return ResourceManager.GetString("AesKeySize_Aes192", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 256-bit.
+        /// </summary>
+        internal static string AesKeySize_Aes256 {
+            get {
+                return ResourceManager.GetString("AesKeySize_Aes256", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle to Secure input.
         /// </summary>

--- a/Activities/Cryptography/UiPath.Cryptography/Properties/UiPath.Cryptography.resx
+++ b/Activities/Cryptography/UiPath.Cryptography/Properties/UiPath.Cryptography.resx
@@ -658,6 +658,15 @@
   <data name="RsaKeySize_Rsa4096" xml:space="preserve">
     <value>4096-bit</value>
   </data>
+  <data name="AesKeySize_Aes128" xml:space="preserve">
+    <value>128-bit</value>
+  </data>
+  <data name="AesKeySize_Aes192" xml:space="preserve">
+    <value>192-bit</value>
+  </data>
+  <data name="AesKeySize_Aes256" xml:space="preserve">
+    <value>256-bit</value>
+  </data>
   <data name="PgpSigningRequiresPrivateKeyAndPassphrase" xml:space="preserve">
     <value>Signing was requested but a private key and passphrase are required to sign. Provide both a private key stream and a passphrase, or set sign to false.</value>
   </data>

--- a/Activities/Cryptography/UiPath.Cryptography/SymmetricInteropHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SymmetricInteropHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Security;
 using System.Text;
+using UiPath.Cryptography.Enums;
 using UiPath.Cryptography.Properties;
 
 #pragma warning disable CS0618 // obsolete encryption algorithms reachable via opt-in formats
@@ -95,7 +96,8 @@ namespace UiPath.Cryptography
             int kdfIterations,
             byte[] keyOrPasswordBytes,
             byte[] ivBytes,
-            byte[] inputBytes)
+            byte[] inputBytes,
+            AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             switch (format)
             {
@@ -111,7 +113,7 @@ namespace UiPath.Cryptography
                 case SymmetricWireFormat.OpenSslEnc:
                 {
                     int iter = kdfIterations > 0 ? kdfIterations : CryptographyHelper.GetRecommendedIterations(SymmetricWireFormat.OpenSslEnc);
-                    return CryptographyHelper.EncryptDataOpenSslEnc(algorithm, inputBytes, keyOrPasswordBytes, iter);
+                    return CryptographyHelper.EncryptDataOpenSslEnc(algorithm, inputBytes, keyOrPasswordBytes, iter, aesKeySize);
                 }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown SymmetricWireFormat");
@@ -164,7 +166,8 @@ namespace UiPath.Cryptography
             SymmetricWireFormat format,
             int kdfIterations,
             byte[] keyOrPasswordBytes,
-            byte[] inputBytes)
+            byte[] inputBytes,
+            AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             switch (format)
             {
@@ -180,7 +183,7 @@ namespace UiPath.Cryptography
                 case SymmetricWireFormat.OpenSslEnc:
                 {
                     int iter = kdfIterations > 0 ? kdfIterations : CryptographyHelper.GetRecommendedIterations(SymmetricWireFormat.OpenSslEnc);
-                    return CryptographyHelper.DecryptDataOpenSslEnc(algorithm, inputBytes, keyOrPasswordBytes, iter);
+                    return CryptographyHelper.DecryptDataOpenSslEnc(algorithm, inputBytes, keyOrPasswordBytes, iter, aesKeySize);
                 }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown SymmetricWireFormat");

--- a/Activities/Cryptography/docs/symmetric-wire-format.md
+++ b/Activities/Cryptography/docs/symmetric-wire-format.md
@@ -13,7 +13,7 @@ formats:
 | `Classic`     | PBKDF2-HMAC-SHA1 @ **10 000**    | Password (Encoding bytes) | `salt(8) ‖ IV ‖ ct [‖ tag]`                              | None — UiPath-specific, backward-compat.   |
 | `Owasp2026`   | PBKDF2-HMAC-SHA1 @ caller-set    | Password (Encoding bytes) | `salt(8) ‖ IV ‖ ct [‖ tag]` (same as Classic)            | None — UiPath layout with OWASP 2026 KDF.  |
 | `Raw`         | none                             | Raw bytes (Hex or Base64) | `IV ‖ ct [‖ tag]`                                        | Yes — e.g. `openssl enc -K <hex> -iv <hex>`, Python `cryptography`, Java `javax.crypto`. |
-| `OpenSslEnc`  | PBKDF2-HMAC-SHA256 @ caller-set  | Password (Encoding bytes) | `Salted__(8) ‖ salt(8) ‖ ct [‖ tag]`                     | Yes — `openssl enc -pbkdf2 -iter <N> -md sha256 -salt -k <pw>`. |
+| `OpenSslEnc`  | PBKDF2-HMAC-SHA256 @ caller-set  | Password (Encoding bytes) | `Salted__(8) ‖ salt(8) ‖ ct [‖ tag]`                     | Yes — `openssl enc -pbkdf2 -iter <N> -md sha256 -salt -k <pw>` (AES-128 / AES-192 / AES-256 selectable via `AesKeySize`). |
 
 **Default is `Classic`.** Existing workflows with no `Format` property set
 behave byte-identically to every prior release of this package. Tracked in
@@ -304,6 +304,18 @@ stream; both key and IV come from the KDF.
 > `KdfIterations` to match `<N>`. Unlike `Owasp2026`, this format's default
 > is *not* pinned to a year by name — future releases may revise the
 > default. Pin `KdfIterations` explicitly if cross-version stability matters.
+
+### AES key size — OpenSslEnc
+
+Under `Algorithm = AES`, the AES key size is configurable via the `AesKeySize`
+property — `Aes128` / `Aes192` / `Aes256`, default `Aes256`. The PBKDF2 output
+length adjusts accordingly (`keySize + IvSize` bytes), so the activity
+round-trips with `openssl enc -aes-128-cbc` / `-aes-192-cbc` / `-aes-256-cbc`
+respectively. Must match the key size the peer (producer or consumer) uses.
+Ignored when `Algorithm` is not AES, and ignored for non-`OpenSslEnc` formats.
+AEAD modes (AESGCM, ChaCha20Poly1305) under `OpenSslEnc` continue to derive a
+fixed 32-byte key — those modes are UiPath-to-UiPath only, with no `openssl enc`
+counterpart.
 
 ### openssl interop
 


### PR DESCRIPTION
## Summary

- `OpenSslEnc` previously hardcoded the AES key to `GetLegalKeySizes().Max()` (256-bit), so workflows could only interop with `openssl enc -aes-256-cbc`. This PR adds an `AesKeySize` enum (`Aes128` / `Aes192` / `Aes256`, default `Aes256`) wired through the helper, dispatcher, API options, the four XAML activities, and the design-time ViewModels.
- The `AesKeySize` widget is visible only when `Algorithm = AES` AND `Format = OpenSslEnc`. The default (`Aes256`) matches today's hardcoded behaviour, so the wire-format-stability fixtures stay byte-identical and existing workflows are unaffected.
- AES-GCM under `OpenSslEnc` continues to derive a fixed 32-byte key (UiPath-to-UiPath extension, no `openssl enc` counterpart). DES / TripleDES / RC2 keep `Max()`.

Jira: https://uipath.atlassian.net/browse/STUD-80390

## Test plan

- [x] Solution builds clean (`dotnet build Activities/Activities.Cryptography.sln`) — 0 errors, no new warnings
- [x] Full suite passes (`dotnet test Activities/Activities.Cryptography.sln`) — **888 passed / 0 failed** (123 API + 765 activities)
- [x] `WireFormatStabilityTests` remains green — the AES-256 default path is byte-stable
- [x] New `aes-128-cbc` / `aes-192-cbc` `InlineData` rows added to `ExternalInteropInProcessTests.OpenSslEnc_AesCbc_*ToInternal` and `ExternalInteropOpenSslCliTests.{OpenSslCli_Encrypts_UiPathDecrypts,UiPathEncrypts_OpenSslCli_Decrypts}`
- [x] **Test discrimination confirmed**: temporarily reverting the `symKeySize` ternary in `CryptographyHelper.{Encrypt,Decrypt}DataOpenSslEnc` made the 4 new AES-128/192 rows fail with padding errors while the AES-256 rows kept passing — the new tests exercise the new path, and the default path remains byte-stable
- [x] Localized resx variants (de, es, es-MX, fr, ja, ko, pt, pt-BR, ro, ru, tr, zh-CN, zh-TW) — left to the Localization-sync flow per repo convention; only the English `.resx` is edited here
- [ ] Manual smoke against the `openssl` CLI on a Windows agent: `openssl enc -aes-128-cbc -pbkdf2 -iter 600000 -k <pwd> -in plain.bin -out cipher.bin` decrypts via `DecryptFile` with `Algorithm = AES, Format = OpenSslEnc, AesKeySize = Aes128`, and the mirror direction

## Caveats

- Public API extension: `Symmetric{Encrypt,Decrypt}Options.OpenSslEnc(...)` factories gain an `AesKeySize aesKeySize = AesKeySize.Aes256` parameter. Default keeps existing callers byte-stable; the new param is positional-after / named-only so existing positional call sites still bind correctly.
- Dispatch / helper signatures (`SymmetricInteropHelper.Dispatch{Encrypt,Decrypt}`, `CryptographyHelper.{Encrypt,Decrypt}DataOpenSslEnc`) likewise gain a trailing optional `AesKeySize` parameter. These are public for cross-assembly use within the package but documented as "treat as internal — may change without notice."

🤖 Generated with [Claude Code](https://claude.com/claude-code)