### PR TITLE
fix(cryptography): preserve persisted KeyFormat on Format reload [STUD-80535]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKeyFormatTests.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Tests/FormatChangeKeyFormatTests.cs
@@ -1,0 +1,107 @@
+using System.Activities.DesignViewModels;
+using Moq;
+using Shouldly;
+using UiPath.Cryptography;
+using UiPath.Cryptography.Activities.NetCore.ViewModels;
+using Xunit;
+
+namespace UiPath.Cryptography.Activities.Tests
+{
+    /// <summary>
+    /// Guards the contract of <c>FormatChanged_Action</c> on the symmetric Encrypt/Decrypt ViewModels
+    /// for the <c>KeyFormat</c> dropdown. The action is wired as a Format rule, so it ALSO fires on reload
+    /// when the persisted Format value is applied to the design property. It therefore must preserve a
+    /// user-selected Hex/Base64 raw-key format and only correct the Encoded default (which Raw's dropdown
+    /// doesn't offer) up to Hex — overwriting it unconditionally dropped a saved Base64 selection back to
+    /// Hex on every reopen (STUD-80535).
+    /// </summary>
+    public class FormatChangeKeyFormatTests
+    {
+        private static EncryptTextViewModel NewEncryptViewModel() =>
+            new EncryptTextViewModel(Mock.Of<IDesignServices>());
+
+        private static DecryptTextViewModel NewDecryptViewModel() =>
+            new DecryptTextViewModel(Mock.Of<IDesignServices>());
+
+        [Fact]
+        public void Encrypt_RawReload_PreservesSelectedBase64KeyFormat()
+        {
+            var vm = NewEncryptViewModel();
+            // User selects Raw, then picks Base64 over the Hex default.
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+            vm.KeyFormat.Value = KeyBytesFormat.Base64;
+
+            // Reopening the XAML re-applies the persisted Format value, firing the rule again.
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Base64);
+        }
+
+        [Fact]
+        public void Decrypt_RawReload_PreservesSelectedBase64KeyFormat()
+        {
+            var vm = NewDecryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+            vm.KeyFormat.Value = KeyBytesFormat.Base64;
+
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Base64);
+        }
+
+        [Fact]
+        public void Encrypt_FormatChangeToRaw_SnapsEncodedDefaultToHex()
+        {
+            var vm = NewEncryptViewModel();
+            vm.KeyFormat.Value = KeyBytesFormat.Encoded;
+
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Hex);
+        }
+
+        [Fact]
+        public void Decrypt_FormatChangeToRaw_SnapsEncodedDefaultToHex()
+        {
+            var vm = NewDecryptViewModel();
+            vm.KeyFormat.Value = KeyBytesFormat.Encoded;
+
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Hex);
+        }
+
+        [Fact]
+        public void Encrypt_FormatChangeToNonRaw_ForcesEncoded()
+        {
+            var vm = NewEncryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+            vm.KeyFormat.Value = KeyBytesFormat.Base64;
+
+            // Leaving Raw: the field is hidden and runtime rejects Hex/Base64 for non-Raw formats.
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Encoded);
+        }
+
+        [Fact]
+        public void Decrypt_FormatChangeToNonRaw_ForcesEncoded()
+        {
+            var vm = NewDecryptViewModel();
+            vm.Format.Value = SymmetricWireFormat.Raw;
+            vm.FormatChanged_Action();
+            vm.KeyFormat.Value = KeyBytesFormat.Base64;
+
+            vm.Format.Value = SymmetricWireFormat.Owasp2026;
+            vm.FormatChanged_Action();
+
+            vm.KeyFormat.Value.ShouldBe(KeyBytesFormat.Encoded);
+        }
+    }
+}

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/DecryptCryptoViewModelBase.cs
@@ -343,11 +343,23 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
                     KdfIterations.Value = CryptographyHelper.GetRecommendedIterations(Format.Value);
                 }
             }
-            // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
-            // Encoded otherwise (so non-Raw runtime validation passes).
-            KeyFormat.Value = Format.Value == SymmetricWireFormat.Raw
-                ? KeyBytesFormat.Hex
-                : KeyBytesFormat.Encoded;
+            // Snap KeyFormat to a value valid for the new Format. This action also fires on reload,
+            // when the persisted Format value is applied to the design property — so for Raw we must
+            // preserve the user's persisted Hex/Base64 choice and only correct the Encoded default
+            // (which Raw's dropdown doesn't even offer) up to Hex. Overwriting it unconditionally
+            // dropped a saved Base64 selection back to Hex on every reopen. Non-Raw formats hide the
+            // field and reject Hex/Base64 at runtime, so they always snap back to Encoded.
+            if (Format.Value == SymmetricWireFormat.Raw)
+            {
+                if (KeyFormat.Value == KeyBytesFormat.Encoded)
+                {
+                    KeyFormat.Value = KeyBytesFormat.Hex;
+                }
+            }
+            else
+            {
+                KeyFormat.Value = KeyBytesFormat.Encoded;
+            }
         }
 
         private void ApplyInteropVisibility()

--- a/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities/NetCore/ViewModels/EncryptCryptoViewModelBase.cs
@@ -363,11 +363,23 @@ namespace UiPath.Cryptography.Activities.NetCore.ViewModels
                     KdfIterations.Value = CryptographyHelper.GetRecommendedIterations(Format.Value);
                 }
             }
-            // Snap KeyFormat: Hex when Raw (so the dropdown lands on a valid option),
-            // Encoded otherwise (so non-Raw runtime validation passes).
-            KeyFormat.Value = Format.Value == SymmetricWireFormat.Raw
-                ? KeyBytesFormat.Hex
-                : KeyBytesFormat.Encoded;
+            // Snap KeyFormat to a value valid for the new Format. This action also fires on reload,
+            // when the persisted Format value is applied to the design property — so for Raw we must
+            // preserve the user's persisted Hex/Base64 choice and only correct the Encoded default
+            // (which Raw's dropdown doesn't even offer) up to Hex. Overwriting it unconditionally
+            // dropped a saved Base64 selection back to Hex on every reopen. Non-Raw formats hide the
+            // field and reject Hex/Base64 at runtime, so they always snap back to Encoded.
+            if (Format.Value == SymmetricWireFormat.Raw)
+            {
+                if (KeyFormat.Value == KeyBytesFormat.Encoded)
+                {
+                    KeyFormat.Value = KeyBytesFormat.Hex;
+                }
+            }
+            else
+            {
+                KeyFormat.Value = KeyBytesFormat.Encoded;
+            }
         }
 
         private void ApplyInteropVisibility()


### PR DESCRIPTION
Problem

On EncryptText/DecryptText (and the file variants), with Format = Raw, changing the key bytes format (KeyFormat) from Hex to Base64, saving the XAML, and reopening it reverts the selection back to Hex. The user's choice appears not to persist.

Root cause

FormatChanged_Action in EncryptCryptoViewModelBase and DecryptCryptoViewModelBase ended with an unconditional snap:

KeyFormat.Value = Format.Value == SymmetricWireFormat.Raw
    ? KeyBytesFormat.Hex
    : KeyBytesFormat.Encoded;

This method is registered as a Rule(nameof(Format), …), so it fires not only on user interaction but also on reload, when the persisted Format = Raw value is re-applied to the design property. At that moment it overwrote the correctly-persisted Base64 with Hex.

The value was being serialized to the XAML — it was being clobbered immediately on reopen. This is the same "rule fires on load" trap that f5bddc5 (#576) fixed for KdfIterations, but that change explicitly left KeyFormat untouched.

Fix

In the Raw branch, only correct the invalid Encoded default (which the Raw dropdown doesn't even offer) up to Hex, and preserve a user-selected Hex/Base64:

if (Format.Value == SymmetricWireFormat.Raw)
{
    if (KeyFormat.Value == KeyBytesFormat.Encoded)
        KeyFormat.Value = KeyBytesFormat.Hex;
}
else
{
    KeyFormat.Value = KeyBytesFormat.Encoded;
}

The non-Raw branch is unchanged — those formats hide the field and require Encoded at runtime. Applied to both the Encrypt and Decrypt base ViewModels.

Tests

New FormatChangeKeyFormatTests (6 tests, Encrypt + Decrypt):
- Reload preserves a selected Base64 — reproduces the bug
- Encoded default snaps to Hex when entering Raw
- Non-Raw forces Encoded

All 12 FormatChange* tests pass (6 new + 6 existing KdfIterations).

Impact

- No public contract or runtime-behavior change; design-time only.
- No effect on existing workflows whose KeyFormat is already Hex or Encoded.

🤖 Generated with Claude Code (https://claude.com/claude-code)

https://uipath.atlassian.net/browse/STUD-80535

**How to reproduce**
For raw encryption - set Base64 and reopen the xaml -> notice that it changes back to Hex