### PR TITLE
fix(cryptography): decouple plaintext encoding + make public Encoding/PlaintextEncoding authoritative over their proxies [STUD-80530][STUD-80559]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
@@ -63,7 +63,11 @@ namespace UiPath.Cryptography.Activities.Tests
             {
                 Algorithm = enumValue,
                 Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
-                KeyEncodingString = null // see the ctor of EncryptText
+                KeyEncodingString = null, // see the ctor of EncryptText
+                // STUD-80530: plaintext encoding is now independent of the key Encoding; this test
+                // bridges to the legacy Unicode helper, so configure the plaintext side as Unicode too.
+                PlaintextEncoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                PlaintextEncodingString = null
             };
             Dictionary<string, object> arguments = new Dictionary<string, object>();
             arguments.Add(nameof(EncryptText.Input), toProcess);
@@ -96,7 +100,10 @@ namespace UiPath.Cryptography.Activities.Tests
             {
                 Algorithm = enumValue,
                 Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
-                KeyEncodingString = null // see the ctor of DecryptText
+                KeyEncodingString = null, // see the ctor of DecryptText
+                // STUD-80530: bridge to the legacy Unicode helper output — configure plaintext as Unicode too.
+                PlaintextEncoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                PlaintextEncodingString = null
             };
 
             Dictionary<string, object> arguments = new Dictionary<string, object>();
@@ -194,7 +201,10 @@ namespace UiPath.Cryptography.Activities.Tests
                 Algorithm = enumValue,
                 Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
                 KeyInputModeSwitch = KeyInputMode.SecureKey,
-                KeyEncodingString = null // see the ctor of EncryptText
+                KeyEncodingString = null, // see the ctor of EncryptText
+                // STUD-80530: bridge to the legacy Unicode helper — configure plaintext as Unicode too.
+                PlaintextEncoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                PlaintextEncodingString = null
             };
             Dictionary<string, object> arguments = new Dictionary<string, object>();
             arguments.Add(nameof(EncryptText.Input), toProcess);
@@ -227,7 +237,10 @@ namespace UiPath.Cryptography.Activities.Tests
                 Algorithm = enumValue,
                 Encoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
                 KeyInputModeSwitch = KeyInputMode.SecureKey,
-                KeyEncodingString = null // see the ctor of DecryptText
+                KeyEncodingString = null, // see the ctor of DecryptText
+                // STUD-80530: bridge to the legacy Unicode helper output — configure plaintext as Unicode too.
+                PlaintextEncoding = new InArgument<Encoding>(ExpressionServices.Convert((env) => System.Text.Encoding.Unicode)),
+                PlaintextEncodingString = null
             };
 
             Dictionary<string, object> arguments = new Dictionary<string, object>();

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyTests.cs
@@ -400,8 +400,17 @@ namespace UiPath.Cryptography.Activities.Tests
         [Fact]
         public void KeyEncodingOrString_NumericCodePageString_ReturnsThatEncoding()
         {
-            var result = EncodingHelpers.KeyEncodingOrString(Encoding.ASCII, "65001"); // UTF-8 code page
+            var result = EncodingHelpers.KeyEncodingOrString(null, "65001"); // UTF-8 code page
             Assert.Equal(Encoding.UTF8.CodePage, result.CodePage);
+        }
+
+        [Fact]
+        public void KeyEncodingOrString_TypedEncoding_WinsOverProxyString()
+        {
+            // The explicit InArgument<Encoding> (Legacy/XAML/programmatic) takes precedence over a
+            // non-null code-page proxy — the proxy is only the modern-designer/default fallback. [STUD-80559]
+            var result = EncodingHelpers.KeyEncodingOrString(Encoding.ASCII, "65001"); // proxy says UTF-8
+            Assert.Same(Encoding.ASCII, result);
         }
 
         [Fact]

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
@@ -103,6 +103,51 @@ namespace UiPath.Cryptography.Activities.Tests
         }
 
         [Fact]
+        public void OpenSslEnc_AesCbc_PublicPlaintextEncodingWinsOverProxyDefault()
+        {
+            // Regression for the public-surface bug: setting the public PlaintextEncoding InArgument must
+            // take effect even though the hidden PlaintextEncodingString proxy still carries its UTF-8
+            // constructor default. Earlier, the non-null proxy won and silently downgraded Unicode to UTF-8.
+            // The helper here assigns ONLY PlaintextEncoding (it no longer clears the proxy), so a passing
+            // assertion proves the public property is authoritative on its own.
+            const int iterations = 600_000;
+            var activity = new EncryptText
+            {
+                Algorithm = EncryptionAlgorithm.AES,
+                Format = SymmetricWireFormat.OpenSslEnc,
+                KeyFormat = KeyBytesFormat.Encoded,
+                Encoding = MakeEncodingArg(Encoding.UTF8),
+                KeyEncodingString = null,
+                AesKeySize = AesKeySize.Aes256,
+                // Public property set to Unicode; proxy intentionally left at its UTF-8 default.
+                PlaintextEncoding = MakeEncodingArg(Encoding.Unicode),
+            };
+
+            var args = new Dictionary<string, object>
+            {
+                [nameof(EncryptText.Input)] = Plaintext,
+                [nameof(EncryptText.Key)] = Password,
+                [nameof(EncryptText.KdfIterations)] = iterations,
+            };
+
+            string encryptedBase64;
+            try
+            {
+                encryptedBase64 = (string)new WorkflowInvoker(activity).Invoke(args)[nameof(activity.Result)];
+            }
+            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+
+            byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(Convert.FromBase64String(encryptedBase64), Password, iterations, 32);
+
+            // Unicode (UTF-16 LE) bytes, NOT the proxy's UTF-8 default.
+            Assert.Equal(Encoding.Unicode.GetBytes(Plaintext), decrypted);
+            Assert.NotEqual(Encoding.UTF8.GetBytes(Plaintext), decrypted);
+        }
+
+        [Fact]
         public void OpenSslEnc_AesCbc_KeyEncodingDoesNotAffectPlaintextBytes()
         {
             // Decoupling: set the key/password Encoding to windows-1252 while leaving PlaintextEncoding
@@ -583,11 +628,12 @@ namespace UiPath.Cryptography.Activities.Tests
                 AesKeySize = aesKeySize,
             };
             // When unset, the constructor default (PlaintextEncodingString = UTF-8) applies, keeping
-            // existing tests byte-stable. When set, exercise the InArgument<Encoding> path explicitly.
+            // existing tests byte-stable. When set, only the public PlaintextEncoding InArgument is
+            // assigned — the PlaintextEncodingString proxy is intentionally left at its UTF-8 default to
+            // prove the public surface wins over the proxy without callers having to clear it (STUD-80530).
             if (plaintextEncoding != null)
             {
                 activity.PlaintextEncoding = MakeEncodingArg(plaintextEncoding);
-                activity.PlaintextEncodingString = null;
             }
 
             var args = new Dictionary<string, object>
@@ -631,11 +677,12 @@ namespace UiPath.Cryptography.Activities.Tests
                 AesKeySize = aesKeySize,
             };
             // When unset, the constructor default (PlaintextEncodingString = UTF-8) applies, keeping
-            // existing tests byte-stable. When set, exercise the InArgument<Encoding> path explicitly.
+            // existing tests byte-stable. When set, only the public PlaintextEncoding InArgument is
+            // assigned — the PlaintextEncodingString proxy is intentionally left at its UTF-8 default to
+            // prove the public surface wins over the proxy without callers having to clear it (STUD-80530).
             if (plaintextEncoding != null)
             {
                 activity.PlaintextEncoding = MakeEncodingArg(plaintextEncoding);
-                activity.PlaintextEncodingString = null;
             }
 
             var args = new Dictionary<string, object>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
@@ -148,6 +148,75 @@ namespace UiPath.Cryptography.Activities.Tests
         }
 
         [Fact]
+        public void OpenSslEnc_AesCbc_PublicKeyEncodingWinsOverProxyDefault()
+        {
+            // Twin of the plaintext regression above, on the key/password side [STUD-80559]: setting the public
+            // key Encoding InArgument must govern key derivation even though the hidden KeyEncodingString proxy
+            // still carries its UTF-8 constructor default. Earlier the non-null proxy won and silently used UTF-8.
+            // UTF-16 vs UTF-8 password bytes differ even for an ASCII password, so the derived key changes.
+            const int iterations = 600_000;
+
+            var encrypt = new EncryptText
+            {
+                Algorithm = EncryptionAlgorithm.AES,
+                Format = SymmetricWireFormat.OpenSslEnc,
+                KeyFormat = KeyBytesFormat.Encoded,
+                AesKeySize = AesKeySize.Aes256,
+                // Public key Encoding set to UTF-16; KeyEncodingString proxy intentionally left at its UTF-8 default.
+                Encoding = MakeEncodingArg(Encoding.Unicode),
+            };
+            var encryptArgs = new Dictionary<string, object>
+            {
+                [nameof(EncryptText.Input)] = Plaintext,
+                [nameof(EncryptText.Key)] = Password,
+                [nameof(EncryptText.KdfIterations)] = iterations,
+            };
+
+            string encryptedBase64;
+            try
+            {
+                encryptedBase64 = (string)new WorkflowInvoker(encrypt).Invoke(encryptArgs)[nameof(encrypt.Result)];
+            }
+            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+
+            byte[] blob = Convert.FromBase64String(encryptedBase64);
+
+            // Positive: a UiPath round-trip with the same UTF-16 key Encoding (proxy left at default) recovers the plaintext.
+            var decrypt = new DecryptText
+            {
+                Algorithm = EncryptionAlgorithm.AES,
+                Format = SymmetricWireFormat.OpenSslEnc,
+                KeyFormat = KeyBytesFormat.Encoded,
+                AesKeySize = AesKeySize.Aes256,
+                Encoding = MakeEncodingArg(Encoding.Unicode),
+            };
+            var decryptArgs = new Dictionary<string, object>
+            {
+                [nameof(DecryptText.Input)] = encryptedBase64,
+                [nameof(DecryptText.Key)] = Password,
+                [nameof(DecryptText.KdfIterations)] = iterations,
+            };
+            string roundTripped;
+            try
+            {
+                roundTripped = (string)new WorkflowInvoker(decrypt).Invoke(decryptArgs)[nameof(decrypt.Result)];
+            }
+            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+            Assert.Equal(Plaintext, roundTripped);
+
+            // Negative cross-check: the BCL counterpart derives the key from UTF-8 password bytes (lines 348/373),
+            // so it cannot decrypt a blob whose key came from UTF-16 bytes — the wrong key fails PKCS7 unpadding.
+            // If the proxy default had won (the pre-fix bug), the key would be UTF-8 and this would SUCCEED.
+            Assert.Throws<CryptographicException>(() => BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations, 32));
+        }
+
+        [Fact]
         public void OpenSslEnc_AesCbc_KeyEncodingDoesNotAffectPlaintextBytes()
         {
             // Decoupling: set the key/password Encoding to windows-1252 while leaving PlaintextEncoding

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
@@ -28,6 +28,14 @@ namespace UiPath.Cryptography.Activities.Tests
         private const string Plaintext = "External-tool interop: round-trip me. 0123456789 ăîșțâ €";
         private const string Password = "interop-test-password-{!@#}";
 
+        static ExternalInteropInProcessTests()
+        {
+            // Touching EncodingHelpers runs its static ctor, which registers
+            // CodePagesEncodingProvider — making legacy code pages such as windows-1252
+            // resolvable in this test process (the OpenSslEnc_AesCbc_KeyEncodingDoesNotAffectPlaintextBytes test).
+            UiPath.Cryptography.Activities.Helpers.EncodingHelpers.GetAvailableEncodings();
+        }
+
         // ────────────────────────────────────────────────────────────────────────
         // OpenSslEnc — AES-256-CBC, bidirectional, AGAINST a BCL counterpart that
         // mirrors `openssl enc -aes-256-cbc -pbkdf2 -iter <N>`. This is the headline
@@ -67,6 +75,52 @@ namespace UiPath.Cryptography.Activities.Tests
             byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations, (int)aesKeySize / 8);
 
             Assert.Equal(Plaintext, Encoding.UTF8.GetString(decrypted));
+        }
+
+        // ────────────────────────────────────────────────────────────────────────
+        // STUD-80530 — plaintext encoding must be governed by PlaintextEncoding, NOT the
+        // key/password Encoding. These two tests would pass against a UiPath↔UiPath round-trip
+        // (the existing suite) but only an external/BCL consumer reading the raw decrypted bytes
+        // can catch the conflation.
+        // ────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void OpenSslEnc_AesCbc_PlaintextEncodingUtf16_PreservedForExternalConsumer()
+        {
+            // Repro: encrypt with PlaintextEncoding = UTF-16 (key Encoding stays UTF-8). An external
+            // openssl consumer must see the UTF-16 LE bytes of the plaintext. Before the fix the
+            // activity transcoded the plaintext through the key Encoding (UTF-8), so this failed.
+            const int iterations = 600_000;
+            string encryptedBase64 = RunEncryptText(
+                EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
+                password: Password, inputEncoding: Encoding.UTF8, plaintextEncoding: Encoding.Unicode,
+                iterations: iterations, aesKeySize: AesKeySize.Aes256);
+
+            byte[] blob = Convert.FromBase64String(encryptedBase64);
+            byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations, 32);
+
+            Assert.Equal(Encoding.Unicode.GetBytes(Plaintext), decrypted);
+        }
+
+        [Fact]
+        public void OpenSslEnc_AesCbc_KeyEncodingDoesNotAffectPlaintextBytes()
+        {
+            // Decoupling: set the key/password Encoding to windows-1252 while leaving PlaintextEncoding
+            // at its UTF-8 default. The password is ASCII, so windows-1252 and UTF-8 derive the same key
+            // and the BCL counterpart (UTF-8 password) still decrypts. The decoded bytes must be the
+            // UTF-8 representation of the plaintext — i.e. the key Encoding did not leak into the plaintext.
+            const int iterations = 600_000;
+            var windows1252 = Encoding.GetEncoding(1252);
+
+            string encryptedBase64 = RunEncryptText(
+                EncryptionAlgorithm.AES, SymmetricWireFormat.OpenSslEnc, KeyBytesFormat.Encoded,
+                password: Password, inputEncoding: windows1252,
+                iterations: iterations, aesKeySize: AesKeySize.Aes256);
+
+            byte[] blob = Convert.FromBase64String(encryptedBase64);
+            byte[] decrypted = BclOpenSslEnc.DecryptAesCbc(blob, Password, iterations, 32);
+
+            Assert.Equal(Encoding.UTF8.GetBytes(Plaintext), decrypted);
         }
 
         // ────────────────────────────────────────────────────────────────────────
@@ -503,7 +557,8 @@ namespace UiPath.Cryptography.Activities.Tests
         {
             if (e == Encoding.UTF8) return new InArgument<Encoding>(ExpressionServices.Convert((env) => Encoding.UTF8));
             if (e == Encoding.Unicode || e == null) return new InArgument<Encoding>(ExpressionServices.Convert((env) => Encoding.Unicode));
-            throw new ArgumentException($"Test helper only supports UTF-8 and Unicode; got {e.WebName}");
+            if (e.CodePage == 1252) return new InArgument<Encoding>(ExpressionServices.Convert((env) => Encoding.GetEncoding(1252)));
+            throw new ArgumentException($"Test helper only supports UTF-8, Unicode, and windows-1252; got {e.WebName}");
         }
 
         private static string RunEncryptText(
@@ -515,6 +570,7 @@ namespace UiPath.Cryptography.Activities.Tests
             string iv = null,
             int iterations = 0,
             Encoding inputEncoding = null,
+            Encoding plaintextEncoding = null,
             AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new EncryptText
@@ -526,6 +582,13 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyEncodingString = null,
                 AesKeySize = aesKeySize,
             };
+            // When unset, the constructor default (PlaintextEncodingString = UTF-8) applies, keeping
+            // existing tests byte-stable. When set, exercise the InArgument<Encoding> path explicitly.
+            if (plaintextEncoding != null)
+            {
+                activity.PlaintextEncoding = MakeEncodingArg(plaintextEncoding);
+                activity.PlaintextEncodingString = null;
+            }
 
             var args = new Dictionary<string, object>
             {
@@ -555,6 +618,7 @@ namespace UiPath.Cryptography.Activities.Tests
             string key = null,
             int iterations = 0,
             Encoding inputEncoding = null,
+            Encoding plaintextEncoding = null,
             AesKeySize aesKeySize = AesKeySize.Aes256)
         {
             var activity = new DecryptText
@@ -566,6 +630,13 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyEncodingString = null,
                 AesKeySize = aesKeySize,
             };
+            // When unset, the constructor default (PlaintextEncodingString = UTF-8) applies, keeping
+            // existing tests byte-stable. When set, exercise the InArgument<Encoding> path explicitly.
+            if (plaintextEncoding != null)
+            {
+                activity.PlaintextEncoding = MakeEncodingArg(plaintextEncoding);
+                activity.PlaintextEncodingString = null;
+            }
 
             var args = new Dictionary<string, object>
             {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropTests.cs
@@ -354,6 +354,11 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                // These tests model a workflow configured with a single encoding for both the key
+                // and the plaintext (the historical coupling). Mirror it explicitly now that the
+                // activity treats key encoding and plaintext encoding as independent (STUD-80530).
+                PlaintextEncoding = MakeEncodingArg(inputEncoding),
+                PlaintextEncodingString = null,
             };
 
             var args = new Dictionary<string, object>
@@ -392,6 +397,10 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyFormat = keyFormat,
                 Encoding = MakeEncodingArg(inputEncoding),
                 KeyEncodingString = null,
+                // See RunEncryptText: mirror the single configured encoding onto the plaintext side
+                // so these legacy-coupling tests stay byte-stable after STUD-80530's decoupling.
+                PlaintextEncoding = MakeEncodingArg(inputEncoding),
+                PlaintextEncodingString = null,
             };
 
             var args = new Dictionary<string, object>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropTests.cs
@@ -357,8 +357,9 @@ namespace UiPath.Cryptography.Activities.Tests
                 // These tests model a workflow configured with a single encoding for both the key
                 // and the plaintext (the historical coupling). Mirror it explicitly now that the
                 // activity treats key encoding and plaintext encoding as independent (STUD-80530).
+                // The PlaintextEncodingString proxy is left at its UTF-8 default; the public
+                // PlaintextEncoding InArgument takes precedence over it.
                 PlaintextEncoding = MakeEncodingArg(inputEncoding),
-                PlaintextEncodingString = null,
             };
 
             var args = new Dictionary<string, object>
@@ -399,8 +400,9 @@ namespace UiPath.Cryptography.Activities.Tests
                 KeyEncodingString = null,
                 // See RunEncryptText: mirror the single configured encoding onto the plaintext side
                 // so these legacy-coupling tests stay byte-stable after STUD-80530's decoupling.
+                // The PlaintextEncodingString proxy is left at its UTF-8 default; the public
+                // PlaintextEncoding InArgument takes precedence over it.
                 PlaintextEncoding = MakeEncodingArg(inputEncoding),
-                PlaintextEncodingString = null,
             };
 
             var args = new Dictionary<string, object>

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
@@ -59,6 +59,14 @@ namespace UiPath.Cryptography.Activities
         public InArgument<string> KeyEncodingString { get; set; }
 
         [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_DecryptText_Property_PlaintextEncoding_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_DecryptText_Property_PlaintextEncoding_Description))]
+        public InArgument<Encoding> PlaintextEncoding { get; set; }
+
+        [Browsable(false)]
+        public InArgument<string> PlaintextEncodingString { get; set; }
+
+        [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_DecryptText_Property_Format_Name))]
         [LocalizedDescription(nameof(Resources.Activity_DecryptText_Property_Format_Description))]
         [DefaultValue(SymmetricWireFormat.Classic)]
@@ -134,6 +142,7 @@ namespace UiPath.Cryptography.Activities
         {
             Algorithm = EncryptionAlgorithm.AESGCM;
             KeyEncodingString = System.Text.Encoding.UTF8.CodePage.ToString();
+            PlaintextEncodingString = System.Text.Encoding.UTF8.CodePage.ToString();
         }
 
         protected override void CacheMetadata(CodeActivityMetadata metadata)
@@ -235,6 +244,8 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
+            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+
             byte[] decrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,
                 keyString: key, keySecureString: keySecureString,
@@ -252,7 +263,7 @@ namespace UiPath.Cryptography.Activities
                     }
                 });
 
-            return keyEncoding.GetString(decrypted);
+            return plaintextEncoding.GetString(decrypted);
         }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
@@ -244,7 +244,7 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
-            var plaintextEncoding = EncodingHelpers.PlaintextEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
 
             byte[] decrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/DecryptText.cs
@@ -244,7 +244,7 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
-            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+            var plaintextEncoding = EncodingHelpers.PlaintextEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
 
             byte[] decrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -257,7 +257,7 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
-            var plaintextEncoding = EncodingHelpers.PlaintextEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
 
             byte[] encrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -257,7 +257,7 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
-            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+            var plaintextEncoding = EncodingHelpers.PlaintextEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
 
             byte[] encrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -58,6 +58,14 @@ namespace UiPath.Cryptography.Activities
         public InArgument<string> KeyEncodingString { get; set; }
 
         [LocalizedCategory(nameof(Resources.Input))]
+        [LocalizedDisplayName(nameof(Resources.Activity_EncryptText_Property_PlaintextEncoding_Name))]
+        [LocalizedDescription(nameof(Resources.Activity_EncryptText_Property_PlaintextEncoding_Description))]
+        public InArgument<Encoding> PlaintextEncoding { get; set; }
+
+        [Browsable(false)]
+        public InArgument<string> PlaintextEncodingString { get; set; }
+
+        [LocalizedCategory(nameof(Resources.Input))]
         [LocalizedDisplayName(nameof(Resources.Activity_EncryptText_Property_Format_Name))]
         [LocalizedDescription(nameof(Resources.Activity_EncryptText_Property_Format_Description))]
         [DefaultValue(SymmetricWireFormat.Classic)]
@@ -139,6 +147,7 @@ namespace UiPath.Cryptography.Activities
         {
             Algorithm = EncryptionAlgorithm.AESGCM;
             KeyEncodingString = System.Text.Encoding.UTF8.CodePage.ToString();
+            PlaintextEncodingString = System.Text.Encoding.UTF8.CodePage.ToString();
         }
 
         protected override void CacheMetadata(CodeActivityMetadata metadata)
@@ -248,12 +257,14 @@ namespace UiPath.Cryptography.Activities
 
             keyEncoding = EncodingHelpers.KeyEncodingOrString(keyEncoding, keyEncodingString);
 
+            var plaintextEncoding = EncodingHelpers.KeyEncodingOrString(PlaintextEncoding.Get(context), PlaintextEncodingString.Get(context)) ?? System.Text.Encoding.UTF8;
+
             byte[] encrypted = SymmetricInteropHelper.RunSymmetricWithKeyLifecycle(
                 Algorithm, Format, KeyFormat, keyEncoding,
                 keyString: key, keySecureString: keySecureString,
                 ivString: ivString, kdfIterations: iterations, needsIv: true,
                 dispatch: (k, iv) => SymmetricInteropHelper.DispatchEncrypt(
-                    Algorithm, Format, iterations, k, iv, keyEncoding.GetBytes(input), AesKeySize));
+                    Algorithm, Format, iterations, k, iv, plaintextEncoding.GetBytes(input), AesKeySize));
 
             return Convert.ToBase64String(encrypted);
         }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Helpers/EncodingHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Helpers/EncodingHelpers.cs
@@ -103,5 +103,17 @@ namespace UiPath.Cryptography.Activities.Helpers
 
             return keyEncoding;
         }
+
+        /// <summary>
+        /// Resolves the plaintext encoding for the paired PlaintextEncoding / PlaintextEncodingString
+        /// inputs. The explicit <paramref name="plaintextEncoding"/> InArgument (classic designer, XAML,
+        /// or programmatic use) takes precedence when bound; the <paramref name="plaintextEncodingString"/>
+        /// code-page proxy (the modern designer dropdown and the activity's UTF-8 constructor default)
+        /// is the fallback. Returns null when neither is set, letting the caller apply its own default.
+        /// </summary>
+        public static Encoding PlaintextEncodingOrString(Encoding plaintextEncoding, string plaintextEncodingString)
+        {
+            return plaintextEncoding ?? KeyEncodingOrString(null, plaintextEncodingString);
+        }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Helpers/EncodingHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Helpers/EncodingHelpers.cs
@@ -91,29 +91,31 @@ namespace UiPath.Cryptography.Activities.Helpers
             }
         }
 
+        /// <summary>
+        /// Resolves an encoding from the paired InArgument&lt;Encoding&gt; / code-page-string inputs used by the
+        /// symmetric and keyed-hash activities (both the key/password encoding and the plaintext encoding follow
+        /// this shape). The explicit <paramref name="keyEncoding"/> InArgument (Legacy designer, hand-authored XAML,
+        /// or programmatic use) takes precedence when bound; the <paramref name="keyEncodingString"/> code-page proxy
+        /// (the modern Windows / cross-platform designer dropdown and the activity's UTF-8 constructor default) is the
+        /// fallback. Returns null when neither is set, letting the caller apply its own default.
+        /// </summary>
         public static Encoding KeyEncodingOrString(Encoding keyEncoding, string keyEncodingString)
         {
+            if (keyEncoding != null)
+            {
+                //explicit InArgument (Legacy/XAML/programmatic) wins when bound
+                return keyEncoding;
+            }
+
             if (keyEncodingString != null)
             {
                 //for modern and cross projects - use the string code page to get the encoding
-                keyEncoding = int.TryParse(keyEncodingString, out int codePage)
+                return int.TryParse(keyEncodingString, out int codePage)
                     ? System.Text.Encoding.GetEncoding(codePage)
                     : System.Text.Encoding.GetEncoding(keyEncodingString);
             }
 
-            return keyEncoding;
-        }
-
-        /// <summary>
-        /// Resolves the plaintext encoding for the paired PlaintextEncoding / PlaintextEncodingString
-        /// inputs. The explicit <paramref name="plaintextEncoding"/> InArgument (classic designer, XAML,
-        /// or programmatic use) takes precedence when bound; the <paramref name="plaintextEncodingString"/>
-        /// code-page proxy (the modern designer dropdown and the activity's UTF-8 constructor default)
-        /// is the fallback. Returns null when neither is set, letting the caller apply its own default.
-        /// </summary>
-        public static Encoding PlaintextEncodingOrString(Encoding plaintextEncoding, string plaintextEncodingString)
-        {
-            return plaintextEncoding ?? KeyEncodingOrString(null, plaintextEncodingString);
+            return null;
         }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -116,6 +116,23 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         /// <summary>
+        /// Configures a code-page encoding dropdown on the supplied design property, mirroring the
+        /// <see cref="KeyEncodingString"/> setup. Used by Text activities to surface their plaintext
+        /// encoding; File activities operate on raw bytes and do not call this.
+        /// </summary>
+        protected void ConfigureEncodingDropdown(DesignInArgument<string> encodingProperty, ref int orderIndex)
+        {
+            var dataSource = EncodingHelpers.ConfigureEncodingDataSource();
+            encodingProperty.IsPrincipal = false;
+            encodingProperty.IsVisible = true;
+            encodingProperty.OrderIndex = orderIndex++;
+            encodingProperty.Category = Resources.Input;
+            encodingProperty.DataSource = dataSource;
+            encodingProperty.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown, Metadata = new Dictionary<string, string>() };
+            dataSource.Data = EncodingHelpers.GetAvailableEncodings();
+        }
+
+        /// <summary>
         /// Configures the third-party-compatibility properties (Format, KeyFormat, KdfIterations).
         /// Format is visible by default; the others are hidden until <see cref="ApplyInteropVisibility"/>
         /// reveals them based on Format/Algorithm. Decrypt has no IV property — the IV is read from
@@ -295,7 +312,14 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             VerifySignature.IsPrincipal = isPgp;
             ApplyPublicKeyVisibility();
             ApplyInteropVisibility();
+            OnAlgorithmChanged(isPgp);
         }
+
+        /// <summary>
+        /// Hook invoked at the end of <see cref="AlgorithmChanged_Action"/> so derived ViewModels can
+        /// react to the active algorithm (e.g. hide Text-only properties when PGP is selected).
+        /// </summary>
+        protected virtual void OnAlgorithmChanged(bool isPgp) { }
 
         private void FormatChanged_Action()
         {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptTextViewModel.cs
@@ -23,6 +23,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         public DesignInArgument<string> Input { get; set; } = new DesignInArgument<string>();
+        public DesignInArgument<string> PlaintextEncodingString { get; set; } = new() { Name = nameof(PlaintextEncodingString) };
         public DesignOutArgument<string> Result { get; set; } = new DesignOutArgument<string>();
 
         protected override void InitializeModel()
@@ -35,6 +36,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             Input.Category = Resources.Input;
 
             ConfigureAlgorithmAndKeyProperties(ref orderIndex);
+            ConfigureEncodingDropdown(PlaintextEncodingString, ref orderIndex);
             ConfigureInteropProperties(ref orderIndex);
 
             Result.IsPrincipal = false;
@@ -45,6 +47,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ConfigureKeyInputModeMenuActions();
             ConfigurePublicKeyFileMenuActions();
             ConfigurePassphraseInputModeMenuActions();
+        }
+
+        protected override void OnAlgorithmChanged(bool isPgp)
+        {
+            PlaintextEncodingString.IsVisible = !isPgp;
         }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -140,7 +140,6 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         {
             var dataSource = EncodingHelpers.ConfigureEncodingDataSource();
             encodingProperty.IsPrincipal = false;
-            encodingProperty.IsVisible = true;
             encodingProperty.OrderIndex = orderIndex++;
             encodingProperty.Category = Resources.Input;
             encodingProperty.DataSource = dataSource;

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -132,6 +132,23 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         /// <summary>
+        /// Configures a code-page encoding dropdown on the supplied design property, mirroring the
+        /// <see cref="KeyEncodingString"/> setup. Used by Text activities to surface their plaintext
+        /// encoding; File activities operate on raw bytes and do not call this.
+        /// </summary>
+        protected void ConfigureEncodingDropdown(DesignInArgument<string> encodingProperty, ref int orderIndex)
+        {
+            var dataSource = EncodingHelpers.ConfigureEncodingDataSource();
+            encodingProperty.IsPrincipal = false;
+            encodingProperty.IsVisible = true;
+            encodingProperty.OrderIndex = orderIndex++;
+            encodingProperty.Category = Resources.Input;
+            encodingProperty.DataSource = dataSource;
+            encodingProperty.Widget = new DefaultWidget { Type = ViewModelWidgetType.Dropdown, Metadata = new Dictionary<string, string>() };
+            dataSource.Data = EncodingHelpers.GetAvailableEncodings();
+        }
+
+        /// <summary>
         /// Configures the third-party-compatibility properties (Format, KeyFormat, Iv, KdfIterations).
         /// Format is visible by default; the others are hidden until <see cref="ApplyInteropVisibility"/>
         /// reveals them based on Format/Algorithm.
@@ -316,7 +333,14 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             PrivateKeyFilePath.IsPrincipal = isPgp && SignData.Value;
             ApplyPassphraseVisibility();
             ApplyInteropVisibility();
+            OnAlgorithmChanged(isPgp);
         }
+
+        /// <summary>
+        /// Hook invoked at the end of <see cref="AlgorithmChanged_Action"/> so derived ViewModels can
+        /// react to the active algorithm (e.g. hide Text-only properties when PGP is selected).
+        /// </summary>
+        protected virtual void OnAlgorithmChanged(bool isPgp) { }
 
         private void FormatChanged_Action()
         {

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
@@ -23,6 +23,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         public DesignInArgument<string> Input { get; set; } = new DesignInArgument<string>();
+        public DesignInArgument<string> PlaintextEncodingString { get; set; } = new() { Name = nameof(PlaintextEncodingString) };
         public DesignOutArgument<string> Result { get; set; } = new DesignOutArgument<string>();
 
         protected override void InitializeModel()
@@ -35,6 +36,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             Input.Category = Resources.Input;
 
             ConfigureAlgorithmAndKeyProperties(ref orderIndex);
+            ConfigureEncodingDropdown(PlaintextEncodingString, ref orderIndex);
             ConfigureInteropProperties(ref orderIndex);
 
             Result.IsPrincipal = false;
@@ -45,6 +47,11 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ConfigureKeyInputModeMenuActions();
             ConfigurePublicKeyFileMenuActions();
             ConfigurePassphraseInputModeMenuActions();
+        }
+
+        protected override void OnAlgorithmChanged(bool isPgp)
+        {
+            PlaintextEncodingString.IsVisible = !isPgp;
         }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptTextViewModel.cs
@@ -23,7 +23,7 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         }
 
         public DesignInArgument<string> Input { get; set; } = new DesignInArgument<string>();
-        public DesignInArgument<string> PlaintextEncodingString { get; set; } = new() { Name = nameof(PlaintextEncodingString) };
+        public DesignInArgument<string> PlaintextEncodingString { get; set; } = new();
         public DesignOutArgument<string> Result { get; set; } = new DesignOutArgument<string>();
 
         protected override void InitializeModel()

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.Designer.cs
@@ -581,6 +581,42 @@ namespace UiPath.Cryptography.Activities.Properties {
                 return ResourceManager.GetString("Activity_DecryptText_Property_Encoding_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The encoding used to convert the decrypted bytes back to text..
+        /// </summary>
+        public static string Activity_DecryptText_Property_PlaintextEncoding_Description {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_PlaintextEncoding_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text encoding.
+        /// </summary>
+        public static string Activity_DecryptText_Property_PlaintextEncoding_Name {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_PlaintextEncoding_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The encoding used to convert the decrypted bytes back to text..
+        /// </summary>
+        public static string Activity_DecryptText_Property_PlaintextEncodingString_Description {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_PlaintextEncodingString_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text encoding.
+        /// </summary>
+        public static string Activity_DecryptText_Property_PlaintextEncodingString_Name {
+            get {
+                return ResourceManager.GetString("Activity_DecryptText_Property_PlaintextEncodingString_Name", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Input byte layout and key-derivation strategy. Must match the format that produced the ciphertext. See docs/symmetric-wire-format.md..
@@ -1416,6 +1452,42 @@ namespace UiPath.Cryptography.Activities.Properties {
         public static string Activity_EncryptText_Property_Encoding_Name {
             get {
                 return ResourceManager.GetString("Activity_EncryptText_Property_Encoding_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The encoding used to convert the input text to bytes before encryption..
+        /// </summary>
+        public static string Activity_EncryptText_Property_PlaintextEncoding_Description {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_PlaintextEncoding_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text encoding.
+        /// </summary>
+        public static string Activity_EncryptText_Property_PlaintextEncoding_Name {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_PlaintextEncoding_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The encoding used to convert the input text to bytes before encryption..
+        /// </summary>
+        public static string Activity_EncryptText_Property_PlaintextEncodingString_Description {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_PlaintextEncodingString_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text encoding.
+        /// </summary>
+        public static string Activity_EncryptText_Property_PlaintextEncodingString_Name {
+            get {
+                return ResourceManager.GetString("Activity_EncryptText_Property_PlaintextEncodingString_Name", resourceCulture);
             }
         }
         

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -330,7 +330,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptText_Property_Encoding_Description" xml:space="preserve">
-    <value>The encoding used to interpret the input text and the key specified in the Key property.</value>
+    <value>The encoding used to interpret the key/password specified in the Key property.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_DecryptText_Property_Encoding_Name" xml:space="preserve">
@@ -343,6 +343,22 @@
   </data>
   <data name="Activity_DecryptText_Property_KeyEncodingString_Name" xml:space="preserve">
     <value>Key encoding</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_PlaintextEncoding_Description" xml:space="preserve">
+    <value>The encoding used to convert the decrypted bytes back to text. Defaults to UTF-8. Set this to match the encoding used by the third-party tool that produced the ciphertext.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_PlaintextEncoding_Name" xml:space="preserve">
+    <value>Text encoding</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_PlaintextEncodingString_Description" xml:space="preserve">
+    <value>The encoding used to convert the decrypted bytes back to text. Defaults to UTF-8. Set this to match the encoding used by the third-party tool that produced the ciphertext.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_DecryptText_Property_PlaintextEncodingString_Name" xml:space="preserve">
+    <value>Text encoding</value>
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptText_Property_Input_Description" xml:space="preserve">
@@ -490,7 +506,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptText_Property_Encoding_Description" xml:space="preserve">
-    <value>The encoding used to interpret the input text and the key specified in the Key property.</value>
+    <value>The encoding used to interpret the key/password specified in the Key property.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_EncryptText_Property_Encoding_Name" xml:space="preserve">
@@ -503,6 +519,22 @@
   </data>
   <data name="Activity_EncryptText_Property_KeyEncodingString_Name" xml:space="preserve">
     <value>Key encoding</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_EncryptText_Property_PlaintextEncoding_Description" xml:space="preserve">
+    <value>The encoding used to convert the input text to bytes before encryption. Defaults to UTF-8. Set this to match the encoding expected by the third-party tool that will consume the ciphertext.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_EncryptText_Property_PlaintextEncoding_Name" xml:space="preserve">
+    <value>Text encoding</value>
+    <comment>Property name</comment>
+  </data>
+  <data name="Activity_EncryptText_Property_PlaintextEncodingString_Description" xml:space="preserve">
+    <value>The encoding used to convert the input text to bytes before encryption. Defaults to UTF-8. Set this to match the encoding expected by the third-party tool that will consume the ciphertext.</value>
+    <comment>Property description</comment>
+  </data>
+  <data name="Activity_EncryptText_Property_PlaintextEncodingString_Name" xml:space="preserve">
+    <value>Text encoding</value>
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptText_Property_Input_Description" xml:space="preserve">

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Resources/ActivitiesMetadata.json
@@ -316,6 +316,18 @@
           }
         },
         {
+          "Name": "PlaintextEncodingString",
+          "DisplayNameKey": "Activity_DecryptText_Property_PlaintextEncodingString_Name",
+          "TooltipKey": "Activity_DecryptText_Property_PlaintextEncodingString_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
+          }
+        },
+        {
           "Name": "Format",
           "DisplayNameKey": "Activity_DecryptText_Property_Format_Name",
           "TooltipKey": "Activity_DecryptText_Property_Format_Description",
@@ -799,6 +811,18 @@
           "Category": {
             "Name": "Options",
             "DisplayNameKey": "Category_Options_Name"
+          }
+        },
+        {
+          "Name": "PlaintextEncodingString",
+          "DisplayNameKey": "Activity_EncryptText_Property_PlaintextEncodingString_Name",
+          "TooltipKey": "Activity_EncryptText_Property_PlaintextEncodingString_Description",
+          "IsRequired": false,
+          "IsPrincipal": false,
+          "IsVisible": true,
+          "Category": {
+            "Name": "Input",
+            "DisplayNameKey": "Input"
           }
         },
         {


### PR DESCRIPTION
## Problem

Two related defects in the `EncryptText` / `DecryptText` (and sibling) encoding handling:

**1. `Encoding` dual-role (STUD-80530).** The activities read a single `Encoding` property and used it for **two unrelated concerns**: parsing the password/key bytes *and* converting the plaintext to bytes. For the `Raw` / `OpenSslEnc` interop formats (STUD-80231), a non-UTF-8 codepage produced ciphertext whose plaintext a Python `cryptography` / Java `javax.crypto` / `openssl enc -d` consumer decoded as mojibake. UiPath↔UiPath round-trips hid it.

**2. Public encoding properties masked by their proxies (STUD-80530 P1 + STUD-80559).** Each encoding is a *paired* input: a public `InArgument<Encoding>` plus a hidden `KeyEncodingString` / `PlaintextEncodingString` code-page proxy for the modern designer. They were merged by `EncodingHelpers.KeyEncodingOrString`, which gave the **string proxy precedence whenever non-null**. Because every constructor defaults the proxy to UTF-8, the proxy was *never* null — so the public `Encoding` / `PlaintextEncoding` InArgument was **silently ignored** (e.g. `new EncryptText { PlaintextEncoding = Encoding.Unicode }` resolved to UTF-8) unless the caller also cleared the hidden proxy. This affects **Legacy designer / hand-authored XAML / programmatic** use; modern Windows and cross-platform designers bind only the proxy, so they were never affected.

## Analysis

The coded API surface is **already correct** (`PasswordKey._encoding` is separate from `SymmetricEncryptOptions.TextEncoding`). This is an **activity-layer-only** fix. The masking precedence dates to commit `c0e892d` (STUD-64242), which flipped the merge to "string wins" while fixing a cross-platform `[RequiredArgument]` design-time error; the runtime flip was incidental and, combined with the always-present UTF-8 constructor default, is what hid the public properties.

## Solution

**Decouple (STUD-80530):** add a `PlaintextEncoding` property (paired `InArgument<Encoding>` + `PlaintextEncodingString` proxy) governing plaintext↔bytes, defaulting to UTF-8. The existing `Encoding` keeps its password/key role. `EncryptFile` / `DecryptFile` are unaffected (raw bytes).

**Fix precedence (STUD-80530 P1 + STUD-80559):** flip `EncodingHelpers.KeyEncodingOrString` to prefer the explicit `InArgument<Encoding>` when bound, falling back to the code-page proxy otherwise (and returning `null` when neither is set, so the caller applies its UTF-8 default):

```csharp
if (keyEncoding != null) return keyEncoding;                 // typed InArgument (Legacy/XAML/programmatic) wins
if (keyEncodingString != null) return /* parse code page */; // modern-designer proxy + UTF-8 ctor default
return null;
```

This one helper change makes the public property authoritative across **all six activities that share it** — `EncryptText`, `DecryptText`, `EncryptFile`, `DecryptFile`, `KeyedHashText`, `KeyedHashFile` — for both the key/password and plaintext encodings.

**Cross-platform safety:** modern Windows + cross-platform bind only the proxy, so the typed InArgument is `null` at runtime and the proxy still governs — byte-stable, no regression. `[RequiredArgument]` stays removed, so STUD-64242's design-time fix is preserved.

## Commits

1. `decouple plaintext encoding from key encoding` — adds `PlaintextEncoding` (STUD-80530).
2. `honor public PlaintextEncoding over its proxy` — plaintext precedence fix (STUD-80530 P1 review feedback).
3. `honor public key Encoding over its proxy across symmetric + keyed-hash activities` — generalizes the precedence fix to the key/password pair via the shared helper and consolidates the now-identical `PlaintextEncodingOrString` away (STUD-80559).

## Testing

- `dotnet build Activities/Activities.Cryptography.sln` — 0 errors, no new warnings.
- `dotnet test Activities/Activities.Cryptography.sln` — **776 + 123 (API) passed, 0 failed, 0 skipped**; `WireFormatStabilityTests` byte-identical.
- Regression tests (each confirmed to **fail on pre-fix code**):
  - `OpenSslEnc_AesCbc_PlaintextEncodingUtf16_PreservedForExternalConsumer` — UTF-16 plaintext decoded by a BCL counterpart.
  - `OpenSslEnc_AesCbc_PublicPlaintextEncodingWinsOverProxyDefault` — public `PlaintextEncoding` wins with the proxy left at its UTF-8 default.
  - `OpenSslEnc_AesCbc_PublicKeyEncodingWinsOverProxyDefault` — public key `Encoding` (UTF-16) governs key derivation with the proxy left at default.
  - `KeyEncodingOrString_TypedEncoding_WinsOverProxyString` — unit-level precedence guard.
  - `OpenSslEnc_AesCbc_KeyEncodingDoesNotAffectPlaintextBytes` — key and plaintext encoding stay decoupled.

## Caveats

- Localized `*.{lang}.resx` variants are intentionally not pre-created; they follow via the standard Localization sync.
- The precedence fix is a behavior change on long-shipped properties, but only for Legacy/XAML/programmatic callers that set a typed encoding whose bytes differ from UTF-8; modern designer workflows are byte-stable.

Closes [STUD-80530](https://uipath.atlassian.net/browse/STUD-80530) and [STUD-80559](https://uipath.atlassian.net/browse/STUD-80559).


[STUD-80530]: https://uipath.atlassian.net/browse/STUD-80530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ