### PR TITLE
fix(cryptography): tolerate URL-safe alphabet and missing padding in Base64 key parsing [STUD-80535]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
@@ -208,6 +208,88 @@ namespace UiPath.Cryptography.Activities.Tests
             Should.Throw<ArgumentOutOfRangeException>(() =>
                 CryptographyHelper.ParseKeyBytes("xx", keySecureString: null, (KeyBytesFormat)999, encoding: null));
         }
+
+        // ────────────────────────────────────────────────────────────────────────
+        // Base64 leniency (STUD-80535) — the entry surface tolerates the artefacts a
+        // third-party tool actually produces, mirroring the Hex pre-cleaner.
+        //   Newly enabled by FromBase64String (threw FormatException before the fix):
+        //     URL-safe alphabet and missing padding.
+        //   Compatibility guards (already accepted — Convert.FromBase64String ignores
+        //     embedded whitespace/CR/LF — pinned so the pre-cleaner keeps tolerating them):
+        //     line wraps and surrounding whitespace.
+        // ────────────────────────────────────────────────────────────────────────
+
+        private static readonly byte[] Key32 = new byte[]
+        {
+            0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
+            16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+        };
+
+        [Fact]
+        public void ParseKeyBytes_Base64_ToleratesLineWrap()
+        {
+            // openssl wraps base64 output and the CLI appends a trailing newline. A 32-byte
+            // key is 44 chars (doesn't wrap naturally) so inject the wrap manually, plus a
+            // trailing newline, mimicking what lands in the key field after copy-paste.
+            // Convert.FromBase64String already ignores these newlines; this pins that the
+            // pre-cleaner does not regress that behavior.
+            string b64 = Convert.ToBase64String(Key32);
+            string wrapped = b64.Substring(0, 22) + "\n" + b64.Substring(22) + "\n";
+            byte[] result = CryptographyHelper.ParseKeyBytes(wrapped, keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+            result.ShouldBe(Key32);
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_ToleratesUrlSafeAlphabet()
+        {
+            // Bytes chosen so the standard encoding contains both '+' and '/', which the
+            // URL-safe alphabet renders as '-' and '_'.
+            byte[] expected = new byte[] { 0xFB, 0xFF, 0xBF, 0x00, 0x10, 0x83 };
+            string standard = Convert.ToBase64String(expected);
+            standard.ShouldContain("+");
+            standard.ShouldContain("/");
+            string urlSafe = standard.Replace('+', '-').Replace('/', '_');
+            byte[] result = CryptographyHelper.ParseKeyBytes(urlSafe, keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+            result.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_ToleratesSurroundingWhitespace()
+        {
+            // Compatibility guard: Convert.FromBase64String already tolerates surrounding
+            // whitespace/CR/LF; this pins that the pre-cleaner keeps accepting it.
+            string padded = "  \t" + Convert.ToBase64String(Key32) + " \r\n";
+            byte[] result = CryptographyHelper.ParseKeyBytes(padded, keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+            result.ShouldBe(Key32);
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_RestoresMissingPadding()
+        {
+            // rem == 2 stem (one byte → "AQ==") and rem == 3 stem (two bytes → "AQI=").
+            byte[] oneByte = CryptographyHelper.ParseKeyBytes("AQ", keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+            oneByte.ShouldBe(new byte[] { 1 });
+            byte[] twoBytes = CryptographyHelper.ParseKeyBytes("AQI", keySecureString: null, KeyBytesFormat.Base64, encoding: null);
+            twoBytes.ShouldBe(new byte[] { 1, 2 });
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_GarbageCharacters_StillThrows()
+        {
+            // Leniency strips whitespace and remaps the URL-safe alphabet only — characters
+            // outside the base64 alphabet must still be rejected by the final strict decode.
+            Should.Throw<FormatException>(() =>
+                CryptographyHelper.ParseKeyBytes("not base64 @#$%!", keySecureString: null, KeyBytesFormat.Base64, encoding: null));
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_InvalidLengthStem_StillThrows()
+        {
+            // A length-mod-4 == 1 stem can never be valid base64; the pre-cleaner rejects it
+            // rather than fabricating padding that would silently accept malformed data.
+            Should.Throw<ArgumentException>(() =>
+                CryptographyHelper.ParseKeyBytes("AQID Z", keySecureString: null, KeyBytesFormat.Base64, encoding: null));
+        }
     }
 }
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using Shouldly;
@@ -290,6 +291,21 @@ namespace UiPath.Cryptography.Activities.Tests
             // FormatException rather than being silently accepted via fabricated padding.
             Should.Throw<FormatException>(() =>
                 CryptographyHelper.ParseKeyBytes("AQID Z", keySecureString: null, KeyBytesFormat.Base64, encoding: null));
+        }
+
+        [Fact]
+        public void ParseKeyBytes_Base64_SecureStringPath_IsLenient()
+        {
+            // The SecureString key path is decoded without ever materializing a managed string
+            // (STUD-80531); it must still apply the same leniency as the keyString path. Feed a
+            // URL-safe, unpadded form through the SecureString overload and confirm it decodes to
+            // the same bytes as the standard padded form.
+            byte[] expected = new byte[] { 0xFB, 0xFF, 0xBF, 0x00, 0x10, 0x83, 0x01 };
+            string urlSafeUnpadded = Convert.ToBase64String(expected)
+                .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+            SecureString secure = TestingHelper.StringToSecureString(urlSafeUnpadded);
+            byte[] result = CryptographyHelper.ParseKeyBytes(keyString: null, secure, KeyBytesFormat.Base64, encoding: null);
+            result.ShouldBe(expected);
         }
     }
 }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/CryptographyHelperInteropTests.cs
@@ -285,9 +285,10 @@ namespace UiPath.Cryptography.Activities.Tests
         [Fact]
         public void ParseKeyBytes_Base64_InvalidLengthStem_StillThrows()
         {
-            // A length-mod-4 == 1 stem can never be valid base64; the pre-cleaner rejects it
-            // rather than fabricating padding that would silently accept malformed data.
-            Should.Throw<ArgumentException>(() =>
+            // A length-mod-4 == 1 stem can never be valid base64; the pre-cleaner leaves it for
+            // Convert.FromBase64String to reject, so malformed input still surfaces as
+            // FormatException rather than being silently accepted via fabricated padding.
+            Should.Throw<FormatException>(() =>
                 CryptographyHelper.ParseKeyBytes("AQID Z", keySecureString: null, KeyBytesFormat.Base64, encoding: null));
         }
     }

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/ExternalInteropInProcessTests.cs
@@ -447,6 +447,31 @@ namespace UiPath.Cryptography.Activities.Tests
             Assert.Equal(Plaintext, decrypted);
         }
 
+        // STUD-80535 compatibility guard: a Base64 key as openssl actually emits it —
+        // line-wrapped with a trailing newline — must round-trip end-to-end. The embedded
+        // newlines were already tolerated by Convert.FromBase64String; this pins that the
+        // full activity path still decodes the messy key to the same 32 bytes the BCL
+        // counterpart uses, so the plaintext survives the round-trip.
+        [Fact]
+        public void Raw_AesCbc_Base64KeyWithLineWrap_InternalToExternal()
+        {
+            byte[] keyBytes = new byte[32];
+            RandomNumberGenerator.Fill(keyBytes);
+
+            string b64 = Convert.ToBase64String(keyBytes);                 // 44 chars
+            string opensslStyleKey = b64.Substring(0, 22) + "\n" + b64.Substring(22) + "\n";
+
+            string encryptedBase64 = RunEncryptText(
+                EncryptionAlgorithm.AES, SymmetricWireFormat.Raw, KeyBytesFormat.Base64,
+                key: opensslStyleKey,
+                inputEncoding: Encoding.UTF8);
+
+            byte[] blob = Convert.FromBase64String(encryptedBase64);
+            byte[] decrypted = BclRaw.DecryptAesCbc(blob, keyBytes);       // literal 32 decoded bytes
+
+            Assert.Equal(Plaintext, Encoding.UTF8.GetString(decrypted));
+        }
+
         // ────────────────────────────────────────────────────────────────────────
         // BCL counterpart implementations — strictly from the wire-format spec.
         // DO NOT call into CryptographyHelper here; the value of these tests is

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/Properties/UiPath.Cryptography.Activities.resx
@@ -1491,7 +1491,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptText_Property_KeyFormat_Description" xml:space="preserve">
-    <value>Encoding of the Key (and IV) string: Hex (e.g. 64 chars for an AES-256 key) or Base64.</value>
+    <value>Encoding of the Key (and IV) string: Hex (e.g. 64 chars for an AES-256 key) or Base64. Base64 input tolerates whitespace, line wraps, URL-safe characters (- and _), and missing padding.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_EncryptText_Property_Iv_Name" xml:space="preserve">
@@ -1532,7 +1532,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptText_Property_KeyFormat_Description" xml:space="preserve">
-    <value>Encoding of the Key string: Hex (e.g. 64 chars for an AES-256 key) or Base64.</value>
+    <value>Encoding of the Key string: Hex (e.g. 64 chars for an AES-256 key) or Base64. Base64 input tolerates whitespace, line wraps, URL-safe characters (- and _), and missing padding.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_DecryptText_Property_KdfIterations_Name" xml:space="preserve">
@@ -1565,7 +1565,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_EncryptFile_Property_KeyFormat_Description" xml:space="preserve">
-    <value>Encoding of the Key (and IV) string: Hex (e.g. 64 chars for an AES-256 key) or Base64.</value>
+    <value>Encoding of the Key (and IV) string: Hex (e.g. 64 chars for an AES-256 key) or Base64. Base64 input tolerates whitespace, line wraps, URL-safe characters (- and _), and missing padding.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_EncryptFile_Property_Iv_Name" xml:space="preserve">
@@ -1606,7 +1606,7 @@
     <comment>Property name</comment>
   </data>
   <data name="Activity_DecryptFile_Property_KeyFormat_Description" xml:space="preserve">
-    <value>Encoding of the Key string: Hex (e.g. 64 chars for an AES-256 key) or Base64.</value>
+    <value>Encoding of the Key string: Hex (e.g. 64 chars for an AES-256 key) or Base64. Base64 input tolerates whitespace, line wraps, URL-safe characters (- and _), and missing padding.</value>
     <comment>Property description</comment>
   </data>
   <data name="Activity_DecryptFile_Property_KdfIterations_Name" xml:space="preserve">

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -1121,7 +1121,9 @@ namespace UiPath.Cryptography
             int rem = cleaned.Length % 4;
             if (rem == 2) cleaned.Append("==");
             else if (rem == 3) cleaned.Append('=');
-            else if (rem != 0) throw new ArgumentException("Base64 string has an invalid length.");
+            // rem == 1 can never be valid Base64; leave it for Convert.FromBase64String to
+            // reject, so malformed input surfaces as FormatException consistently with the
+            // rest of the Base64 contract rather than a different exception type.
             return Convert.FromBase64String(cleaned.ToString());
         }
 

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -1059,10 +1059,11 @@ namespace UiPath.Cryptography
 
                 case KeyBytesFormat.Base64:
                 {
-                    string raw = keyString ?? (keySecureString != null ? new NetworkCredential(string.Empty, keySecureString).Password : null);
-                    if (string.IsNullOrEmpty(raw))
-                        throw new ArgumentException("Base64 key/IV string is empty.");
-                    return FromBase64String(raw);
+                    if (!string.IsNullOrEmpty(keyString))
+                        return FromBase64String(keyString);
+                    if (keySecureString != null && keySecureString.Length > 0)
+                        return SecureStringHelpers.WithSecureChars(keySecureString, chars => FromBase64String(chars));
+                    throw new ArgumentException("Base64 key/IV string is empty.");
                 }
 
                 default:
@@ -1105,26 +1106,42 @@ namespace UiPath.Cryptography
             }
         }
 
-        private static byte[] FromBase64String(string s)
+        // Takes ReadOnlySpan<char> (not string) so a SecureString-derived char[] can be parsed
+        // without ever producing a managed string — mirroring FromHexString and preserving the
+        // no-managed-string guarantee of the SecureString key path (STUD-80531). The cleaned
+        // scratch buffer holds a copy of the secret key material, so it is zeroed in finally.
+        // It is a char[] (not stackalloc) because Convert.FromBase64CharArray needs an array;
+        // a key/IV is short, so the allocation is negligible.
+        private static byte[] FromBase64String(ReadOnlySpan<char> s)
         {
             // Tolerate whitespace/line wraps, the URL-safe alphabet, and missing padding —
             // common forms a third-party tool (openssl, JWT/OAuth secrets) produces. The final
-            // Convert.FromBase64String call still enforces strict validation on the cleaned text.
-            var cleaned = new StringBuilder(s.Length);
-            foreach (char c in s)
+            // Convert.FromBase64CharArray call still enforces strict validation on the cleaned
+            // text: characters outside the alphabet and a mod-4==1 length both surface as
+            // FormatException, consistent with the rest of the Base64 contract.
+            char[] cleaned = new char[s.Length + 2]; // +2 head-room for the padding we may append
+            try
             {
-                if (c == ' ' || c == '\t' || c == '\r' || c == '\n') continue;
-                if (c == '-') cleaned.Append('+');      // URL-safe alphabet → standard
-                else if (c == '_') cleaned.Append('/');
-                else cleaned.Append(c);
+                int n = 0;
+                foreach (char c in s)
+                {
+                    if (c == ' ' || c == '\t' || c == '\r' || c == '\n') continue;
+                    if (c == '-') cleaned[n++] = '+';        // URL-safe alphabet → standard
+                    else if (c == '_') cleaned[n++] = '/';
+                    else cleaned[n++] = c;
+                }
+                int rem = n % 4;
+                if (rem == 2) { cleaned[n++] = '='; cleaned[n++] = '='; }
+                else if (rem == 3) { cleaned[n++] = '='; }
+                // rem == 1 can never be valid Base64; leave it for Convert.FromBase64CharArray
+                // to reject as FormatException, consistent with the rest of the Base64 contract.
+                return Convert.FromBase64CharArray(cleaned, 0, n);
             }
-            int rem = cleaned.Length % 4;
-            if (rem == 2) cleaned.Append("==");
-            else if (rem == 3) cleaned.Append('=');
-            // rem == 1 can never be valid Base64; leave it for Convert.FromBase64String to
-            // reject, so malformed input surfaces as FormatException consistently with the
-            // rest of the Base64 contract rather than a different exception type.
-            return Convert.FromBase64String(cleaned.ToString());
+            finally
+            {
+                // Zero the secret-bearing scratch buffer before the frame unwinds.
+                Array.Clear(cleaned, 0, cleaned.Length);
+            }
         }
 
         /// <summary>

--- a/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
+++ b/Activities/Cryptography/UiPath.Cryptography/CryptographyHelper.cs
@@ -1059,11 +1059,10 @@ namespace UiPath.Cryptography
 
                 case KeyBytesFormat.Base64:
                 {
-                    if (!string.IsNullOrEmpty(keyString))
-                        return Convert.FromBase64String(keyString);
-                    if (keySecureString != null && keySecureString.Length > 0)
-                        return SecureStringHelpers.WithSecureChars(keySecureString, chars => Convert.FromBase64CharArray(chars, 0, chars.Length));
-                    throw new ArgumentException("Base64 key/IV string is empty.");
+                    string raw = keyString ?? (keySecureString != null ? new NetworkCredential(string.Empty, keySecureString).Password : null);
+                    if (string.IsNullOrEmpty(raw))
+                        throw new ArgumentException("Base64 key/IV string is empty.");
+                    return FromBase64String(raw);
                 }
 
                 default:
@@ -1104,6 +1103,26 @@ namespace UiPath.Cryptography
                 // Zero the secret-bearing scratch buffer (covers both the stackalloc and heap-allocated cases).
                 cleaned.Clear();
             }
+        }
+
+        private static byte[] FromBase64String(string s)
+        {
+            // Tolerate whitespace/line wraps, the URL-safe alphabet, and missing padding —
+            // common forms a third-party tool (openssl, JWT/OAuth secrets) produces. The final
+            // Convert.FromBase64String call still enforces strict validation on the cleaned text.
+            var cleaned = new StringBuilder(s.Length);
+            foreach (char c in s)
+            {
+                if (c == ' ' || c == '\t' || c == '\r' || c == '\n') continue;
+                if (c == '-') cleaned.Append('+');      // URL-safe alphabet → standard
+                else if (c == '_') cleaned.Append('/');
+                else cleaned.Append(c);
+            }
+            int rem = cleaned.Length % 4;
+            if (rem == 2) cleaned.Append("==");
+            else if (rem == 3) cleaned.Append('=');
+            else if (rem != 0) throw new ArgumentException("Base64 string has an invalid length.");
+            return Convert.FromBase64String(cleaned.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
## Context
The Cryptography package's symmetric activities (EncryptText/File, DecryptText/File) support a `Format = Raw` mode where the user supplies a literal key as bytes, encoded either as Hex or Base64 (the `KeyBytesFormat` dropdown). Key parsing is centralized in `CryptographyHelper.ParseKeyBytes`, which both the activities and `SymmetricInteropHelper.ParseKeyOrIv` route through. This is the headline interop path for round-tripping keys produced by third-party tools (openssl, JWT/OAuth).

## Problem Statement
The Hex branch of `ParseKeyBytes` tolerates the artefacts users actually paste into a key field (a `0x` prefix, whitespace, colons, dashes) via its `FromHexString` pre-cleaner. The Base64 branch called `Convert.FromBase64String(raw)` directly, so it rejected two common third-party forms with `FormatException`: the URL-safe alphabet (`-`/`_`, as emitted for JWT secrets / OAuth client_secrets) and Base64 with stripped `=` padding. The "works for Hex / fails for Base64" asymmetry made the contract feel arbitrary for the format's main interop use case.

## Analysis
`CryptographyHelper.ParseKeyBytes` (Base64 branch) had no pre-cleaning step, unlike the Hex branch's `FromHexString`. Note `Convert.FromBase64String` already ignores embedded whitespace/CR/LF, so line wraps and surrounding whitespace were never the actual failure — only the URL-safe alphabet and missing padding threw.

## Behavior Before This PR
Configuring EncryptText with `Format=Raw, KeyBytesFormat=Base64` and pasting a URL-safe key (e.g. a JWT secret containing `-`/`_`) or a key with its `=` padding stripped throws `FormatException` at parse time, before any encryption runs.

## Behavior After This PR
The same URL-safe or unpadded Base64 key parses successfully: a new `FromBase64String` pre-cleaner (mirroring `FromHexString`) maps the URL-safe alphabet to standard and restores missing padding, then delegates to `Convert.FromBase64String` for the final strict validation. Genuinely malformed input (out-of-alphabet characters, a length-mod-4 == 1 stem) still throws.

## Considered Use Cases
- URL-safe Base64 with `-`/`_` (JWT / OAuth secrets) → now accepted
- Base64 with stripped `=` padding (remainder 2 and 3) → now accepted
- openssl line-wrapped key + trailing newline; surrounding whitespace → still accepted (compatibility guards)
- Garbage characters, length-mod-4 == 1 stem → still rejected (no silent acceptance)
- Standard Base64 keys → decode to identical bytes (no backward-compat change)

## Implementation
The final `Convert.FromBase64String` call is retained as the strict validator — only the surface that meets the user becomes lenient, so the produced bytes stay deterministic. Hex branch and downstream key-length validation are unchanged. Builds on the symmetric interop work in STUD=64429 / STUD=80231.

## How to Test
- `dotnet test Activities/Activities.Cryptography.sln` — full suite green (783 + 123).
- New tolerance + pin tests in `CryptographyHelperInteropTests.cs`; e2e round-trip guard `Raw_AesCbc_Base64KeyWithLineWrap_InternalToExternal` in `ExternalInteropInProcessTests.cs`.