### PR TITLE
fix(cryptography): preserve bound KdfIterations expression on Format change [STUD-80533]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKdfIterationsTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKdfIterationsTests.cs
@@ -82,5 +82,40 @@ namespace UiPath.Cryptography.Activities.Tests
             var literal = vm.KdfIterations.Value.Expression.ShouldBeOfType<Literal<int>>();
             literal.Value.ShouldBe(1_300_000); // Owasp2026 recommended PBKDF2-HMAC-SHA1 count
         }
+
+        // KdfIterations is not applicable to Classic/Raw — those formats hide it and the runtime
+        // (SymmetricInteropHelper.ValidateInteropSettings) rejects any non-zero value paired with them.
+        // So even a bound expression must be cleared to 0 when switching to a non-KDF format; preserving
+        // a hidden binding that resolves non-zero would resurface as a runtime validation failure.
+
+        [Fact]
+        public void Encrypt_FormatChangeToClassic_ClearsBoundKdfIterationsToZero()
+        {
+            var vm = NewEncryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            vm.KdfIterations.Value = new InArgument<int> { Expression = new VisualBasicValue<int>("In_KdfIterations") };
+
+            vm.Format.Value = SymmetricWireFormat.Classic;
+            vm.FormatChanged_Action();
+
+            vm.KdfIterations.IsVisible.ShouldBeFalse();
+            var literal = vm.KdfIterations.Value.Expression.ShouldBeOfType<Literal<int>>();
+            literal.Value.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Decrypt_FormatChangeToRaw_ClearsBoundKdfIterationsToZero()
+        {
+            var vm = NewDecryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.OpenSslEnc;
+            vm.KdfIterations.Value = new InArgument<int> { Expression = new VisualBasicValue<int>("In_KdfIterations") };
+
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+
+            vm.KdfIterations.IsVisible.ShouldBeFalse();
+            var literal = vm.KdfIterations.Value.Expression.ShouldBeOfType<Literal<int>>();
+            literal.Value.ShouldBe(0);
+        }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKdfIterationsTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKdfIterationsTests.cs
@@ -1,0 +1,86 @@
+using System.Activities;
+using System.Activities.DesignViewModels;
+using System.Activities.Expressions;
+using Microsoft.VisualBasic.Activities;
+using Moq;
+using Shouldly;
+using UiPath.Cryptography;
+using UiPath.Cryptography.Activities.NetCore.ViewModels;
+using Xunit;
+
+namespace UiPath.Cryptography.Activities.Tests
+{
+    /// <summary>
+    /// Guards the contract of <c>FormatChanged_Action</c> on the symmetric Encrypt/Decrypt ViewModels:
+    /// switching the <c>Format</c> dropdown snaps an untouched/literal <c>KdfIterations</c> to the new
+    /// format's recommended iteration count (helpful default), but must NOT overwrite a user-bound
+    /// VB/argument expression — doing so silently loses design-time data and lets the encrypt and decrypt
+    /// sides drift to different iteration counts (STUD-80533).
+    /// </summary>
+    public class FormatChangeKdfIterationsTests
+    {
+        private static EncryptTextViewModel NewEncryptViewModel() =>
+            new EncryptTextViewModel(Mock.Of<IDesignServices>());
+
+        private static DecryptTextViewModel NewDecryptViewModel() =>
+            new DecryptTextViewModel(Mock.Of<IDesignServices>());
+
+        [Fact]
+        public void Encrypt_FormatChange_PreservesBoundKdfIterationsExpression()
+        {
+            var vm = NewEncryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            var boundExpression = new VisualBasicValue<int>("In_KdfIterations");
+            vm.KdfIterations.Value = new InArgument<int> { Expression = boundExpression };
+
+            vm.Format.Value = SymmetricWireFormat.OpenSslEnc;
+            vm.FormatChanged_Action();
+
+            vm.KdfIterations.Value.Expression.ShouldBeSameAs(boundExpression);
+            ((VisualBasicValue<int>)vm.KdfIterations.Value.Expression).ExpressionText.ShouldBe("In_KdfIterations");
+        }
+
+        [Fact]
+        public void Decrypt_FormatChange_PreservesBoundKdfIterationsExpression()
+        {
+            var vm = NewDecryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            var boundExpression = new VisualBasicValue<int>("In_KdfIterations");
+            vm.KdfIterations.Value = new InArgument<int> { Expression = boundExpression };
+
+            vm.Format.Value = SymmetricWireFormat.OpenSslEnc;
+            vm.FormatChanged_Action();
+
+            vm.KdfIterations.Value.Expression.ShouldBeSameAs(boundExpression);
+            ((VisualBasicValue<int>)vm.KdfIterations.Value.Expression).ExpressionText.ShouldBe("In_KdfIterations");
+        }
+
+        [Fact]
+        public void Encrypt_FormatChange_SnapsLiteralKdfIterationsToRecommendedValue()
+        {
+            var vm = NewEncryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.OpenSslEnc;
+            vm.KdfIterations.Value = new InArgument<int>(50_000); // a Literal<int>, not a binding
+
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            vm.FormatChanged_Action();
+
+            var literal = vm.KdfIterations.Value.Expression.ShouldBeOfType<Literal<int>>();
+            literal.Value.ShouldBe(1_300_000); // Owasp2026 recommended PBKDF2-HMAC-SHA1 count
+        }
+
+        [Fact]
+        public void Decrypt_FormatChange_SnapsLiteralKdfIterationsToRecommendedValue()
+        {
+            var vm = NewDecryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.OpenSslEnc;
+            vm.KdfIterations.Value = new InArgument<int>(50_000); // a Literal<int>, not a binding
+
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            vm.FormatChanged_Action();
+
+            var literal = vm.KdfIterations.Value.Expression.ShouldBeOfType<Literal<int>>();
+            literal.Value.ShouldBe(1_300_000); // Owasp2026 recommended PBKDF2-HMAC-SHA1 count
+        }
+    }
+}

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -297,15 +297,20 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ApplyInteropVisibility();
         }
 
-        private void FormatChanged_Action()
+        internal void FormatChanged_Action()
         {
             ApplyInteropVisibility();
-            // Snap KdfIterations to a concrete value whenever Format changes — avoids the user seeing 0
-            // and having to look up what the format ships with. Customizations made before the format
-            // change are discarded by design (they were tied to the previous format's KDF anyway).
-            KdfIterations.Value = KdfIterations.IsVisible
-                ? CryptographyHelper.GetRecommendedIterations(Format.Value)
-                : 0;
+            // Snap KdfIterations to the new format's recommended literal so the user never sees a bare 0
+            // and has to look up the format's default. Untouched fields and stale literal defaults snap;
+            // a user-bound VB/argument expression is preserved — overwriting it would be silent
+            // design-time data loss (encrypt/decrypt sides bound to the same argument must stay in sync).
+            var boundExpression = KdfIterations.Value?.Expression;
+            if (boundExpression == null || boundExpression.IsLiteral())
+            {
+                KdfIterations.Value = KdfIterations.IsVisible
+                    ? CryptographyHelper.GetRecommendedIterations(Format.Value)
+                    : 0;
+            }
             // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
             // Encoded otherwise (so non-Raw runtime validation passes).
             KeyFormat.Value = Format.Value == SymmetricWireFormat.Raw

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -300,16 +300,24 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         internal void FormatChanged_Action()
         {
             ApplyInteropVisibility();
-            // Snap KdfIterations to the new format's recommended literal so the user never sees a bare 0
-            // and has to look up the format's default. Untouched fields and stale literal defaults snap;
-            // a user-bound VB/argument expression is preserved — overwriting it would be silent
-            // design-time data loss (encrypt/decrypt sides bound to the same argument must stay in sync).
-            var boundExpression = KdfIterations.Value?.Expression;
-            if (boundExpression == null || boundExpression.IsLiteral())
+            // KdfIterations isn't applicable to Classic/Raw (the field is hidden). Reset it to 0 there —
+            // a hidden non-zero value, literal OR a bound expression that resolves non-zero, fails
+            // SymmetricInteropHelper.ValidateInteropSettings at runtime. When it IS applicable
+            // (Owasp2026/OpenSslEnc), snap an untouched/literal field to the format's recommended default
+            // so the user never sees a bare 0, but preserve a user-bound VB/argument expression —
+            // overwriting it would be silent design-time data loss (encrypt/decrypt sides bound to the
+            // same argument must stay in sync).
+            if (!KdfIterations.IsVisible)
             {
-                KdfIterations.Value = KdfIterations.IsVisible
-                    ? CryptographyHelper.GetRecommendedIterations(Format.Value)
-                    : 0;
+                KdfIterations.Value = 0;
+            }
+            else
+            {
+                var boundExpression = KdfIterations.Value?.Expression;
+                if (boundExpression == null || boundExpression.IsLiteral())
+                {
+                    KdfIterations.Value = CryptographyHelper.GetRecommendedIterations(Format.Value);
+                }
             }
             // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
             // Encoded otherwise (so non-Raw runtime validation passes).

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -318,15 +318,20 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
             ApplyInteropVisibility();
         }
 
-        private void FormatChanged_Action()
+        internal void FormatChanged_Action()
         {
             ApplyInteropVisibility();
-            // Snap KdfIterations to a concrete value whenever Format changes — avoids the user seeing 0
-            // and having to look up what the format ships with. Customizations made before the format
-            // change are discarded by design (they were tied to the previous format's KDF anyway).
-            KdfIterations.Value = KdfIterations.IsVisible
-                ? CryptographyHelper.GetRecommendedIterations(Format.Value)
-                : 0;
+            // Snap KdfIterations to the new format's recommended literal so the user never sees a bare 0
+            // and has to look up the format's default. Untouched fields and stale literal defaults snap;
+            // a user-bound VB/argument expression is preserved — overwriting it would be silent
+            // design-time data loss (encrypt/decrypt sides bound to the same argument must stay in sync).
+            var boundExpression = KdfIterations.Value?.Expression;
+            if (boundExpression == null || boundExpression.IsLiteral())
+            {
+                KdfIterations.Value = KdfIterations.IsVisible
+                    ? CryptographyHelper.GetRecommendedIterations(Format.Value)
+                    : 0;
+            }
             // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
             // Encoded otherwise (so non-Raw runtime validation passes).
             KeyFormat.Value = Format.Value == SymmetricWireFormat.Raw

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -321,16 +321,24 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
         internal void FormatChanged_Action()
         {
             ApplyInteropVisibility();
-            // Snap KdfIterations to the new format's recommended literal so the user never sees a bare 0
-            // and has to look up the format's default. Untouched fields and stale literal defaults snap;
-            // a user-bound VB/argument expression is preserved — overwriting it would be silent
-            // design-time data loss (encrypt/decrypt sides bound to the same argument must stay in sync).
-            var boundExpression = KdfIterations.Value?.Expression;
-            if (boundExpression == null || boundExpression.IsLiteral())
+            // KdfIterations isn't applicable to Classic/Raw (the field is hidden). Reset it to 0 there —
+            // a hidden non-zero value, literal OR a bound expression that resolves non-zero, fails
+            // SymmetricInteropHelper.ValidateInteropSettings at runtime. When it IS applicable
+            // (Owasp2026/OpenSslEnc), snap an untouched/literal field to the format's recommended default
+            // so the user never sees a bare 0, but preserve a user-bound VB/argument expression —
+            // overwriting it would be silent design-time data loss (encrypt/decrypt sides bound to the
+            // same argument must stay in sync).
+            if (!KdfIterations.IsVisible)
             {
-                KdfIterations.Value = KdfIterations.IsVisible
-                    ? CryptographyHelper.GetRecommendedIterations(Format.Value)
-                    : 0;
+                KdfIterations.Value = 0;
+            }
+            else
+            {
+                var boundExpression = KdfIterations.Value?.Expression;
+                if (boundExpression == null || boundExpression.IsLiteral())
+                {
+                    KdfIterations.Value = CryptographyHelper.GetRecommendedIterations(Format.Value);
+                }
             }
             // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
             // Encoded otherwise (so non-Raw runtime validation passes).


### PR DESCRIPTION
## Context
The symmetric Encrypt/Decrypt activities in the Cryptography package expose a `Format` dropdown (Classic / Owasp2026 / Raw / OpenSslEnc) and a `KdfIterations` input that controls the PBKDF2 iteration count. In Studio these are driven by the design-time ViewModels `EncryptCryptoViewModelBase` / `DecryptCryptoViewModelBase`, which register a `FormatChanged_Action` rule that re-snaps interop fields whenever the user changes `Format`. `KdfIterations` is a `DesignInArgument<int>`, so it can hold either a literal or a VB/workflow-argument expression.

## Problem Statement
`FormatChanged_Action` unconditionally wrote a literal int into `KdfIterations.Value` on every `Format` change. This silently wiped any expression the user had bound — e.g. binding both EncryptText and DecryptText to a shared `In_KdfIterations` input argument so the same value flows to both sides. After the wipe the two sides resolve different iteration counts; because the count is not embedded in the wire format, the mismatch surfaces far from its cause as a runtime `CryptographicException` / padding error.

## Analysis
The snap lived at `EncryptCryptoViewModelBase.FormatChanged_Action` and its mirror in `DecryptCryptoViewModelBase`. The old comment defended the discard as "tied to the previous format's KDF anyway", but that conflates a stale literal default (safe to overwrite) with a user-bound expression (silent data loss). A bound expression is distinguished from a literal via `InArgument<int>.Expression` plus the `IsLiteral()` SDK extension.

## Behavior Before This PR
User binds `KdfIterations` to `In_KdfIterations` on an EncryptText with `Format = Owasp2026`, then switches `Format` to `OpenSslEnc`. The binding silently disappears and is replaced by the new format's default literal. Encrypt and decrypt now diverge and decryption fails at runtime.

## Behavior After This PR
Same scenario: switching `Format` between KDF formats (`Owasp2026` <-> `OpenSslEnc`) leaves the bound `In_KdfIterations` expression intact. An untouched or literal field still snaps to the new format's recommended value (the helpful default is preserved). Switching to a non-KDF format (`Classic` / `Raw`), where the field is hidden and a non-zero value is rejected at runtime, resets `KdfIterations` to 0 — for literals and bindings alike — exactly as before.

## Considered Use Cases
- Untouched / null `KdfIterations` -> snaps to recommended literal
- Literal value -> snaps to recommended literal
- Bound VB/argument expression, visible KDF format -> preserved
- Bound expression, switch to Classic/Raw (hidden) -> reset to 0 (avoids runtime validation failure)

## Implementation
The guard preserves a bound expression only while `KdfIterations` stays applicable (`IsVisible`). When the new format hides it, the value is reset to 0 regardless of binding — a hidden non-zero value (literal or expression) would fail `SymmetricInteropHelper.ValidateInteropSettings`. The same block is duplicated in both ViewModels because the shared-base extraction (STUD=80470) has not landed yet. `FormatChanged_Action` was widened `private` -> `internal` to allow direct unit-test invocation (`InternalsVisibleTo` for the test assembly already exists). `KeyFormat` is a `DesignProperty` (no expression binding) and is unchanged.

This PR was cross-validated with an independent reviewer (Codex), which caught one Major issue — preserving a bound expression when switching to Classic/Raw would carry a hidden, non-applicable value into runtime validation; fixed by the reset-when-hidden branch above.

## How to Test
- `dotnet test Activities/Activities.Cryptography.sln` — green (894 tests incl. 6 new `FormatChangeKdfIterationsTests`).
- Studio Desktop: (a) drop EncryptText, bind `KdfIterations` to a workflow argument, change `Format` Classic->Owasp2026, confirm the binding is intact; (b) drop EncryptText, set `KdfIterations` to a literal, change `Format` Classic->Owasp2026, confirm the literal updates to 1,300,000.