### PR TITLE
docs(cryptography): fix gaps in activity and coded-API docs [STUD-80530]

### DIFF
--- a/Activities/Cryptography/UiPath.Cryptography.Activities.API/Services/ICryptographyService.cs
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.API/Services/ICryptographyService.cs
@@ -74,18 +74,21 @@ namespace UiPath.Cryptography.Activities.API
         byte[] DecryptBytes(byte[] input, EncryptionAlgorithm algorithm, SymmetricDecryptOptions options);
 
         /// <summary>
-        /// Encrypts a string and returns the ciphertext as Base64. The input string is always
-        /// transcoded to bytes via <see cref="System.Text.Encoding.UTF8"/> — there is no
-        /// encoding parameter. For non-UTF-8 text or for explicit encoding control, transcode
-        /// to bytes at the call site and use <see cref="EncryptBytes"/> instead.
+        /// Encrypts a string and returns the ciphertext as Base64. The input string is transcoded
+        /// to bytes via <c>options.TextEncoding</c> (set through the format factory's optional
+        /// <c>encoding:</c> parameter; defaults to <see cref="System.Text.Encoding.UTF8"/>). For
+        /// byte-exact control you can still transcode at the call site and use
+        /// <see cref="EncryptBytes"/> instead.
         /// </summary>
         string EncryptText(string input, EncryptionAlgorithm algorithm, SymmetricEncryptOptions options);
 
         /// <summary>
-        /// Decrypts a Base64-encoded ciphertext and returns the plaintext as a UTF-8 string.
-        /// The plaintext bytes are always decoded via <see cref="System.Text.Encoding.UTF8"/>
-        /// — there is no encoding parameter. For non-UTF-8 text or for explicit encoding
-        /// control, use <see cref="DecryptBytes"/> and decode at the call site.
+        /// Decrypts a Base64-encoded ciphertext and returns the plaintext as a string. The
+        /// plaintext bytes are decoded via <c>options.TextEncoding</c> (set through the format
+        /// factory's optional <c>encoding:</c> parameter; defaults to
+        /// <see cref="System.Text.Encoding.UTF8"/>) and must match the encoding used at encrypt
+        /// time. For byte-exact control you can still use <see cref="DecryptBytes"/> and decode
+        /// at the call site.
         /// </summary>
         string DecryptText(string input, EncryptionAlgorithm algorithm, SymmetricDecryptOptions options);
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptFile.md
@@ -17,10 +17,11 @@ Decrypts a file using a symmetric algorithm and key, or using PGP with a private
 | `InputFilePath` | File path | InArgument | `string` | Conditional |  | The path to the file that you want to decrypt. Paired with a hidden `IResource` alternative selectable via a designer menu action. |
 | `Key` | Key | InArgument | `string` | Conditional |  | The key used to decrypt the file. Provide either `Key` or `KeySecureString`. Symmetric algorithms only. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the key. Provide either `Key` or `KeySecureString`. Symmetric algorithms only. |
-| `KeyEncoding` | Key encoding | InArgument | `Encoding` |  |  | The encoding used to interpret the key. Symmetric algorithms only. |
+| `KeyEncoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to interpret the key. Symmetric algorithms only. |
 | `Format` | Wire format | Property | `SymmetricWireFormat` |  | `Classic` | The symmetric ciphertext layout to decrypt. Must match the format used at encrypt time. Symmetric algorithms only. |
 | `KeyFormat` | Key bytes format | Property | `KeyBytesFormat` |  | `Encoded` | How the `Key` string is interpreted. `Hex` or `Base64` are required when `Format = Raw`. Symmetric algorithms only. |
 | `KdfIterations` | KDF iterations | InArgument | `int` |  | `0` | PBKDF2 iteration count. Must match the value used at encrypt time. `0` uses the format's OWASP-recommended default. Rejected for `Classic` and `Raw`. |
+| `AesKeySize` | AES key size | Property | `AesKeySize` |  | `Aes256` | AES key size in bits used to encrypt the input. Applies only when `Algorithm = AES` and `Format = OpenSslEnc`; ignored otherwise. Must match the key size the producer used (e.g. `openssl enc -aes-128-cbc` / `-aes-192-cbc` / `-aes-256-cbc`). Not stored in the wire format — encrypt and decrypt sides must use matching values. |
 | `OutputFilePath` | Output file path | InArgument | `string` |  |  | The full path where the decrypted file will be saved. When empty, the file is written next to the input file using the name `<input-name>_Decrypted<input-extension>`. |
 | `OutputFileName` | Decrypted file name | InArgument | `string` |  |  | The file name to use for the decrypted file. Honored when `OutputFilePath` is empty. |
 | `PrivateKeyFilePath` | Private key file path | InArgument | `string` | Conditional |  | Path to your PGP private key file. Required when `Algorithm = PGP`. |
@@ -36,6 +37,12 @@ Decrypts a file using a symmetric algorithm and key, or using PGP with a private
 | `VerifySignature` | Verify signature | `bool` |  | `false` | When enabled, verifies the PGP signature of the decrypted data using the public key. PGP only. |
 | `ContinueOnError` | Continue on error | `InArgument<bool>` |  |  | Specifies if the automation should continue when the activity throws an error. |
 
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `DecryptedFile` | Decrypted file | OutArgument | `ILocalResource` | A resource handle to the file that was written. Hidden in the designer (`[Browsable(false)]`) but populated at runtime — bind it to chain the decrypted file into a downstream activity. The decrypted bytes are also written to disk at `OutputFilePath`, or — when `OutputFilePath` is empty — at the computed default path next to the input file (`<input-name>_Decrypted<input-extension>`). |
+
 ## Valid Configurations
 
 The activity has two modes selected by `Algorithm`:
@@ -45,6 +52,7 @@ The activity has two modes selected by `Algorithm`:
 - `KeyEncoding` defaults to UTF-8.
 - `Format` defaults to `Classic` — must match what was used at encrypt time. The IV (when present) is read from the ciphertext stream prefix automatically.
 - For `Owasp2026` and `OpenSslEnc`: set `KdfIterations` to the same value used at encrypt time.
+- For `OpenSslEnc` with `Algorithm = AES`: set `AesKeySize` to the same value used at encrypt time (also not carried in the wire format).
 - For `Raw`: set `KeyFormat = Hex` or `Base64` and supply the same raw key bytes used at encrypt time.
 - PGP properties (private/public key, passphrase, `VerifySignature`) are ignored.
 
@@ -62,6 +70,8 @@ The default symmetric format (`Classic`) is UiPath-specific (`salt(8) || IV || c
 **`SymmetricWireFormat`**: `Classic` (default), `Owasp2026`, `Raw`, `OpenSslEnc`.
 
 **`KeyBytesFormat`**: `Encoded` (default — string is a password), `Hex`, `Base64`. The activity's dropdown only surfaces `Hex` / `Base64` because `Encoded` is the implicit non-Raw choice.
+
+**`AesKeySize`**: `Aes128`, `Aes192`, `Aes256` (default). Only consulted when `Format = OpenSslEnc` and `Algorithm = AES`.
 
 ## XAML Example
 
@@ -105,4 +115,4 @@ PGP decrypt with signature verification:
 ## Notes
 
 - `Key` ↔ `KeySecureString` and `Passphrase` ↔ `PassphraseSecureString` are paired via a designer menu action: only one side of each pair is active at a time.
-- This activity has no `OutArgument` — the decrypted bytes are written to the file at `OutputFilePath`.
+- The decrypted bytes are written to the file at `OutputFilePath`, or — when `OutputFilePath` is empty — to the computed default path next to the input file (`<input-name>_Decrypted<input-extension>`). The activity also exposes a hidden `DecryptedFile` output (`OutArgument<ILocalResource>`) — see the Output table above.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/DecryptText.md
@@ -17,10 +17,12 @@ Decrypts a text string using a symmetric algorithm, or using PGP with a private 
 | `Input` | Text | InArgument | `string` | Yes |  | The encrypted text to decrypt (Base64-encoded for symmetric algorithms, ASCII-armored for PGP). |
 | `Key` | Key | InArgument | `string` | Conditional |  | The key used to decrypt the input. Provide either `Key` or `KeySecureString`. Symmetric algorithms only. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the key. Symmetric algorithms only. |
-| `Encoding` | Encoding | InArgument | `Encoding` |  |  | The encoding used to interpret the input text and the key. Symmetric algorithms only. |
+| `Encoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to interpret the key/password in `Key`. Surfaced in the designer as a "Key encoding" dropdown. Symmetric algorithms only. |
+| `PlaintextEncoding` | Text encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to convert the decrypted bytes back to text. Set this to match the encoding used by the tool that produced the ciphertext. Symmetric algorithms only. |
 | `Format` | Wire format | Property | `SymmetricWireFormat` |  | `Classic` | The symmetric ciphertext layout to decrypt. Must match the format used at encrypt time. Symmetric algorithms only. |
 | `KeyFormat` | Key bytes format | Property | `KeyBytesFormat` |  | `Encoded` | How the `Key` string is interpreted. `Hex` or `Base64` are required when `Format = Raw`. Symmetric algorithms only. |
 | `KdfIterations` | KDF iterations | InArgument | `int` |  | `0` | PBKDF2 iteration count. Must match the value used at encrypt time. `0` uses the format's OWASP-recommended default. Rejected for `Classic` and `Raw`. |
+| `AesKeySize` | AES key size | Property | `AesKeySize` |  | `Aes256` | AES key size in bits used to encrypt the input. Applies only when `Algorithm = AES` and `Format = OpenSslEnc`; ignored otherwise. Must match the key size the producer used (e.g. `openssl enc -aes-128-cbc` / `-aes-192-cbc` / `-aes-256-cbc`). Not stored in the wire format — encrypt and decrypt sides must use matching values. |
 | `PrivateKeyFilePath` | Private key file path | InArgument | `string` | Conditional |  | Path to your PGP private key file. Required when `Algorithm = PGP`. |
 | `Passphrase` | Passphrase | InArgument | `string` | Conditional |  | Passphrase that unlocks the private key. Provide either `Passphrase` or `PassphraseSecureString`. PGP only. |
 | `PassphraseSecureString` | Passphrase (secure) | InArgument | `SecureString` | Conditional |  | Secure-string variant of the passphrase. PGP only. |
@@ -45,15 +47,16 @@ The activity has two modes selected by `Algorithm`:
 
 **Symmetric mode** (`AESGCM`, `ChaCha20Poly1305`, `AES`, `TripleDES`, `DES`, `RC2`, `Rijndael`):
 - Provide `Input`, `Algorithm`, and exactly one of `Key` / `KeySecureString`.
-- `Encoding` defaults to UTF-8.
+- `Encoding` (key/password) and `PlaintextEncoding` (output text) are independent and **both default to UTF-8**. Set either one alone — e.g. change only `PlaintextEncoding` to match the encoding used at encrypt time, while leaving the key as UTF-8.
 - `Format` defaults to `Classic` — must match what was used at encrypt time. The IV (when present) is read from the ciphertext stream prefix automatically.
 - For `Owasp2026` and `OpenSslEnc`: set `KdfIterations` to the same value used at encrypt time (the iteration count is **not** carried in the wire format).
+- For `OpenSslEnc` with `Algorithm = AES`: set `AesKeySize` to the same value used at encrypt time (also not carried in the wire format).
 - For `Raw`: set `KeyFormat = Hex` or `Base64` and supply the same raw key bytes used at encrypt time.
 
 **PGP mode** (`Algorithm = PGP`):
 - Provide `Input`, `PrivateKeyFilePath`, and exactly one of `Passphrase` / `PassphraseSecureString`.
 - Set `VerifySignature = True` and provide `PublicKeyFilePath` to additionally verify the embedded signature.
-- Symmetric properties (`Key`, `KeySecureString`, `Encoding`, `Format`, `KeyFormat`, `KdfIterations`) are ignored.
+- Symmetric properties (`Key`, `KeySecureString`, `Encoding`, `PlaintextEncoding`, `Format`, `KeyFormat`, `KdfIterations`) are ignored.
 
 The default symmetric format (`Classic`) is UiPath-specific (`salt(8) || IV || ciphertext [|| tag]`, PBKDF2-HMAC-SHA1 @ 10 000 iterations). Use `Raw` or `OpenSslEnc` to decrypt ciphertext produced by `openssl enc`, Java `javax.crypto`, Python `cryptography`, browser tools, etc. See `docs/symmetric-wire-format.md` for byte layouts and decoder examples.
 
@@ -64,6 +67,8 @@ The default symmetric format (`Classic`) is UiPath-specific (`salt(8) || IV || c
 **`SymmetricWireFormat`**: `Classic` (default), `Owasp2026`, `Raw`, `OpenSslEnc`.
 
 **`KeyBytesFormat`**: `Encoded` (default — string is a password), `Hex`, `Base64`. The activity's dropdown only surfaces `Hex` / `Base64` because `Encoded` is the implicit non-Raw choice.
+
+**`AesKeySize`**: `Aes128`, `Aes192`, `Aes256` (default). Only consulted when `Format = OpenSslEnc` and `Algorithm = AES`.
 
 ## XAML Example
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptFile.md
@@ -17,11 +17,12 @@ Encrypts a file using a symmetric algorithm and key, or using PGP with a recipie
 | `InputFilePath` | File path | InArgument | `string` | Conditional |  | The path to the file that you want to encrypt. Paired with a hidden `IResource` alternative selectable via a designer menu action. |
 | `Key` | Key | InArgument | `string` | Conditional |  | The key used to encrypt the file. Provide either `Key` or `KeySecureString`. Symmetric algorithms only. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the key. Symmetric algorithms only. |
-| `KeyEncoding` | Key encoding | InArgument | `Encoding` |  |  | The encoding used to interpret the key. Symmetric algorithms only. |
+| `KeyEncoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to interpret the key. Symmetric algorithms only. |
 | `Format` | Wire format | Property | `SymmetricWireFormat` |  | `Classic` | The symmetric ciphertext layout. `Classic` (default) is UiPath's byte-stable layout; `Owasp2026` uses the same layout with stronger KDF iterations; `Raw` is caller-supplied key + IV for third-party interop; `OpenSslEnc` produces `openssl enc`-compatible output. Symmetric algorithms only. |
 | `KeyFormat` | Key bytes format | Property | `KeyBytesFormat` |  | `Encoded` | How the `Key` string is interpreted. `Hex` or `Base64` are required when `Format = Raw`. Symmetric algorithms only. |
 | `Iv` | IV | InArgument | `string` | Conditional |  | Initialization vector when `Format = Raw`. Interpreted per `KeyFormat`. Optional — leave empty to let the cipher generate one. Rejected for all other formats. |
 | `KdfIterations` | KDF iterations | InArgument | `int` |  | `0` | PBKDF2 iteration count. `0` uses the format's OWASP-recommended default (1 300 000 for `Owasp2026`, 600 000 for `OpenSslEnc`). Rejected for `Classic` and `Raw`. |
+| `AesKeySize` | AES key size | Property | `AesKeySize` |  | `Aes256` | AES key size in bits. Applies only when `Algorithm = AES` and `Format = OpenSslEnc`; ignored otherwise. Must match the key size the peer uses (e.g. `openssl enc -aes-128-cbc` / `-aes-192-cbc` / `-aes-256-cbc`). Not stored in the wire format — encrypt and decrypt sides must use matching values. |
 | `OutputFilePath` | Output file path | InArgument | `string` |  |  | The full path where the encrypted file will be saved. When empty, the file is written next to the input file using the name `<input-name>_Encrypted<input-extension>`. |
 | `OutputFileName` | Encrypted file name | InArgument | `string` |  |  | The file name to use for the encrypted file. Honored when `OutputFilePath` is empty. |
 | `PublicKeyFilePath` | Public key file path | InArgument | `string` | Conditional |  | Path to the recipient's PGP public key file. Required when `Algorithm = PGP`. |
@@ -37,6 +38,12 @@ Encrypts a file using a symmetric algorithm and key, or using PGP with a recipie
 | `SignData` | Sign data | `bool` |  | `false` | When enabled, signs the encrypted data using the private key. PGP only. |
 | `ContinueOnError` | Continue on error | `InArgument<bool>` |  |  | Specifies if the automation should continue when the activity throws an error. |
 
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `EncryptedFile` | Encrypted file | OutArgument | `ILocalResource` | A resource handle to the file that was written. Hidden in the designer (`[Browsable(false)]`) but populated at runtime — bind it to chain the encrypted file into a downstream activity. The encrypted bytes are also written to disk at `OutputFilePath`, or — when `OutputFilePath` is empty — at the computed default path next to the input file (`<input-name>_Encrypted<input-extension>`). |
+
 ## Valid Configurations
 
 The activity has two modes selected by `Algorithm`:
@@ -46,6 +53,7 @@ The activity has two modes selected by `Algorithm`:
 - `KeyEncoding` defaults to UTF-8.
 - `Format` defaults to `Classic` — existing workflows that omit this property produce the same byte-stable output as before.
 - For `Owasp2026` or `OpenSslEnc`: `KeyFormat` stays `Encoded`; optionally set `KdfIterations`.
+- For `OpenSslEnc` with `Algorithm = AES`: optionally set `AesKeySize` (`Aes128` / `Aes192` / `Aes256`, default `Aes256`) to match the peer's `openssl enc -aes-N-cbc`.
 - For `Raw`: set `KeyFormat = Hex` or `Base64` and supply a literal cipher key. `Iv` is optional. `KdfIterations` is rejected.
 - PGP properties (`PublicKeyFilePath`, `PrivateKeyFilePath`, `Passphrase`, `SignData`) are ignored.
 
@@ -65,6 +73,8 @@ The default symmetric format (`Classic`) is UiPath-specific (`salt(8) || IV || c
 **`SymmetricWireFormat`**: `Classic` (default), `Owasp2026`, `Raw`, `OpenSslEnc`.
 
 **`KeyBytesFormat`**: `Encoded` (default — string is a password), `Hex`, `Base64`. The activity's dropdown only surfaces `Hex` / `Base64` because `Encoded` is the implicit non-Raw choice.
+
+**`AesKeySize`**: `Aes128`, `Aes192`, `Aes256` (default). Only consulted when `Format = OpenSslEnc` and `Algorithm = AES`.
 
 ## XAML Example
 
@@ -108,4 +118,4 @@ PGP encrypt and sign:
 ## Notes
 
 - `Key` ↔ `KeySecureString` and `Passphrase` ↔ `PassphraseSecureString` are paired via a designer menu action: only one side of each pair is active at a time.
-- This activity has no `OutArgument` — the encrypted bytes are written to the file at `OutputFilePath`.
+- The encrypted bytes are written to the file at `OutputFilePath`, or — when `OutputFilePath` is empty — to the computed default path next to the input file (`<input-name>_Encrypted<input-extension>`). The activity also exposes a hidden `EncryptedFile` output (`OutArgument<ILocalResource>`) — see the Output table above.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/EncryptText.md
@@ -17,11 +17,13 @@ Encrypts a text string using a symmetric algorithm, or using PGP with a recipien
 | `Input` | Text | InArgument | `string` | Yes |  | The text that you want to encrypt. |
 | `Key` | Key | InArgument | `string` | Conditional |  | The key used to encrypt the input. Provide either `Key` or `KeySecureString`. Symmetric algorithms only. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the key. Symmetric algorithms only. |
-| `Encoding` | Encoding | InArgument | `Encoding` |  |  | The encoding used to interpret the input text and the key. Symmetric algorithms only. |
+| `Encoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to interpret the key/password in `Key`. Surfaced in the designer as a "Key encoding" dropdown. Symmetric algorithms only. |
+| `PlaintextEncoding` | Text encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to convert the input text to bytes before encryption. Set this to match the encoding expected by the third-party tool that will consume the ciphertext. Symmetric algorithms only. |
 | `Format` | Wire format | Property | `SymmetricWireFormat` |  | `Classic` | The symmetric ciphertext layout. `Classic` (default) is UiPath's byte-stable layout; `Owasp2026` uses the same layout with stronger KDF iterations; `Raw` is caller-supplied key + IV for third-party interop; `OpenSslEnc` produces `openssl enc`-compatible output. Symmetric algorithms only. |
 | `KeyFormat` | Key bytes format | Property | `KeyBytesFormat` |  | `Encoded` | How the `Key` string is interpreted. `Hex` or `Base64` are required when `Format = Raw`; otherwise the key is treated as a password. Symmetric algorithms only. |
 | `Iv` | IV | InArgument | `string` | Conditional |  | Initialization vector when `Format = Raw`. Interpreted per `KeyFormat`. Optional — leave empty to let the cipher generate one. Rejected for all other formats. |
 | `KdfIterations` | KDF iterations | InArgument | `int` |  | `0` | PBKDF2 iteration count. `0` uses the format's OWASP-recommended default (1 300 000 for `Owasp2026`, 600 000 for `OpenSslEnc`). Rejected for `Classic` and `Raw`. |
+| `AesKeySize` | AES key size | Property | `AesKeySize` |  | `Aes256` | AES key size in bits. Applies only when `Algorithm = AES` and `Format = OpenSslEnc`; ignored otherwise. Must match the key size the peer uses (e.g. `openssl enc -aes-128-cbc` / `-aes-192-cbc` / `-aes-256-cbc`). Not stored in the wire format — encrypt and decrypt sides must use matching values. |
 | `PublicKeyFilePath` | Public key file path | InArgument | `string` | Conditional |  | Path to the recipient's PGP public key file. Required when `Algorithm = PGP`. |
 | `PrivateKeyFilePath` | Private key file path | InArgument | `string` | Conditional |  | Path to your PGP private key file. Required only when `SignData = True`. |
 | `Passphrase` | Passphrase | InArgument | `string` | Conditional |  | Passphrase that unlocks the private key (signing). Provide either `Passphrase` or `PassphraseSecureString`. PGP-sign only. |
@@ -44,13 +46,14 @@ Encrypts a text string using a symmetric algorithm, or using PGP with a recipien
 
 **Symmetric mode** (`AESGCM`, `ChaCha20Poly1305`, `AES`, `TripleDES`, `DES`, `RC2`, `Rijndael`):
 - Provide `Input`, `Algorithm`, and exactly one of `Key` / `KeySecureString`.
-- `Encoding` defaults to UTF-8.
+- `Encoding` (key/password) and `PlaintextEncoding` (input text) are independent and **both default to UTF-8**. Set either one alone — e.g. change only `PlaintextEncoding` to match the encoding the consumer expects, while leaving the key as UTF-8.
 - `Format` defaults to `Classic` — existing workflows that omit this property produce the same byte-stable output as before.
 - For `Owasp2026` or `OpenSslEnc`: `KeyFormat` stays `Encoded`; optionally set `KdfIterations`.
+- For `OpenSslEnc` with `Algorithm = AES`: optionally set `AesKeySize` (`Aes128` / `Aes192` / `Aes256`, default `Aes256`) to match the peer's `openssl enc -aes-N-cbc`.
 - For `Raw`: set `KeyFormat = Hex` or `Base64` and supply a literal cipher key. `Iv` is optional. `KdfIterations` is rejected.
 
 **PGP encrypt only** (`Algorithm = PGP`, `SignData = False`):
-- Provide `Input` and `PublicKeyFilePath` (recipient). Symmetric `Format` / `KeyFormat` / `Iv` / `KdfIterations` are ignored.
+- Provide `Input` and `PublicKeyFilePath` (recipient). Symmetric properties (`Key`, `KeySecureString`, `Encoding`, `PlaintextEncoding`, `Format`, `KeyFormat`, `Iv`, `KdfIterations`) are ignored.
 
 **PGP encrypt + sign** (`Algorithm = PGP`, `SignData = True`):
 - Provide `Input`, `PublicKeyFilePath`, `PrivateKeyFilePath`, and exactly one of `Passphrase` / `PassphraseSecureString`.
@@ -64,6 +67,8 @@ The default symmetric format (`Classic`) is UiPath-specific (`salt(8) || IV || c
 **`SymmetricWireFormat`**: `Classic` (default), `Owasp2026`, `Raw`, `OpenSslEnc`.
 
 **`KeyBytesFormat`**: `Encoded` (default — string is a password), `Hex`, `Base64`. The activity's dropdown only surfaces `Hex` / `Base64` because `Encoded` is the implicit non-Raw choice.
+
+**`AesKeySize`**: `Aes128`, `Aes192`, `Aes256` (default). Only consulted when `Format = OpenSslEnc` and `Algorithm = AES`.
 
 ## XAML Example
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashFile.md
@@ -17,6 +17,7 @@ Hashes a file using the specified algorithm and returns the hexadecimal hash str
 | `FilePath` | File path | InArgument | `string` | Conditional |  | The path to the file you want to hash. Paired with a hidden `IResource` alternative selectable via a designer menu action. |
 | `Key` | Key | InArgument | `string` | Conditional |  | The HMAC key. Required when `Algorithm` is an HMAC variant. Provide either `Key` or `KeySecureString`. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the HMAC key. Required when `Algorithm` is an HMAC variant. |
+| `Encoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to convert the key to bytes. Surfaced in the designer as a "Key encoding" dropdown. File contents are hashed byte-for-byte regardless of this setting. |
 
 ### Configuration
 
@@ -34,7 +35,7 @@ Hashes a file using the specified algorithm and returns the hexadecimal hash str
 
 **Keyed (HMAC) mode** — `Algorithm` is one of `HMACMD5`, `HMACSHA1`, `HMACSHA256`, `HMACSHA384`, `HMACSHA512`:
 - Provide `FilePath`, `Algorithm`, and exactly one of `Key` / `KeySecureString`.
-- The key is interpreted as UTF-8.
+- The key is converted to bytes using the `Encoding` ("Key encoding") dropdown, which defaults to UTF-8. File contents are always hashed byte-for-byte.
 
 **Plain hash mode** — `Algorithm` is one of `SHA1`, `SHA256`, `SHA384`, `SHA512`:
 - Provide `FilePath` and `Algorithm`. `Key` / `KeySecureString` are not used.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/KeyedHashText.md
@@ -17,6 +17,7 @@ Hashes a text string using the specified algorithm and returns the hexadecimal h
 | `Input` | Text | InArgument | `string` | Yes |  | The text that you want to hash. |
 | `Key` | Key | InArgument | `string` | Conditional |  | The HMAC key. Required when `Algorithm` is an HMAC variant. Provide either `Key` or `KeySecureString`. |
 | `KeySecureString` | Key secure string | InArgument | `SecureString` | Conditional |  | Secure-string variant of the HMAC key. Required when `Algorithm` is an HMAC variant. |
+| `Encoding` | Key encoding | InArgument | `Encoding` |  | UTF-8 | The encoding used to convert the input text (and the key, in HMAC mode) to bytes before hashing. Surfaced in the designer as a "Key encoding" dropdown. |
 
 ### Configuration
 
@@ -34,10 +35,11 @@ Hashes a text string using the specified algorithm and returns the hexadecimal h
 
 **Keyed (HMAC) mode** — `Algorithm` is one of `HMACMD5`, `HMACSHA1`, `HMACSHA256`, `HMACSHA384`, `HMACSHA512`:
 - Provide `Input`, `Algorithm`, and exactly one of `Key` / `KeySecureString`.
-- The text and the key are both interpreted as UTF-8.
+- The input text and the key are converted to bytes using the `Encoding` ("Key encoding") dropdown, which defaults to UTF-8.
 
 **Plain hash mode** — `Algorithm` is one of `SHA1`, `SHA256`, `SHA384`, `SHA512`:
 - Provide `Input` and `Algorithm`. `Key` / `KeySecureString` are not used.
+- The input text is converted to bytes using the `Encoding` dropdown (default UTF-8).
 
 ### Enum Reference
 

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpClearSignFile.md
@@ -26,6 +26,12 @@ Creates a PGP clear-text signature of a file using a private key. The clearsigne
 | `Overwrite` | Overwrite | `bool` | `false` | If a file already exists at the output path, this overwrites it. |
 | `ContinueOnError` | Continue on error | `InArgument<bool>` |  | Specifies if the automation should continue when the activity throws an error. |
 
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ClearSignedFile` | Clearsigned file | OutArgument | `ILocalResource` | A resource handle to the clearsigned file that was written. Hidden in the designer (`[Browsable(false)]`) but populated at runtime — bind it to chain the file into a downstream activity. The clearsigned text is also written to `OutputFilePath`. |
+
 ## Valid Configurations
 
 - Provide `InputFilePath`, `PrivateKeyFilePath`, and `OutputFilePath`.
@@ -47,4 +53,4 @@ Creates a PGP clear-text signature of a file using a private key. The clearsigne
 - `Passphrase` ↔ `PassphraseSecureString` are paired via a designer menu action: only one side is active at a time.
 - The input file must be text — clearsigning is designed for ASCII/UTF-8 content. For binary data, use `PgpSignFile`.
 - Verify the output with `PgpVerify` in `ClearSignature` mode.
-- This activity has no `OutArgument` — the clearsigned text is written to the file at `OutputFilePath`.
+- The clearsigned text is written to the file at `OutputFilePath`. The activity also exposes a hidden `ClearSignedFile` output (`OutArgument<ILocalResource>`) — see the Output table above.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeys.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpGenerateKeys.md
@@ -27,6 +27,13 @@ Generates an OpenPGP public/private RSA key pair and saves them to the specified
 | `Overwrite` | Overwrite | `InArgument<bool>` | `false` | If files already exist at the output paths, this overwrites them. |
 | `ContinueOnError` | Continue on error | `InArgument<bool>` |  | Specifies if the automation should continue when the activity throws an error. |
 
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `PublicKeyFile` | Public key file | OutArgument | `ILocalResource` | A resource handle to the generated public key file. Hidden in the designer (`[Browsable(false)]`) but populated at runtime — bind it to chain the file into a downstream activity. The key is also written to `PublicKeyFilePath`. |
+| `PrivateKeyFile` | Private key file | OutArgument | `ILocalResource` | A resource handle to the generated private key file. Hidden in the designer (`[Browsable(false)]`) but populated at runtime. The key is also written to `PrivateKeyFilePath`. |
+
 ## Valid Configurations
 
 - Provide `PublicKeyFilePath`, `PrivateKeyFilePath`, and `UserId`.
@@ -52,5 +59,5 @@ Generates an OpenPGP public/private RSA key pair and saves them to the specified
 ## Notes
 
 - `Passphrase` ↔ `PassphraseSecureString` are paired via a designer menu action: only one side is active at a time.
-- This activity has no `OutArgument` — the generated keys are written to the file paths above.
+- The generated keys are written to the file paths above. The activity also exposes hidden `PublicKeyFile` / `PrivateKeyFile` outputs (`OutArgument<ILocalResource>`) — see the Output table above.
 - The default `KeySize` is `Rsa4096`, which meets NIST guidance through 2030+ and aligns with the strictest enterprise security recommendations.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/activities/PgpSignFile.md
@@ -26,6 +26,12 @@ Creates a PGP binary signature of a file using a private key. The signed output 
 | `Overwrite` | Overwrite | `bool` | `false` | If a file already exists at the output path, this overwrites it. |
 | `ContinueOnError` | Continue on error | `InArgument<bool>` |  | Specifies if the automation should continue when the activity throws an error. |
 
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `SignedFile` | Signed file | OutArgument | `ILocalResource` | A resource handle to the signed file that was written. Hidden in the designer (`[Browsable(false)]`) but populated at runtime — bind it to chain the signed file into a downstream activity. The signed bytes are also written to `OutputFilePath`. |
+
 ## Valid Configurations
 
 - Provide `InputFilePath`, `PrivateKeyFilePath`, and `OutputFilePath`.
@@ -46,4 +52,4 @@ Creates a PGP binary signature of a file using a private key. The signed output 
 
 - `Passphrase` ↔ `PassphraseSecureString` are paired via a designer menu action: only one side is active at a time.
 - Produces a binary OpenPGP signature. For a text-friendly armored signature that embeds the plaintext, use `PgpClearSignFile` instead.
-- This activity has no `OutArgument` — the signed bytes are written to the file at `OutputFilePath`.
+- The signed bytes are written to the file at `OutputFilePath`. The activity also exposes a hidden `SignedFile` output (`OutArgument<ILocalResource>`) — see the Output table above.

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/coded-api.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/coded-api.md
@@ -23,7 +23,7 @@ UiPath.Cryptography.Enums
 
 ## Service Overview
 
-The `cryptography` service exposes all operations as **direct method calls** — there is no connection, handle, or scope to open. Call methods on the service accessor directly:
+The `cryptography` service exposes all operations as **direct method calls** — there is no connection, handle, or scope to open. It is registered as a **stateless singleton**, so the accessor is shared across the workflow and its methods are safe to call concurrently. Call methods on the service accessor directly:
 
 ```csharp
 var key = PasswordKey.FromPassword("mykey", Encoding.UTF8);
@@ -63,6 +63,8 @@ Symmetric and keyed-hash operations take key material as one of two concrete `Cr
 
 Keyed-hash methods accept either subtype (they take `CryptoKey` directly — no wire-format axis).
 
+A `RawKey`'s length is **not** validated by `RawKey.FromBytes` / `FromHex` / `FromBase64`; it is checked when you call the encrypt/decrypt method, and an illegal length for the chosen algorithm throws `ArgumentException` listing the legal byte lengths (e.g. 16/24/32 for AES). Construct the key with exactly the algorithm's required key size.
+
 ### Symmetric wire format — `SymmetricEncryptOptions` / `SymmetricDecryptOptions`
 
 The options object bundles the key, wire format, and any format-specific knobs (IV for `Raw`, KDF iterations for `Owasp2026` / `OpenSslEnc`). Construct via a format factory — the factory's key-parameter type enforces the (key kind × wire format) pairing at compile time, so a `PasswordKey` cannot be passed to `Raw(...)` and a `RawKey` cannot be passed to `Classic(...)` etc.
@@ -75,6 +77,8 @@ The options object bundles the key, wire format, and any format-specific knobs (
 | `SymmetricEncryptOptions.OpenSslEnc(PasswordKey key, int kdfIterations = 600_000, Encoding encoding = null, AesKeySize aesKeySize = AesKeySize.Aes256)` | `OpenSslEnc` | `PasswordKey` | `openssl enc`-compatible (`Salted__` magic + PBKDF2-HMAC-SHA256). `aesKeySize` selects AES-128 / -192 / -256 to match the peer's `openssl enc -aes-N-cbc`. |
 
 The decrypt factories take the same shape (no `IV` on the decrypt side — the IV is read from the ciphertext stream automatically). The optional `encoding:` parameter sets `TextEncoding` on the options (defaults to UTF-8) and is only consulted by `EncryptText` / `DecryptText`.
+
+A constructed options object is read-only but **introspectable**: `CryptoOptions` exposes the getters `Key`, `Format`, `KdfIterations`, and `TextEncoding`; `SymmetricEncryptOptions` additionally exposes `IV` and `AesKeySize`, and `SymmetricDecryptOptions` exposes `AesKeySize`. All are set only through the factories (the setters are not public), so an options instance is immutable once built.
 
 See [`docs/symmetric-wire-format.md`](../../docs/symmetric-wire-format.md) for the full byte layouts and third-party interop reference.
 
@@ -101,13 +105,45 @@ PGP methods take strongly-typed key handles. Construct them once and reuse them 
 | `PgpPrivateKey.FromFilePath(string path, string passphrase)` | Private key from file. |
 | `PgpPrivateKey.FromFilePath(string path, SecureString passphrase)` | Private key from file with `SecureString`. |
 
-`PgpKeyPair` (returned by `PgpGenerateKeys`) holds a matched public/private pair. Use `pair.PublicKey` / `pair.PrivateKey`, or deconstruct with `var (pub, priv) = pair;`. Persist with `pair.PublicKey.Save(path)` / `pair.PrivateKey.Save(path)` when you need files on disk.
+Each key handle also exposes two instance methods:
+
+| Member | Purpose |
+|--------|---------|
+| `byte[] ToBytes()` | Returns a copy of the key bytes **as loaded** — ASCII-armored if the key was created from armored input, binary if loaded from binary; `ToBytes()` round-trips the original bytes rather than re-encoding them. Keys returned by `PgpGenerateKeys` are ASCII-armored. |
+| `void Save(string filePath, bool overwrite = false)` | Writes the key to disk. **Throws `InvalidOperationException` if the file exists and `overwrite` is `false`** — pass `overwrite: true` to replace an existing file. |
+
+`PgpKeyPair` (returned by `PgpGenerateKeys`, or constructed directly via `new PgpKeyPair(publicKey, privateKey)`) holds a matched public/private pair. Use `pair.PublicKey` / `pair.PrivateKey`, or deconstruct with `var (pub, priv) = pair;`. Persist with `pair.PublicKey.Save(path)` / `pair.PrivateKey.Save(path)` (add `overwrite: true` to replace existing files) when you need files on disk.
 
 Passing a `PgpPrivateKey` to an encrypt method implies signing; passing a `PgpPublicKey` to a decrypt method implies signature verification — separate `bool sign` / `bool verifySignature` flags are not used.
 
-### PGP passphrase limitation
+### PGP passphrase handling
 
-`PgpPrivateKey` carries its passphrase as a managed `string` because the underlying BouncyCastle library requires a plain string and offers no `byte[]`-based passphrase API. The `SecureString` factories materialise to a string at construction and cannot zero it afterward. For maximum security with PGP, prefer key rings without passphrase protection, or accept that the passphrase briefly exists as a managed string.
+`PgpPrivateKey` stores its passphrase as a `SecureString` for the lifetime of the instance (both the `string` and `SecureString` factories copy the supplied passphrase into one). It is materialised to a managed `string` only for the duration of each cryptographic operation — on the service call's stack frame, not pinned to the key object — because the underlying BouncyCastle library requires a plain `string` and offers no `byte[]`-based passphrase API. That transient string cannot be deterministically zeroed (managed strings are immutable), but its heap residency is bounded by the operation rather than by the object's lifetime.
+
+`PgpPrivateKey` is `IDisposable`: calling `Dispose()` eagerly zeroes the protected `SecureString` buffer. The instance is safe to use without disposing — the `SecureString` finalizer cleans up eventually — but disposing is recommended for sensitive, long-lived workflows. (`PgpPublicKey` holds no secret material and is not `IDisposable`.)
+
+---
+
+## Relationship to the XAML activities
+
+The coded API and the [XAML activities](overview.md) run on the **same cryptographic core**, so they are at full parity on algorithms, wire formats (`Classic` / `Owasp2026` / `Raw` / `OpenSslEnc`), IV / `KdfIterations` / `AesKeySize` / encoding options, keyed-hash algorithms, and every PGP operation (encrypt, decrypt, sign, clearsign, verify in all three modes, generate). Anything you can compute with an activity, you can compute with this service. The differences are about **I/O shape and key-input form**, not capability.
+
+**The coded API does more than the activities:**
+
+| Coded-only capability | Detail |
+|----------------------|--------|
+| **Bytes I/O on every operation** | `EncryptBytes` / `DecryptBytes`, `KeyedHashBytes`, `PgpEncryptBytes` / `PgpDecryptBytes`, `PgpSignBytes` / `PgpClearSignBytes`, `PgpVerifyBytes` / `PgpVerifyClearSignedBytes`. No activity has a `byte[]` in/out form. |
+| **Raw `byte[]` keys** | `RawKey.FromBytes(byte[])` for symmetric `Raw` and keyed hash. Activities can only supply raw keys as hex/base64 **strings** (and keyed-hash activities have no raw-key path at all). |
+| **In-memory PGP key material** | `PgpPublicKey.FromBytes` / `PgpPrivateKey.FromBytes` let you encrypt/decrypt/sign/verify without key files on disk. The activities require key **files**. |
+| **Text & Bytes Sign / ClearSign / Verify** | `PgpSignText` / `PgpClearSignText`, `PgpVerifyText` / `PgpVerifyClearSignedText` (+ Bytes forms). The activities expose only `PgpSignFile` / `PgpClearSignFile`, and `PgpVerify` is file-only. |
+| **In-memory `PgpKeyPair`** | `PgpGenerateKeys` returns a usable key pair without forcing file output; the activity only writes the two key files. |
+
+**The activities do two things the coded API doesn't — neither is a cryptographic capability:**
+
+- **UiPath resource handles** (`IResource` / `ILocalResource`) as inputs and outputs (e.g. Storage-bucket / project resources). The coded API takes plain `string` file paths and `byte[]`; a coded workflow works with local paths and in-memory data, not resource handles.
+- **`ContinueOnError`** swallow-and-continue. In a coded workflow you use ordinary `try/catch` instead — every method throws on failure.
+
+> **Encoding note (shaped differently, not a gap):** the Text activities split *key encoding* and *plaintext encoding* into two properties. In the coded API the password encoding is set on `PasswordKey.FromPassword(..., encoding)` and the plaintext encoding via the options `encoding:` parameter — both axes remain independently controllable.
 
 ---
 
@@ -310,7 +346,7 @@ Used by `EncryptBytes`/`EncryptText`/`EncryptFile` and `DecryptBytes`/`DecryptTe
 | `AESGCM` | AES-GCM with 96-bit nonce and 128-bit auth tag. AEAD — **recommended for new workflows.** |
 | `ChaCha20Poly1305` | ChaCha20-Poly1305 AEAD. Non-FIPS. Alternative to AES-GCM. |
 | `AES` | AES in CBC mode. |
-| `Rijndael` | Rijndael in CBC mode. |
+| `Rijndael` | Rijndael in CBC mode. **`[Obsolete]` — weak; avoid.** |
 | `DES` | DES in CBC mode. **`[Obsolete]` — weak; avoid.** |
 | `TripleDES` | 3DES in CBC mode. **`[Obsolete]` — weak; avoid.** |
 | `RC2` | RC2 in CBC mode. **`[Obsolete]` — weak; avoid.** |

--- a/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/overview.md
+++ b/Activities/Cryptography/UiPath.Cryptography.Activities.Packaging/docs/overview.md
@@ -18,3 +18,7 @@
 | [PGP Sign File](activities/PgpSignFile.md) | Creates a PGP binary signature of a file using a private key |
 | [PGP ClearSign File](activities/PgpClearSignFile.md) | Creates a PGP clear-text signature of a file using a private key |
 | [PGP Verify](activities/PgpVerify.md) | Verifies a PGP signature, clearsignature, or validates a public key file |
+
+## Coded workflows
+
+The same capabilities are available to coded (C#) workflows through the `cryptography` service — see the [Coded Workflow API](coded-api.md). The activities and the coded API share one cryptographic core, so they are at full parity on algorithms, wire formats, and PGP operations. The coded API additionally offers `byte[]` I/O, raw-byte and in-memory keys, and Text/Bytes variants of sign/clearsign/verify; the activities add UiPath `IResource` handle support and the `ContinueOnError` option. See [Relationship to the XAML activities](coded-api.md#relationship-to-the-xaml-activities) for the full comparison.


### PR DESCRIPTION
Updated the .md documentation files for the Cryptography activities and the coded-workflow API to match the source after an accuracy review:

- Documented the AesKeySize property + enum in the four symmetric activity docs (EncryptText/EncryptFile/DecryptText/DecryptFile).
- Split Encoding (key) vs PlaintextEncoding (text) and relabeled the key encoding dropdown in the Text docs.
- Documented the previously hidden ILocalResource OutArguments (EncryptedFile/DecryptedFile/SignedFile/ClearSignedFile/PublicKeyFile/ PrivateKeyFile) and removed the false 'no OutArgument' notes.
- Documented the user-visible 'Key encoding' dropdown for Hash File/Text.
- coded-api.md: corrected the PGP passphrase section (SecureString, materialized per-operation), documented PgpPrivateKey IDisposable, fixed the ToBytes() wording, and added notes on the stateless singleton, RawKey length validation, and read-only CryptoOptions getters.
- coded-api.md/overview.md: added an activities-vs-coded-API parity section documenting coded-only (bytes I/O, raw/in-memory keys, Text/Bytes sign/clearsign/verify) and activity-only (IResource, ContinueOnError) capabilities.
- ICryptographyService.cs: corrected EncryptText/DecryptText XML doc-comments (encoding comes from options.TextEncoding); comment-only, no behavior change.

Using this jira for tracking purposes: https://uipath.atlassian.net/browse/STUD-80530