### PR TITLE
fix(crypto): Gate IV nonce-reuse warning to Raw format [STUD-80532]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Shouldly;
 using UiPath.Cryptography.Enums;
 using Xunit;
+using CryptoRes = UiPath.Cryptography.Activities.Properties.Resources;
 
 #pragma warning disable CS0618 // tests intentionally use obsolete algorithms to fire FIPS warnings.
 
@@ -48,8 +49,8 @@ namespace UiPath.Cryptography.Activities.Tests
         }
 
         // Iv set on EncryptText with Format == Raw → IV nonce-reuse warning. The IV is only
-        // consumed by the Raw wire format, so the warning is gated on it. The warning text
-        // mentions "(Key, IV) pair" so the user can self-serve.
+        // consumed by the Raw wire format, so the warning is gated on it. Matched by exact
+        // resource equality so a reword of the message can't silently weaken the assertion.
         [Fact]
         public void EncryptText_WithExplicitIv_EmitsNonceReuseWarning()
         {
@@ -61,7 +62,7 @@ namespace UiPath.Cryptography.Activities.Tests
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
-            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("explicit IV", StringComparison.Ordinal)).ShouldBeTrue(
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeTrue(
                 $"expected an IV nonce-reuse warning, got: {Format(warnings)}");
         }
 
@@ -81,7 +82,7 @@ namespace UiPath.Cryptography.Activities.Tests
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
-            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("nonce", StringComparison.Ordinal)).ShouldBeFalse(
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
                 $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
         }
 
@@ -91,7 +92,7 @@ namespace UiPath.Cryptography.Activities.Tests
             var activity = new EncryptText { Algorithm = EncryptionAlgorithm.AESGCM };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
-            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("nonce", StringComparison.Ordinal)).ShouldBeFalse(
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
                 $"did not expect IV nonce-reuse warning, got: {Format(warnings)}");
         }
 
@@ -117,7 +118,7 @@ namespace UiPath.Cryptography.Activities.Tests
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
-            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("explicit IV", StringComparison.Ordinal)).ShouldBeTrue();
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeTrue();
         }
 
         // Companion to EncryptText_ExplicitIv_NonRawFormat_NoNonceReuseWarning: both activities
@@ -136,7 +137,7 @@ namespace UiPath.Cryptography.Activities.Tests
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
-            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("nonce", StringComparison.Ordinal)).ShouldBeFalse(
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
                 $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
         }
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
@@ -47,20 +47,42 @@ namespace UiPath.Cryptography.Activities.Tests
                 $"did not expect FIPS warning for {algorithm}, got: {Format(warnings)}");
         }
 
-        // Iv set on EncryptText (any non-Raw format) → IV nonce-reuse warning.
-        // The warning text mentions "(Key, IV) pair" so the user can self-serve.
+        // Iv set on EncryptText with Format == Raw → IV nonce-reuse warning. The IV is only
+        // consumed by the Raw wire format, so the warning is gated on it. The warning text
+        // mentions "(Key, IV) pair" so the user can self-serve.
         [Fact]
         public void EncryptText_WithExplicitIv_EmitsNonceReuseWarning()
         {
             var activity = new EncryptText
             {
                 Algorithm = EncryptionAlgorithm.AESGCM,
+                Format = SymmetricWireFormat.Raw,
                 Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
             warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("explicit IV", StringComparison.Ordinal)).ShouldBeTrue(
                 $"expected an IV nonce-reuse warning, got: {Format(warnings)}");
+        }
+
+        // Iv set but Format is non-Raw → no warning. Non-Raw formats reject an IV at runtime,
+        // so the warning fired in unrelated contexts and desensitized the user. STUD-80532.
+        [Theory]
+        [InlineData(SymmetricWireFormat.Classic)]
+        [InlineData(SymmetricWireFormat.Owasp2026)]
+        [InlineData(SymmetricWireFormat.OpenSslEnc)]
+        public void EncryptText_ExplicitIv_NonRawFormat_NoNonceReuseWarning(SymmetricWireFormat format)
+        {
+            var activity = new EncryptText
+            {
+                Algorithm = EncryptionAlgorithm.AESGCM,
+                Format = format,
+                Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
+            };
+            ValidationError[] warnings = ValidateAndGetWarnings(activity);
+
+            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("nonce", StringComparison.Ordinal)).ShouldBeFalse(
+                $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
         }
 
         [Fact]
@@ -90,11 +112,32 @@ namespace UiPath.Cryptography.Activities.Tests
             var activity = new EncryptFile
             {
                 Algorithm = EncryptionAlgorithm.AES,
+                Format = SymmetricWireFormat.Raw,
                 Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
             };
             ValidationError[] warnings = ValidateAndGetWarnings(activity);
 
             warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("explicit IV", StringComparison.Ordinal)).ShouldBeTrue();
+        }
+
+        // Companion to EncryptText_ExplicitIv_NonRawFormat_NoNonceReuseWarning: both activities
+        // share the same CacheMetadata gate and must stay aligned. STUD-80532.
+        [Theory]
+        [InlineData(SymmetricWireFormat.Classic)]
+        [InlineData(SymmetricWireFormat.Owasp2026)]
+        [InlineData(SymmetricWireFormat.OpenSslEnc)]
+        public void EncryptFile_ExplicitIv_NonRawFormat_NoNonceReuseWarning(SymmetricWireFormat format)
+        {
+            var activity = new EncryptFile
+            {
+                Algorithm = EncryptionAlgorithm.AES,
+                Format = format,
+                Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
+            };
+            ValidationError[] warnings = ValidateAndGetWarnings(activity);
+
+            warnings.Any(w => w.Message.Contains("(Key, IV) pair", StringComparison.Ordinal) || w.Message.Contains("nonce", StringComparison.Ordinal)).ShouldBeFalse(
+                $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
         }
 
         // DecryptText/DecryptFile emit FIPS + ChaCha warnings but NOT the IV warning

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CacheMetadataWarningTests.cs
@@ -86,6 +86,23 @@ namespace UiPath.Cryptography.Activities.Tests
                 $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
         }
 
+        // PGP ignores Format/Iv entirely (Execute routes to the PGP path, bypassing the
+        // symmetric helper). Even Raw + explicit IV must not warn under PGP. STUD-80532.
+        [Fact]
+        public void EncryptText_PgpWithExplicitRawIv_NoNonceReuseWarning()
+        {
+            var activity = new EncryptText
+            {
+                Algorithm = EncryptionAlgorithm.PGP,
+                Format = SymmetricWireFormat.Raw,
+                Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
+            };
+            ValidationError[] warnings = ValidateAndGetWarnings(activity);
+
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
+                $"did not expect IV nonce-reuse warning for PGP, got: {Format(warnings)}");
+        }
+
         [Fact]
         public void EncryptText_WithoutIv_NoNonceReuseWarning()
         {
@@ -139,6 +156,22 @@ namespace UiPath.Cryptography.Activities.Tests
 
             warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
                 $"did not expect IV nonce-reuse warning for non-Raw format {format}, got: {Format(warnings)}");
+        }
+
+        // Companion to EncryptText_PgpWithExplicitRawIv_NoNonceReuseWarning. STUD-80532.
+        [Fact]
+        public void EncryptFile_PgpWithExplicitRawIv_NoNonceReuseWarning()
+        {
+            var activity = new EncryptFile
+            {
+                Algorithm = EncryptionAlgorithm.PGP,
+                Format = SymmetricWireFormat.Raw,
+                Iv = new InArgument<string>("AABBCCDDEEFF00112233445566778899"),
+            };
+            ValidationError[] warnings = ValidateAndGetWarnings(activity);
+
+            warnings.Any(w => w.Message == CryptoRes.Iv_NonceReuseWarning).ShouldBeFalse(
+                $"did not expect IV nonce-reuse warning for PGP, got: {Format(warnings)}");
         }
 
         // DecryptText/DecryptFile emit FIPS + ChaCha warnings but NOT the IV warning

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
@@ -186,7 +186,7 @@ namespace UiPath.Cryptography.Activities
                 metadata.AddValidationError(new ValidationError(Resources.ChaCha20Poly1305NotSupported, isWarning: true, nameof(Algorithm)));
             }
 
-            if (Iv != null)
+            if (Iv != null && Format == SymmetricWireFormat.Raw)
             {
                 metadata.AddValidationError(new ValidationError(Resources.Iv_NonceReuseWarning, isWarning: true, nameof(Iv)));
             }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptFile.cs
@@ -186,7 +186,7 @@ namespace UiPath.Cryptography.Activities
                 metadata.AddValidationError(new ValidationError(Resources.ChaCha20Poly1305NotSupported, isWarning: true, nameof(Algorithm)));
             }
 
-            if (Iv != null && Format == SymmetricWireFormat.Raw)
+            if (Iv != null && Format == SymmetricWireFormat.Raw && Algorithm != EncryptionAlgorithm.PGP)
             {
                 metadata.AddValidationError(new ValidationError(Resources.Iv_NonceReuseWarning, isWarning: true, nameof(Iv)));
             }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -155,7 +155,7 @@ namespace UiPath.Cryptography.Activities
                 metadata.AddValidationError(new ValidationError(Resources.ChaCha20Poly1305NotSupported, isWarning: true, nameof(Algorithm)));
             }
 
-            if (Iv != null)
+            if (Iv != null && Format == SymmetricWireFormat.Raw)
             {
                 metadata.AddValidationError(new ValidationError(Resources.Iv_NonceReuseWarning, isWarning: true, nameof(Iv)));
             }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/EncryptText.cs
@@ -155,7 +155,7 @@ namespace UiPath.Cryptography.Activities
                 metadata.AddValidationError(new ValidationError(Resources.ChaCha20Poly1305NotSupported, isWarning: true, nameof(Algorithm)));
             }
 
-            if (Iv != null && Format == SymmetricWireFormat.Raw)
+            if (Iv != null && Format == SymmetricWireFormat.Raw && Algorithm != EncryptionAlgorithm.PGP)
             {
                 metadata.AddValidationError(new ValidationError(Resources.Iv_NonceReuseWarning, isWarning: true, nameof(Iv)));
             }


### PR DESCRIPTION
## Context
`EncryptText` and `EncryptFile` (UiPath.Cryptography.Activities) are the
symmetric/PGP encryption activities in the Cryptography package. At design time
they raise validation warnings from `CacheMetadata` that Studio surfaces on the
activity. One such warning, added under STUD=64429 / STUD=80231 alongside the
`Raw` wire format and the explicit `Iv` property, cautions against reusing a
`(Key, IV)` pair.

## Problem Statement
The IV nonce-reuse warning fired far too eagerly. Its only guard was
`if (Iv != null)`, with no regard for the selected wire `Format` or `Algorithm`.
An IV is consumed *only* by the `Raw` format on symmetric algorithms — the
runtime rejects an IV on `Classic` / `Owasp2026` / `OpenSslEnc`
(`SymmetricInteropHelper`, `Validation_Iv_OnlyForRaw`) and PGP ignores it
entirely. So an author who set an `Iv` and then switched away from `Raw` kept
seeing the alarming "NEVER reuse (Key, IV)" warning in contexts where no IV is
used — desensitizing them before a real Raw + explicit-IV reuse risk.

## Behavior Before This PR
An author sets `Iv` on `EncryptText`, then sets `Format = Classic` (or picks
`Algorithm = PGP`). The design-time warning "NEVER reuse the same (Key, IV)
pair…" still shows, even though that configuration never consumes the IV at
runtime.

## Behavior After This PR
Same scenario: with `Format = Classic` (or any non-Raw format), or with
`Algorithm = PGP`, no IV warning is shown. The warning appears only for the one
configuration that actually consumes an explicit IV — symmetric algorithm +
`Format = Raw` — exactly mirroring the runtime's IV-consumption path.

## Considered Use Cases
- Symmetric + `Raw` + explicit IV → warns (the real reuse risk).
- Symmetric + `Classic`/`Owasp2026`/`OpenSslEnc` + IV → no warning (runtime rejects the IV).
- `Raw` + empty IV → no warning (legitimate "generate a random IV per call").
- `PGP` + `Raw` + IV (hand-edited/persisted XAML) → no warning (PGP ignores Format/Iv).

## Implementation
The `CacheMetadata` guard becomes
`Iv != null && Format == SymmetricWireFormat.Raw && Algorithm != EncryptionAlgorithm.PGP`
in both activities. `Format` and `Algorithm` are plain properties (not
`InArgument`), so they are readable at design time. The wrapper-vs-value aspect
of `Iv != null` (a touched-but-empty IV field) is intentionally left as-is per
the ticket — it can't be reliably evaluated from `CacheMetadata`, and "Raw +
empty IV" is a valid configuration.

Test assertions for this warning were standardized on exact resource equality
(`w.Message == Resources.Iv_NonceReuseWarning`) instead of brittle substring
matching, via an aliased `using` to disambiguate the production `Resources`
class from the test project's own `Resources` namespace.

## How to Test
- `dotnet test Activities/Activities.Cryptography.sln --filter "FullyQualifiedName~CacheMetadataWarningTests"` — 18/18 pass.
- The negative tests fail if the `Format == Raw` / `Algorithm != PGP` gate is removed (verified), confirming they're genuine reproducers.
- Full pack regression: `dotnet test Activities/Activities.Cryptography.sln` stays green.
