### PR TITLE
FTP: make SFTP Delete recursive for non-empty directories [STUD-80569]

### DIFF
--- a/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
+++ b/Activities/FTP/UiPath.FTP.Tests/SessionsTests/SftpSessionTests.cs
@@ -1,5 +1,7 @@
+using Moq;
 using Renci.SshNet;
 using Renci.SshNet.Common;
+using Renci.SshNet.Sftp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -200,6 +202,137 @@ namespace UiPath.FTP.Tests
             Assert.False(result);
         }
 
+        // --- Recursive delete ---
+
+        [Fact]
+        public async Task SFTP_DeleteAsync_RemovesDirectoryContentsDepthFirst_ThenDirectory()
+        {
+            // /root
+            //   /root/a.txt
+            //   /root/sub
+            //     /root/sub/b.txt
+            var deleted = new List<string>();
+            var root = FakeItem("/root", "root", isDirectory: true, deleted: deleted);
+            var aTxt = FakeItem("/root/a.txt", "a.txt", isDirectory: false, deleted: deleted);
+            var sub = FakeItem("/root/sub", "sub", isDirectory: true, deleted: deleted);
+            var bTxt = FakeItem("/root/sub/b.txt", "b.txt", isDirectory: false, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/root"] = root },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>
+                {
+                    ["/root"] = new[] { aTxt, sub },
+                    ["/root/sub"] = new[] { bTxt },
+                });
+
+            await ((IFtpSession)session).DeleteAsync("/root", CancellationToken.None);
+
+            // Children are deleted before their parent; the target directory is removed last.
+            Assert.Equal(new[] { "/root/a.txt", "/root/sub/b.txt", "/root/sub", "/root" }, deleted);
+        }
+
+        [Fact]
+        public async Task SFTP_DeleteAsync_DeletesSingleFile_WithoutListing()
+        {
+            var deleted = new List<string>();
+            var file = FakeItem("/root/file.txt", "file.txt", isDirectory: false, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/root/file.txt"] = file },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>());
+
+            await ((IFtpSession)session).DeleteAsync("/root/file.txt", CancellationToken.None);
+
+            Assert.Equal(new[] { "/root/file.txt" }, deleted);
+            Assert.Equal(0, session.ListDirectoryCallCount);
+        }
+
+        [Fact]
+        public async Task SFTP_DeleteAsync_DoesNotRecurseIntoSymbolicLink()
+        {
+            // A symlink that points at a directory must be unlinked, not walked into.
+            var deleted = new List<string>();
+            var link = FakeItem("/link", "link", isDirectory: true, deleted: deleted, isSymbolicLink: true);
+            var insideLink = FakeItem("/link/should-not-touch.txt", "should-not-touch.txt", isDirectory: false, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/link"] = link },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>
+                {
+                    ["/link"] = new[] { insideLink },
+                });
+
+            await ((IFtpSession)session).DeleteAsync("/link", CancellationToken.None);
+
+            Assert.Equal(new[] { "/link" }, deleted);
+            Assert.Equal(0, session.ListDirectoryCallCount);
+        }
+
+        [Fact]
+        public async Task SFTP_DeleteAsync_SkipsDotAndDotDotEntries()
+        {
+            var deleted = new List<string>();
+            var root = FakeItem("/root", "root", isDirectory: true, deleted: deleted);
+            var dot = FakeItem("/root/.", ".", isDirectory: true, deleted: deleted);
+            var dotDot = FakeItem("/root/..", "..", isDirectory: true, deleted: deleted);
+            var aTxt = FakeItem("/root/a.txt", "a.txt", isDirectory: false, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/root"] = root },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>
+                {
+                    ["/root"] = new[] { dot, dotDot, aTxt },
+                });
+
+            await ((IFtpSession)session).DeleteAsync("/root", CancellationToken.None);
+
+            // "." and ".." are never deleted (deleting them would corrupt the tree / loop).
+            Assert.Equal(new[] { "/root/a.txt", "/root" }, deleted);
+        }
+
+        [Fact]
+        public async Task SFTP_DeleteAsync_ThrowsWhenCancelled()
+        {
+            var deleted = new List<string>();
+            var root = FakeItem("/root", "root", isDirectory: true, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/root"] = root },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>());
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => ((IFtpSession)session).DeleteAsync("/root", cts.Token));
+            Assert.Empty(deleted);
+        }
+
+        [Fact]
+        public void SFTP_Delete_Sync_RemovesDirectoryContentsThenDirectory()
+        {
+            var deleted = new List<string>();
+            var root = FakeItem("/root", "root", isDirectory: true, deleted: deleted);
+            var aTxt = FakeItem("/root/a.txt", "a.txt", isDirectory: false, deleted: deleted);
+
+            using var session = new SftpSessionWithFakeTree(
+                CreateTestConfig(),
+                itemsByPath: new Dictionary<string, ISftpFile> { ["/root"] = root },
+                childrenByPath: new Dictionary<string, IEnumerable<ISftpFile>>
+                {
+                    ["/root"] = new[] { aTxt },
+                });
+
+            ((IFtpSession)session).Delete("/root");
+
+            Assert.Equal(new[] { "/root/a.txt", "/root" }, deleted);
+        }
+
         // --- Helpers ---
 
         /// <summary>
@@ -218,6 +351,61 @@ namespace UiPath.FTP.Tests
             }
 
             protected internal override bool ClientExists(string path) => _existsBehaviour();
+        }
+
+        /// <summary>
+        /// Subclass of <see cref="SftpSession"/> that overrides the <c>ClientGet</c>/<c>ClientListDirectory</c>
+        /// seams so the recursive delete walk can be exercised against an in-memory tree without a live
+        /// connection. Also counts <c>ClientListDirectory</c> calls so tests can assert that files and
+        /// symbolic links are not enumerated.
+        /// </summary>
+        private sealed class SftpSessionWithFakeTree : SftpSession
+        {
+            private readonly IReadOnlyDictionary<string, ISftpFile> _itemsByPath;
+            private readonly IReadOnlyDictionary<string, IEnumerable<ISftpFile>> _childrenByPath;
+
+            public SftpSessionWithFakeTree(
+                FtpConfiguration config,
+                IReadOnlyDictionary<string, ISftpFile> itemsByPath,
+                IReadOnlyDictionary<string, IEnumerable<ISftpFile>> childrenByPath)
+                : base(config)
+            {
+                _itemsByPath = itemsByPath;
+                _childrenByPath = childrenByPath;
+            }
+
+            public int ListDirectoryCallCount { get; private set; }
+
+            protected internal override ISftpFile ClientGet(string path) => _itemsByPath[path];
+
+            protected internal override IEnumerable<ISftpFile> ClientListDirectory(string path)
+            {
+                ListDirectoryCallCount++;
+                return _childrenByPath.TryGetValue(path, out var children)
+                    ? children
+                    : Enumerable.Empty<ISftpFile>();
+            }
+        }
+
+        /// <summary>
+        /// Builds a mocked <see cref="ISftpFile"/> whose <c>Delete</c> records its full name into
+        /// <paramref name="deleted"/>, so tests can assert both that an item was deleted and the order
+        /// in which deletions happened.
+        /// </summary>
+        private static ISftpFile FakeItem(
+            string fullName,
+            string name,
+            bool isDirectory,
+            List<string> deleted,
+            bool isSymbolicLink = false)
+        {
+            var mock = new Mock<ISftpFile>();
+            mock.SetupGet(f => f.FullName).Returns(fullName);
+            mock.SetupGet(f => f.Name).Returns(name);
+            mock.SetupGet(f => f.IsDirectory).Returns(isDirectory);
+            mock.SetupGet(f => f.IsSymbolicLink).Returns(isSymbolicLink);
+            mock.Setup(f => f.Delete()).Callback(() => deleted.Add(fullName));
+            return mock.Object;
         }
 
         /// <summary>

--- a/Activities/FTP/UiPath.FTP/SftpSession.cs
+++ b/Activities/FTP/UiPath.FTP/SftpSession.cs
@@ -329,6 +329,55 @@ namespace UiPath.FTP
         protected internal virtual bool ClientExists(string path) => _sftpClient.Exists(path);
 
         /// <summary>
+        /// Resolves <paramref name="path"/> to an <see cref="ISftpFile"/> via the underlying client.
+        /// Extracted as a <c>protected internal virtual</c> seam so tests can simulate a remote
+        /// directory tree without a live connection (mirrors <see cref="ClientExists"/>).
+        /// </summary>
+        protected internal virtual ISftpFile ClientGet(string path) => _sftpClient.Get(path);
+
+        /// <summary>
+        /// Lists the entries of the directory at <paramref name="path"/> via the underlying client.
+        /// Extracted as a <c>protected internal virtual</c> seam for testability (see <see cref="ClientGet"/>).
+        /// </summary>
+        protected internal virtual IEnumerable<ISftpFile> ClientListDirectory(string path) => _sftpClient.ListDirectory(path);
+
+        /// <summary>
+        /// Recursively deletes the SFTP object at <paramref name="path"/>.
+        /// The SFTP protocol's RMDIR (issued by <see cref="ISftpFile.Delete"/> for directories) only
+        /// removes empty directories, so a directory's contents must be deleted first. Files and
+        /// symbolic links are unlinked directly; real directories are emptied depth-first and then
+        /// removed. Symbolic links are never followed during the walk, mirroring <c>rm -rf</c>.
+        /// A missing <paramref name="path"/> surfaces as the same exception SSH.NET raises for
+        /// <c>Get</c>, preserving the previous "path not found" behaviour.
+        /// </summary>
+        private void DeleteRecursive(string path, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            DeleteRecursive(ClientGet(path), cancellationToken);
+        }
+
+        private void DeleteRecursive(ISftpFile item, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (item.IsDirectory && !item.IsSymbolicLink)
+            {
+                foreach (ISftpFile child in ClientListDirectory(item.FullName))
+                {
+                    if (child.Name == "." || child.Name == "..")
+                    {
+                        continue;
+                    }
+
+                    DeleteRecursive(child, cancellationToken);
+                }
+            }
+
+            item.Delete();
+        }
+
+        /// <summary>
         /// Wraps <see cref="ClientExists"/> and returns <c>false</c> for bare
         /// <see cref="SshException"/> (SSH_FX_FAILURE) thrown by some SFTP server
         /// implementations when a path does not exist, while letting typed subclasses
@@ -424,7 +473,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            _sftpClient.Delete(path);
+            DeleteRecursive(path, CancellationToken.None);
         }
 
         Task IFtpSession.DeleteAsync(string path, CancellationToken cancellationToken)
@@ -434,7 +483,7 @@ namespace UiPath.FTP
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return Task.Run(() => _sftpClient.Delete(path), cancellationToken);
+            return Task.Run(() => DeleteRecursive(path, cancellationToken), cancellationToken);
         }
 
         bool IFtpSession.DirectoryExists(string path)


### PR DESCRIPTION
## Problem

Jira: [STUD-80569](https://uipath.atlassian.net/browse/STUD-80569)

The `Delete` activity fails when the target is a **non-empty directory over SFTP**. `SftpSession.Delete`/`DeleteAsync` called `SftpClient.Delete(path)`, which issues a single `SSH_FXP_RMDIR`. The SFTP protocol only permits `RMDIR` on an **empty** directory, so the server returns a failure and SSH.NET throws. SSH.NET ships no built-in recursive delete.

The FTP path was already fine — FluentFTP's `DeleteDirectory(path)` is recursive by default.

## Fix

Replace the one-shot delete in `SftpSession` with a depth-first recursive walk used by both the sync `Delete` and async `DeleteAsync`:

- Removes a directory's contents before removing the directory itself.
- **Symbolic links are unlinked, not followed** (`IsDirectory && !IsSymbolicLink`), mirroring `rm -rf` and avoiding loops/escaping the tree.
- Skips `.` and `..` entries.
- Honors the `CancellationToken` throughout the walk (the previous one-shot `Task.Run` did not).
- Preserves the prior "path not found" behavior (missing path surfaces the same `SftpPathNotFoundException`).

This brings SFTP in line with FTP so both protocols delete non-empty folders consistently. No `rm -rf`/shell dependency — the walk stays within the SFTP subsystem, so it remains portable across SFTP-only and non-POSIX servers and has no command-injection surface.

Added `ClientGet`/`ClientListDirectory` `protected internal virtual` seams (alongside the existing `ClientExists`) so the walk is unit-testable without a live server.

## Behavior change

Deleting a non-empty directory over **SFTP** previously threw; it now succeeds recursively (matching FTP). Flagging per the repo's "breaking changes require discussion" convention. Kept as silent-recursive rather than gated behind a new opt-in `Recursive` property — happy to switch to opt-in if preferred.

## Tests

6 new `SftpSessionTests` (all green; 21 total pass, builds clean on net6.0 and net6.0-windows):
- depth-first deletion order (children before parent, target last)
- single-file delete without listing
- symlink not recursed into
- `.`/`..` skipped
- cancellation throws and deletes nothing
- sync `Delete` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STUD-80569]: https://uipath.atlassian.net/browse/STUD-80569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ