### PR TITLE
fix(crypto): materialise SecureString keys without a managed string [STUD-80531]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropHelperTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/SymmetricInteropHelperTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Security;
 using System.Text;
 using Shouldly;
@@ -154,8 +153,8 @@ namespace UiPath.Cryptography.Activities.Tests
             result.ShouldBe(new byte[] { 0x01, 0x02, 0xFF });
         }
 
-        // Hex via SecureString routes through the NetworkCredential trick on line 74 of
-        // SymmetricInteropHelper. Pins that this path produces the same bytes as plain hex.
+        // Hex via SecureString routes through ParseKeyBytes' string-free materialisation.
+        // Pins that this path produces the same bytes as plain hex.
         [Fact]
         public void ParseKeyOrIv_SecureStringHex_MatchesPlainHex()
         {
@@ -179,6 +178,70 @@ namespace UiPath.Cryptography.Activities.Tests
         {
             byte[] result = SymmetricInteropHelper.ParseKeyOrIv("0102", secureValue: ToSecureString("FFFF"), KeyBytesFormat.Hex, encoding: null);
             result.ShouldBe(new byte[] { 0x01, 0x02 });
+        }
+
+        // ────────────────────────────────────────────────────────────────────────
+        // STUD-80531 — SecureString → bytes must never round-trip through a managed
+        // System.String. Pinned via the SecureStringHelpers materialisation seam:
+        // every non-plain branch (Encoded / Hex / Base64) must route through the
+        // unmanaged-buffer helper (which increments the counter), not the old
+        // NetworkCredential.Password idiom (which left the secret on the GC heap and
+        // never touched this counter). Each test also asserts byte-equivalence with the
+        // plain-string path so the security fix can't silently corrupt the output.
+        // ────────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(KeyBytesFormat.Encoded)]
+        [InlineData(KeyBytesFormat.Hex)]
+        [InlineData(KeyBytesFormat.Base64)]
+        public void ParseKeyOrIv_SecureString_RoutesThroughSecureHelper_NeverMaterialisesString(KeyBytesFormat format)
+        {
+            // A value that is simultaneously valid UTF-8 text, hex, and Base64.
+            const string secret = "DEADBEEF";
+            Encoding encoding = format == KeyBytesFormat.Encoded ? Encoding.UTF8 : null;
+
+            byte[] viaPlain = SymmetricInteropHelper.ParseKeyOrIv(secret, secureValue: null, format, encoding);
+
+            long before = SecureStringHelpers.MaterialisationCount;
+            byte[] viaSecure = SymmetricInteropHelper.ParseKeyOrIv(value: null, secureValue: ToSecureString(secret), format, encoding);
+            long after = SecureStringHelpers.MaterialisationCount;
+
+            after.ShouldBe(before + 1, "the SecureString must be materialised through the string-free helper exactly once");
+            viaSecure.ShouldBe(viaPlain);
+        }
+
+        [Fact]
+        public void ParseKeyOrIv_PlainString_DoesNotMaterialiseThroughSecureHelper()
+        {
+            long before = SecureStringHelpers.MaterialisationCount;
+            SymmetricInteropHelper.ParseKeyOrIv("DEADBEEF", secureValue: null, KeyBytesFormat.Hex, encoding: null);
+            SecureStringHelpers.MaterialisationCount.ShouldBe(before, "a plain-string key must not touch the SecureString helper");
+        }
+
+        [Fact]
+        public void CryptographyHelper_KeyEncoding_SecureString_MatchesPlainAndUsesSecureHelper()
+        {
+            const string secret = "ăîș-password";
+            byte[] viaPlain = CryptographyHelper.KeyEncoding(Encoding.UTF8, secret, keySecureString: null);
+
+            long before = SecureStringHelpers.MaterialisationCount;
+            byte[] viaSecure = CryptographyHelper.KeyEncoding(Encoding.UTF8, key: null, ToSecureString(secret));
+
+            SecureStringHelpers.MaterialisationCount.ShouldBe(before + 1);
+            viaSecure.ShouldBe(viaPlain);
+        }
+
+        [Fact]
+        public void CryptographyHelper_ParseKeyBytes_SecureStringBase64_MatchesPlainAndUsesSecureHelper()
+        {
+            string secret = Convert.ToBase64String(new byte[] { 9, 8, 7, 6, 5, 4 });
+            byte[] viaPlain = CryptographyHelper.ParseKeyBytes(secret, keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+
+            long before = SecureStringHelpers.MaterialisationCount;
+            byte[] viaSecure = CryptographyHelper.ParseKeyBytes(keyString: null, ToSecureString(secret), KeyBytesFormat.Base64, encoding: null);
+
+            SecureStringHelpers.MaterialisationCount.ShouldBe(before + 1);
+            viaSecure.ShouldBe(viaPlain);
         }
 
         // ────────────────────────────────────────────────────────────────────────
@@ -352,7 +415,14 @@ namespace UiPath.Cryptography.Activities.Tests
 
         // ────────────────────────────────────────────────────────────────────────
 
-        private static SecureString ToSecureString(string s) => new NetworkCredential(string.Empty, s).SecurePassword;
+        private static SecureString ToSecureString(string s)
+        {
+            var secure = new SecureString();
+            foreach (char c in s)
+                secure.AppendChar(c);
+            secure.MakeReadOnly();
+            return secure;
+        }
     }
 }
 

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -1073,14 +1073,14 @@ namespace UiPath.Cryptography
 
         // Takes ReadOnlySpan<char> (not string) so a SecureString-derived char[] can be parsed without
         // ever producing a managed string. The cleaned scratch buffer is stackalloc'd for the common
-        // (short key/IV) case and rented for the oversized fallback; either way it holds a copy of the
-        // secret hex digits, so it is zeroed in finally before the frame unwinds.
+        // (short key/IV) case and heap-allocated for the oversized fallback; either way it holds a copy
+        // of the secret hex digits, so it is zeroed in finally before the frame unwinds.
         private static byte[] FromHexString(ReadOnlySpan<char> hex)
         {
             // Tolerate "0x" prefix and any embedded whitespace/colons typical of hex dumps.
             int start = (hex.Length >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) ? 2 : 0;
-            char[] rented = hex.Length > 512 ? new char[hex.Length] : null;
-            Span<char> cleaned = rented ?? stackalloc char[hex.Length];
+            char[] heapBuffer = hex.Length > 512 ? new char[hex.Length] : null;
+            Span<char> cleaned = heapBuffer ?? stackalloc char[hex.Length];
             try
             {
                 int n = 0;

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -1101,7 +1101,7 @@ namespace UiPath.Cryptography
             }
             finally
             {
-                // Zero the secret-bearing scratch buffer (covers both the stackalloc and rented cases).
+                // Zero the secret-bearing scratch buffer (covers both the stackalloc and heap-allocated cases).
                 cleaned.Clear();
             }
         }

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Security;
 using System.Security.Cryptography;
@@ -1030,7 +1029,9 @@ namespace UiPath.Cryptography
 
         public static byte[] KeyEncoding(Encoding encoding, string key, SecureString keySecureString)
         {
-            return key != null ? encoding.GetBytes(key) : encoding.GetBytes(new NetworkCredential("", keySecureString).Password);
+            return key != null
+                ? encoding.GetBytes(key)
+                : SecureStringHelpers.WithSecureChars(keySecureString, chars => encoding.GetBytes(chars));
         }
 
         /// <summary>
@@ -1049,18 +1050,20 @@ namespace UiPath.Cryptography
 
                 case KeyBytesFormat.Hex:
                 {
-                    string raw = keyString ?? (keySecureString != null ? new NetworkCredential(string.Empty, keySecureString).Password : null);
-                    if (string.IsNullOrEmpty(raw))
-                        throw new ArgumentException("Hex key/IV string is empty.");
-                    return FromHexString(raw);
+                    if (!string.IsNullOrEmpty(keyString))
+                        return FromHexString(keyString);
+                    if (keySecureString != null && keySecureString.Length > 0)
+                        return SecureStringHelpers.WithSecureChars(keySecureString, chars => FromHexString(chars));
+                    throw new ArgumentException("Hex key/IV string is empty.");
                 }
 
                 case KeyBytesFormat.Base64:
                 {
-                    string raw = keyString ?? (keySecureString != null ? new NetworkCredential(string.Empty, keySecureString).Password : null);
-                    if (string.IsNullOrEmpty(raw))
-                        throw new ArgumentException("Base64 key/IV string is empty.");
-                    return Convert.FromBase64String(raw);
+                    if (!string.IsNullOrEmpty(keyString))
+                        return Convert.FromBase64String(keyString);
+                    if (keySecureString != null && keySecureString.Length > 0)
+                        return SecureStringHelpers.WithSecureChars(keySecureString, chars => Convert.FromBase64CharArray(chars, 0, chars.Length));
+                    throw new ArgumentException("Base64 key/IV string is empty.");
                 }
 
                 default:
@@ -1068,25 +1071,39 @@ namespace UiPath.Cryptography
             }
         }
 
-        private static byte[] FromHexString(string hex)
+        // Takes ReadOnlySpan<char> (not string) so a SecureString-derived char[] can be parsed without
+        // ever producing a managed string. The cleaned scratch buffer is stackalloc'd for the common
+        // (short key/IV) case and rented for the oversized fallback; either way it holds a copy of the
+        // secret hex digits, so it is zeroed in finally before the frame unwinds.
+        private static byte[] FromHexString(ReadOnlySpan<char> hex)
         {
             // Tolerate "0x" prefix and any embedded whitespace/colons typical of hex dumps.
-            var cleaned = new StringBuilder(hex.Length);
             int start = (hex.Length >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) ? 2 : 0;
-            for (int i = start; i < hex.Length; i++)
+            char[] rented = hex.Length > 512 ? new char[hex.Length] : null;
+            Span<char> cleaned = rented ?? stackalloc char[hex.Length];
+            try
             {
-                char c = hex[i];
-                if (c == ' ' || c == ':' || c == '-' || c == '\t' || c == '\r' || c == '\n') continue;
-                cleaned.Append(c);
+                int n = 0;
+                for (int i = start; i < hex.Length; i++)
+                {
+                    char c = hex[i];
+                    if (c == ' ' || c == ':' || c == '-' || c == '\t' || c == '\r' || c == '\n') continue;
+                    cleaned[n++] = c;
+                }
+                if ((n & 1) != 0)
+                    throw new ArgumentException("Hex string has an odd number of digits.");
+                byte[] bytes = new byte[n / 2];
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    bytes[i] = byte.Parse(cleaned.Slice(i * 2, 2), System.Globalization.NumberStyles.HexNumber);
+                }
+                return bytes;
             }
-            if ((cleaned.Length & 1) != 0)
-                throw new ArgumentException("Hex string has an odd number of digits.");
-            byte[] bytes = new byte[cleaned.Length / 2];
-            for (int i = 0; i < bytes.Length; i++)
+            finally
             {
-                bytes[i] = byte.Parse(cleaned.ToString(i * 2, 2), System.Globalization.NumberStyles.HexNumber);
+                // Zero the secret-bearing scratch buffer (covers both the stackalloc and rented cases).
+                cleaned.Clear();
             }
-            return bytes;
         }
 
         /// <summary>

--- a/Activities/Cryptography/UiPath.Cryptography/Properties/AssemblyInfo.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("92e8345e-2ca1-439d-926d-d979893840f5")]
+[assembly: InternalsVisibleTo("UiPath.Cryptography.Activities.Tests")]

--- a/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
@@ -46,10 +46,12 @@ namespace UiPath.Cryptography
             char[] chars = null;
             try
             {
-                Interlocked.Increment(ref _materialisationCount);
                 ptr = Marshal.SecureStringToGlobalAllocUnicode(secret);
                 chars = new char[secret.Length];
                 Marshal.Copy(ptr, chars, 0, secret.Length);
+                // Count only once the char[] is fully populated, so a failed materialisation
+                // (e.g. OOM in the marshal/copy above) does not overcount the seam.
+                Interlocked.Increment(ref _materialisationCount);
                 return convert(chars);
             }
             finally

--- a/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
@@ -19,12 +19,16 @@ namespace UiPath.Cryptography
     /// </remarks>
     internal static class SecureStringHelpers
     {
+        private static long _materialisationCount;
+
         /// <summary>
         /// Debug/test seam: number of times a <see cref="SecureString"/> has been materialised to a
         /// <c>char[]</c> via <see cref="WithSecureChars"/>. Tests assert this increments to prove the
         /// secret takes the string-free path rather than the old <c>NetworkCredential.Password</c> one.
+        /// Exposed as an atomic read-only accessor (via <see cref="Interlocked.Read"/>) so 64-bit reads
+        /// never tear on 32-bit runtimes and the backing field cannot be overwritten from elsewhere.
         /// </summary>
-        internal static long MaterialisationCount;
+        internal static long MaterialisationCount => Interlocked.Read(ref _materialisationCount);
 
         /// <summary>
         /// Copies <paramref name="secret"/> into a transient <c>char[]</c>, invokes
@@ -42,7 +46,7 @@ namespace UiPath.Cryptography
             char[] chars = null;
             try
             {
-                Interlocked.Increment(ref MaterialisationCount);
+                Interlocked.Increment(ref _materialisationCount);
                 ptr = Marshal.SecureStringToGlobalAllocUnicode(secret);
                 chars = new char[secret.Length];
                 Marshal.Copy(ptr, chars, 0, secret.Length);

--- a/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Threading;
+
+namespace UiPath.Cryptography
+{
+    /// <summary>
+    /// Materialises a <see cref="SecureString"/> to bytes without ever producing a managed
+    /// <see cref="string"/>. The secret is copied to an unmanaged Unicode buffer and an
+    /// intermediate <c>char[]</c>; both are zeroed in <c>finally</c> so the only thing that
+    /// survives is the returned <c>byte[]</c> (which callers zero via
+    /// <see cref="SymmetricInteropHelper.ClearKeyBytes"/>).
+    /// </summary>
+    /// <remarks>
+    /// Modelled on <c>PasswordKey.MaterialisePasswordBytes</c>. Replaces the
+    /// <c>new NetworkCredential(string.Empty, secret).Password</c> idiom, which left an
+    /// uncontrolled copy of the secret on the GC heap.
+    /// </remarks>
+    internal static class SecureStringHelpers
+    {
+        /// <summary>
+        /// Debug/test seam: number of times a <see cref="SecureString"/> has been materialised to a
+        /// <c>char[]</c> via <see cref="WithSecureChars"/>. Tests assert this increments to prove the
+        /// secret takes the string-free path rather than the old <c>NetworkCredential.Password</c> one.
+        /// </summary>
+        internal static long MaterialisationCount;
+
+        /// <summary>
+        /// Copies <paramref name="secret"/> into a transient <c>char[]</c>, invokes
+        /// <paramref name="convert"/> to produce the result bytes, and zeroes both the unmanaged
+        /// buffer and the <c>char[]</c> in <c>finally</c>. Returns an empty array when the secret is
+        /// null or empty.
+        /// </summary>
+        internal static byte[] WithSecureChars(SecureString secret, Func<char[], byte[]> convert)
+        {
+            if (convert == null) throw new ArgumentNullException(nameof(convert));
+            if (secret == null || secret.Length == 0)
+                return Array.Empty<byte>();
+
+            IntPtr ptr = IntPtr.Zero;
+            char[] chars = null;
+            try
+            {
+                Interlocked.Increment(ref MaterialisationCount);
+                ptr = Marshal.SecureStringToGlobalAllocUnicode(secret);
+                chars = new char[secret.Length];
+                Marshal.Copy(ptr, chars, 0, secret.Length);
+                return convert(chars);
+            }
+            finally
+            {
+                if (ptr != IntPtr.Zero)
+                    Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+                if (chars != null)
+                    Array.Clear(chars, 0, chars.Length);
+            }
+        }
+    }
+}

--- a/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SecureStringHelpers.cs
@@ -9,8 +9,10 @@ namespace UiPath.Cryptography
     /// Materialises a <see cref="SecureString"/> to bytes without ever producing a managed
     /// <see cref="string"/>. The secret is copied to an unmanaged Unicode buffer and an
     /// intermediate <c>char[]</c>; both are zeroed in <c>finally</c> so the only thing that
-    /// survives is the returned <c>byte[]</c> (which callers zero via
-    /// <see cref="SymmetricInteropHelper.ClearKeyBytes"/>).
+    /// survives is the returned <c>byte[]</c>. Zeroing that buffer is the caller's
+    /// responsibility: the symmetric path scrubs it via
+    /// <see cref="SymmetricInteropHelper.ClearKeyBytes"/>, while other callers
+    /// (e.g. the keyed-hash path through <see cref="CryptographyHelper.KeyEncoding"/>) do not.
     /// </summary>
     /// <remarks>
     /// Modelled on <c>PasswordKey.MaterialisePasswordBytes</c>. Replaces the

--- a/Activities/Cryptography/UiPath.Cryptography/SymmetricInteropHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/SymmetricInteropHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Security;
 using System.Text;
 using UiPath.Cryptography.Enums;
@@ -74,8 +73,8 @@ namespace UiPath.Cryptography
             if (format == KeyBytesFormat.Encoded)
                 return CryptographyHelper.KeyEncoding(encoding, hasPlain ? value : null, hasSecure ? secureValue : null);
 
-            string raw = hasPlain ? value : new NetworkCredential(string.Empty, secureValue).Password;
-            return CryptographyHelper.ParseKeyBytes(raw, null, format, null);
+            // Pass the SecureString through; ParseKeyBytes materialises it string-free.
+            return CryptographyHelper.ParseKeyBytes(hasPlain ? value : null, hasSecure ? secureValue : null, format, null);
         }
 
         /// <summary>


### PR DESCRIPTION
## Context
The Cryptography package's symmetric layer (`UiPath.Cryptography`) resolves a user-supplied key/IV/password — provided either as a plain string or a `SecureString` — into the `byte[]` consumed by the AES/symmetric primitives. `SymmetricInteropHelper.ParseKeyOrIv` and `CryptographyHelper.KeyEncoding`/`ParseKeyBytes` are the resolution entry points; the helper documents key-zeroing (`ClearKeyBytes`) as part of its security posture.

## Problem Statement
Every `SecureString → byte[]` path materialised the secret as a managed `System.String` via `new NetworkCredential(string.Empty, secure).Password` before encoding it. Once on the GC heap that string is uncontrolled — never zeroed, copyable across compactions, may outlive the operation — which defeats the point of `SecureString` and silently nullifies the advertised `ClearKeyBytes` zeroing (it zeroes the resulting `byte[]`, but the intermediate string is already leaked). Affects any caller passing a key/IV/password as a `SecureString`.

## Behavior Before This PR
A workflow encrypts with a `SecureString` key (Raw+Hex, Raw+Base64, or Encoded). The helper builds `new NetworkCredential("", secure).Password`, producing a `System.String` copy of the secret on the GC heap. The operation completes and `ClearKeyBytes` zeroes the `byte[]`, but the managed string survives — visible to memory dumps, swap, and crash captures.

## Behavior After This PR
Same scenario: the secret is copied to an unmanaged Unicode buffer and a transient `char[]`, encoded straight to bytes, and both intermediates are zeroed in `finally`. No `System.String` is ever produced from the secret. Byte output is identical, so existing ciphertext/wire-format fixtures decrypt unchanged.

## Implementation
The four sites share one internal helper, `SecureStringHelpers.WithSecureChars` (modelled on the existing `PasswordKey.MaterialisePasswordBytes`). `FromHexString` was reworked to take `ReadOnlySpan<char>` with a stackalloc/rented scratch buffer (no `StringBuilder` string), and that scratch buffer — a copy of the secret hex digits — is also zeroed. A deliberate, always-on `MaterialisationCount` seam (per the ticket DoD) lets tests assert the string-free path is taken; it carries no secret content and is thread-safe.

## Caveats / Potential Issues
- PGP passphrase paths still use `NetworkCredential(...).Password` — out of scope (BouncyCastle requires `string` passphrases). Downstream PBKDF2/`SecretBytes` zeroing is tracked under STUD=80409.
- `MaterialisationCount` is a test-only counter that ships in the production assembly (internal).

## How to Test
- `dotnet test Activities/Activities.Cryptography.sln` — full suite green (894 tests), including the new STUD-80531 reproducers in `SymmetricInteropHelperTests` and the unchanged wire-format fixtures.
- `dotnet build Activities/Activities.Cryptography.sln` — no new analyzer warnings (CA5394/CA3003/CA5350).